### PR TITLE
fix: CI에서 Testcontainers 사용하도록 롤백

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,18 +20,6 @@ jobs:
       contents: read
       packages: write
 
-    # 통합 테스트용 서비스 컨테이너
-    services:
-      redis:
-        image: redis:7-alpine
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -46,12 +34,6 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: Run tests
-        env:
-          # Testcontainers 대신 GitHub Actions Redis 사용
-          SPRING_DATA_REDIS_HOST: localhost
-          SPRING_DATA_REDIS_PORT: 6379
-          # Testcontainers 비활성화 (CI에서는 services 사용)
-          TESTCONTAINERS_RYUK_DISABLED: true
         run: ./gradlew test
 
       - name: Set up Docker Buildx

--- a/src/test/java/com/cotalk/infrastructure/ratelimit/RateLimitIntegrationTest.java
+++ b/src/test/java/com/cotalk/infrastructure/ratelimit/RateLimitIntegrationTest.java
@@ -52,24 +52,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class RateLimitIntegrationTest {
 
     /**
-     * CI 환경 여부를 확인한다.
-     *
-     * @return CI 환경이면 true
-     */
-    static boolean isCI() {
-        return System.getenv("CI") != null;
-    }
-
-    /**
      * Docker 사용 가능 여부를 확인한다.
-     * CI 환경에서는 GitHub Actions services를 사용하므로 항상 true.
      *
-     * @return Docker가 사용 가능하거나 CI 환경이면 true
+     * @return Docker가 사용 가능하면 true
      */
     static boolean isDockerAvailable() {
-        if (isCI()) {
-            return true; // CI에서는 GitHub Actions services 사용
-        }
         try {
             DockerClientFactory.instance().client();
             return true;
@@ -81,26 +68,17 @@ class RateLimitIntegrationTest {
     private static final Logger log = LoggerFactory.getLogger(RateLimitIntegrationTest.class);
 
     @Container
-    static GenericContainer<?> redis = isCI() ? null :
-            new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
-                    .withExposedPorts(6379);
+    static GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+            .withExposedPorts(6379);
 
     @DynamicPropertySource
     static void configureProperties(DynamicPropertyRegistry registry) {
         // Rate Limit 활성화
         registry.add("app.rate-limit.enabled", () -> "true");
 
-        if (isCI()) {
-            // CI 환경: GitHub Actions services Redis 사용
-            String redisHost = System.getenv().getOrDefault("SPRING_DATA_REDIS_HOST", "localhost");
-            String redisPort = System.getenv().getOrDefault("SPRING_DATA_REDIS_PORT", "6379");
-            registry.add("spring.data.redis.host", () -> redisHost);
-            registry.add("spring.data.redis.port", () -> redisPort);
-        } else {
-            // 로컬 환경: Testcontainers Redis 사용
-            registry.add("spring.data.redis.host", redis::getHost);
-            registry.add("spring.data.redis.port", redis::getFirstMappedPort);
-        }
+        // Testcontainers Redis 설정
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", redis::getFirstMappedPort);
     }
 
     @Autowired

--- a/src/test/java/com/cotalk/integration/WebSocketChatIntegrationTest.java
+++ b/src/test/java/com/cotalk/integration/WebSocketChatIntegrationTest.java
@@ -54,31 +54,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("WebSocket Chat Integration")
 class WebSocketChatIntegrationTest {
 
-    /**
-     * CI 환경 여부를 확인한다.
-     */
-    static boolean isCI() {
-        return System.getenv("CI") != null;
-    }
-
     @Container
-    static final GenericContainer<?> redis = isCI() ? null :
-            new GenericContainer<>(DockerImageName.parse("redis:7.2-alpine"))
-                    .withExposedPorts(6379);
+    static final GenericContainer<?> redis = new GenericContainer<>(
+            DockerImageName.parse("redis:7.2-alpine")
+    ).withExposedPorts(6379);
 
     @DynamicPropertySource
     static void redisProps(DynamicPropertyRegistry registry) {
-        if (isCI()) {
-            // CI 환경: GitHub Actions services Redis 사용
-            String redisHost = System.getenv().getOrDefault("SPRING_DATA_REDIS_HOST", "localhost");
-            String redisPort = System.getenv().getOrDefault("SPRING_DATA_REDIS_PORT", "6379");
-            registry.add("spring.data.redis.host", () -> redisHost);
-            registry.add("spring.data.redis.port", () -> redisPort);
-        } else {
-            // 로컬 환경: Testcontainers Redis 사용
-            registry.add("spring.data.redis.host", redis::getHost);
-            registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
-        }
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
     }
 
     @LocalServerPort


### PR DESCRIPTION
## Summary

GitHub Actions services 대신 Testcontainers 사용하도록 롤백

## 문제

- `@Container` 필드가 `null`이면 Testcontainers extension이 `ExtensionConfigurationException` 발생
- CI 환경 분기 처리 시 `null` 할당으로 인한 초기화 오류

## 해결

- Testcontainers는 GitHub Actions에서 Docker가 있으므로 정상 동작함
- 조건부 로직 제거하고 원래 Testcontainers 코드 사용

🤖 Generated with [Claude Code](https://claude.ai/claude-code)