### PR TITLE
fix: 테스트 환경에서 MinIO 비활성화

### DIFF
--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -32,6 +32,9 @@ jwt:
 firebase:
   enabled: false
 
+minio:
+  enabled: false
+
 # Snowflake ID 생성기 설정 (Redis 미사용)
 snowflake:
   use-redis-allocation: false


### PR DESCRIPTION
## Summary

- 테스트 환경에서 MinIO 연결 시도를 비활성화하여 CI 테스트 실패 문제 해결
- `application-test.yml`에 `minio.enabled: false` 추가

## Related Issue

Closes #30

## Changes

- `src/test/resources/application-test.yml`: MinIO 비활성화 설정 추가

## Test Plan

- [x] 로컬 테스트 통과 확인
- [ ] GitHub Actions CI 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)