### PR TITLE
fix: Redisson이 Testcontainers Redis에 연결하도록 설정 추가

### DIFF
--- a/src/test/java/com/cotalk/infrastructure/ratelimit/RateLimitIntegrationTest.java
+++ b/src/test/java/com/cotalk/infrastructure/ratelimit/RateLimitIntegrationTest.java
@@ -76,9 +76,13 @@ class RateLimitIntegrationTest {
         // Rate Limit 활성화
         registry.add("app.rate-limit.enabled", () -> "true");
 
-        // Testcontainers Redis 설정
+        // Testcontainers Redis 설정 (Spring Data Redis)
         registry.add("spring.data.redis.host", redis::getHost);
         registry.add("spring.data.redis.port", redis::getFirstMappedPort);
+
+        // Redisson 설정 (single server mode)
+        registry.add("spring.redis.host", redis::getHost);
+        registry.add("spring.redis.port", redis::getFirstMappedPort);
     }
 
     @Autowired

--- a/src/test/java/com/cotalk/integration/WebSocketChatIntegrationTest.java
+++ b/src/test/java/com/cotalk/integration/WebSocketChatIntegrationTest.java
@@ -61,8 +61,13 @@ class WebSocketChatIntegrationTest {
 
     @DynamicPropertySource
     static void redisProps(DynamicPropertyRegistry registry) {
+        // Spring Data Redis 설정
         registry.add("spring.data.redis.host", redis::getHost);
         registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
+
+        // Redisson 설정 (single server mode)
+        registry.add("spring.redis.host", redis::getHost);
+        registry.add("spring.redis.port", () -> redis.getMappedPort(6379));
     }
 
     @LocalServerPort


### PR DESCRIPTION
## Summary

Redisson이 Testcontainers Redis에 연결할 수 있도록 설정 추가

## 문제

- Redisson은 `spring.data.redis` 설정을 사용하지 않고 `spring.redis` 설정을 사용
- Testcontainers Redis 동적 포트가 Redisson에 전달되지 않음

## 해결

DynamicPropertySource에 Redisson용 설정 추가:
- `spring.redis.host`
- `spring.redis.port`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)