### PR TITLE
fix: CI 환경에서 통합 테스트 Redis 연결 문제 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,18 @@ jobs:
       contents: read
       packages: write
 
+    # 통합 테스트용 서비스 컨테이너
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -34,6 +46,12 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: Run tests
+        env:
+          # Testcontainers 대신 GitHub Actions Redis 사용
+          SPRING_DATA_REDIS_HOST: localhost
+          SPRING_DATA_REDIS_PORT: 6379
+          # Testcontainers 비활성화 (CI에서는 services 사용)
+          TESTCONTAINERS_RYUK_DISABLED: true
         run: ./gradlew test
 
       - name: Set up Docker Buildx

--- a/src/test/java/com/cotalk/infrastructure/ratelimit/RateLimitIntegrationTest.java
+++ b/src/test/java/com/cotalk/infrastructure/ratelimit/RateLimitIntegrationTest.java
@@ -52,11 +52,24 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class RateLimitIntegrationTest {
 
     /**
-     * Docker 사용 가능 여부를 확인한다.
+     * CI 환경 여부를 확인한다.
      *
-     * @return Docker가 사용 가능하면 true
+     * @return CI 환경이면 true
+     */
+    static boolean isCI() {
+        return System.getenv("CI") != null;
+    }
+
+    /**
+     * Docker 사용 가능 여부를 확인한다.
+     * CI 환경에서는 GitHub Actions services를 사용하므로 항상 true.
+     *
+     * @return Docker가 사용 가능하거나 CI 환경이면 true
      */
     static boolean isDockerAvailable() {
+        if (isCI()) {
+            return true; // CI에서는 GitHub Actions services 사용
+        }
         try {
             DockerClientFactory.instance().client();
             return true;
@@ -68,17 +81,26 @@ class RateLimitIntegrationTest {
     private static final Logger log = LoggerFactory.getLogger(RateLimitIntegrationTest.class);
 
     @Container
-    static GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
-            .withExposedPorts(6379);
+    static GenericContainer<?> redis = isCI() ? null :
+            new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+                    .withExposedPorts(6379);
 
     @DynamicPropertySource
     static void configureProperties(DynamicPropertyRegistry registry) {
         // Rate Limit 활성화
         registry.add("app.rate-limit.enabled", () -> "true");
 
-        // Testcontainers Redis 설정
-        registry.add("spring.data.redis.host", redis::getHost);
-        registry.add("spring.data.redis.port", redis::getFirstMappedPort);
+        if (isCI()) {
+            // CI 환경: GitHub Actions services Redis 사용
+            String redisHost = System.getenv().getOrDefault("SPRING_DATA_REDIS_HOST", "localhost");
+            String redisPort = System.getenv().getOrDefault("SPRING_DATA_REDIS_PORT", "6379");
+            registry.add("spring.data.redis.host", () -> redisHost);
+            registry.add("spring.data.redis.port", () -> redisPort);
+        } else {
+            // 로컬 환경: Testcontainers Redis 사용
+            registry.add("spring.data.redis.host", redis::getHost);
+            registry.add("spring.data.redis.port", redis::getFirstMappedPort);
+        }
     }
 
     @Autowired

--- a/src/test/java/com/cotalk/integration/WebSocketChatIntegrationTest.java
+++ b/src/test/java/com/cotalk/integration/WebSocketChatIntegrationTest.java
@@ -54,15 +54,31 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("WebSocket Chat Integration")
 class WebSocketChatIntegrationTest {
 
+    /**
+     * CI 환경 여부를 확인한다.
+     */
+    static boolean isCI() {
+        return System.getenv("CI") != null;
+    }
+
     @Container
-    static final GenericContainer<?> redis = new GenericContainer<>(
-            DockerImageName.parse("redis:7.2-alpine")
-    ).withExposedPorts(6379);
+    static final GenericContainer<?> redis = isCI() ? null :
+            new GenericContainer<>(DockerImageName.parse("redis:7.2-alpine"))
+                    .withExposedPorts(6379);
 
     @DynamicPropertySource
     static void redisProps(DynamicPropertyRegistry registry) {
-        registry.add("spring.data.redis.host", redis::getHost);
-        registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
+        if (isCI()) {
+            // CI 환경: GitHub Actions services Redis 사용
+            String redisHost = System.getenv().getOrDefault("SPRING_DATA_REDIS_HOST", "localhost");
+            String redisPort = System.getenv().getOrDefault("SPRING_DATA_REDIS_PORT", "6379");
+            registry.add("spring.data.redis.host", () -> redisHost);
+            registry.add("spring.data.redis.port", () -> redisPort);
+        } else {
+            // 로컬 환경: Testcontainers Redis 사용
+            registry.add("spring.data.redis.host", redis::getHost);
+            registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
+        }
     }
 
     @LocalServerPort


### PR DESCRIPTION
## Summary

GitHub Actions CI에서 통합 테스트 실행 시 Redis 연결 실패 문제 해결

## Changes

- `.github/workflows/deploy.yml`: Redis 서비스 컨테이너 추가
- `RateLimitIntegrationTest.java`: CI 환경에서 GitHub Actions Redis 사용
- `WebSocketChatIntegrationTest.java`: CI 환경에서 GitHub Actions Redis 사용

## 현업 표준 방식

- CI: GitHub Actions services로 Redis 제공
- 로컬: 기존 Testcontainers 유지

## Test Plan

- [x] 로컬 테스트 통과
- [ ] GitHub Actions CI 테스트 통과

🤖 Generated with [Claude Code](https://claude.ai/claude-code)