### PR TITLE
fix: Redisson YAML 설정을 직접 전달

### DIFF
--- a/src/test/java/com/cotalk/infrastructure/ratelimit/RateLimitIntegrationTest.java
+++ b/src/test/java/com/cotalk/infrastructure/ratelimit/RateLimitIntegrationTest.java
@@ -80,9 +80,12 @@ class RateLimitIntegrationTest {
         registry.add("spring.data.redis.host", redis::getHost);
         registry.add("spring.data.redis.port", redis::getFirstMappedPort);
 
-        // Redisson 설정 (single server mode)
-        registry.add("spring.redis.host", redis::getHost);
-        registry.add("spring.redis.port", redis::getFirstMappedPort);
+        // Redisson 설정 (single server mode) - YAML 직접 전달
+        registry.add("spring.redisson.config", () ->
+                "singleServerConfig:\n" +
+                "  address: \"redis://" + redis.getHost() + ":" + redis.getFirstMappedPort() + "\"\n" +
+                "  connectionMinimumIdleSize: 1\n" +
+                "  connectionPoolSize: 2");
     }
 
     @Autowired

--- a/src/test/java/com/cotalk/integration/WebSocketChatIntegrationTest.java
+++ b/src/test/java/com/cotalk/integration/WebSocketChatIntegrationTest.java
@@ -65,9 +65,12 @@ class WebSocketChatIntegrationTest {
         registry.add("spring.data.redis.host", redis::getHost);
         registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
 
-        // Redisson 설정 (single server mode)
-        registry.add("spring.redis.host", redis::getHost);
-        registry.add("spring.redis.port", () -> redis.getMappedPort(6379));
+        // Redisson 설정 (single server mode) - YAML 직접 전달
+        registry.add("spring.redisson.config", () ->
+                "singleServerConfig:\n" +
+                "  address: \"redis://" + redis.getHost() + ":" + redis.getMappedPort(6379) + "\"\n" +
+                "  connectionMinimumIdleSize: 1\n" +
+                "  connectionPoolSize: 2");
     }
 
     @LocalServerPort


### PR DESCRIPTION
Redisson이 Testcontainers Redis에 연결하도록 spring.redisson.config YAML 설정 직접 전달