### PR TITLE
fix: PR #58 머지 시 생성된 중복 메서드 제거

### DIFF
--- a/src/main/java/com/cotalk/adapter/inbound/rest/ChatMessageController.java
+++ b/src/main/java/com/cotalk/adapter/inbound/rest/ChatMessageController.java
@@ -23,7 +23,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -184,75 +183,6 @@ public class ChatMessageController {
                 .toList();
 
         return ResponseEntity.ok(new MediaGalleryResponse(items, result.nextCursor(), result.hasMore()));
-    }
-
-    /**
-     * 채팅방의 미디어 갤러리를 조회합니다.
-     * 사진, 파일, 링크를 타입별로 페이징하여 반환합니다.
-     *
-     * @param principal 인증된 사용자 정보
-     * @param roomId 채팅방 ID
-     * @param type 미디어 유형 (PHOTO, FILE, LINK)
-     * @param page 페이지 번호 (0부터 시작)
-     * @param size 페이지 크기 (기본값: 30)
-     * @return 미디어 갤러리 응답
-     */
-    @Operation(summary = "미디어 갤러리 조회", description = "채팅방의 사진, 파일, 링크를 조회합니다.")
-    @GetMapping("/rooms/{roomId}/media")
-    public ResponseEntity<MediaGalleryResponse> getMediaGallery(
-            @AuthenticationPrincipal CustomUserPrincipal principal,
-            @PathVariable Long roomId,
-            @RequestParam String type,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "30") int size) {
-
-        // 권한 체크: 채팅방 멤버인지 확인
-        chatRoomMemberRepository.findByChatRoomIdAndUserId(roomId, principal.getUserId())
-                .orElseThrow(() -> new IllegalArgumentException("채팅방에 접근 권한이 없습니다."));
-
-        Pageable pageable = org.springframework.data.domain.PageRequest.of(page, size);
-        List<Message> messages;
-
-        switch (type.toUpperCase()) {
-            case "PHOTO" -> messages = messageRepository.findByTypeInChatRoom(
-                    roomId, List.of(Message.MessageType.IMAGE), pageable);
-            case "FILE" -> messages = messageRepository.findByTypeInChatRoom(
-                    roomId, List.of(Message.MessageType.FILE), pageable);
-            case "LINK" -> messages = messageRepository.findMessagesWithLinkPreview(roomId, pageable);
-            default -> throw new IllegalArgumentException("지원하지 않는 미디어 유형입니다: " + type);
-        }
-
-        // 발신자 정보 배치 조회
-        Set<Long> senderIds = messages.stream().map(Message::getSenderId).collect(Collectors.toSet());
-        Map<Long, User> senderMap = userRepository.findAllById(senderIds).stream()
-                .collect(Collectors.toMap(User::getId, user -> user));
-
-        List<MediaGalleryResponse.MediaGalleryItem> items = messages.stream()
-                .map(message -> {
-                    User sender = senderMap.get(message.getSenderId());
-                    return new MediaGalleryResponse.MediaGalleryItem(
-                            message.getId(),
-                            message.getType().name(),
-                            message.getFileUrl(),
-                            message.getFileName(),
-                            message.getFileSize(),
-                            message.getFileContentType(),
-                            message.getThumbnailUrl(),
-                            message.getLinkPreviewUrl(),
-                            message.getLinkPreviewTitle(),
-                            message.getLinkPreviewDescription(),
-                            message.getLinkPreviewImageUrl(),
-                            message.getCreatedAt().atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
-                            message.getSenderId(),
-                            sender != null ? sender.getNickname() : null
-                    );
-                })
-                .toList();
-
-        Long nextCursor = messages.isEmpty() ? null : messages.get(messages.size() - 1).getId();
-        boolean hasMore = messages.size() == size;
-
-        return ResponseEntity.ok(new MediaGalleryResponse(items, nextCursor, hasMore));
     }
 
     /**

--- a/src/main/java/com/cotalk/adapter/inbound/websocket/ChatWebSocketController.java
+++ b/src/main/java/com/cotalk/adapter/inbound/websocket/ChatWebSocketController.java
@@ -244,49 +244,6 @@ public class ChatWebSocketController {
     }
 
     /**
-     * 타이핑 상태를 브로드캐스트한다.
-     * 클라이언트가 타이핑 시작/중지를 알리면 같은 채팅방의 다른 멤버들에게 전달한다.
-     *
-     * @param request        타이핑 상태 요청 (채팅방 ID, 타이핑 여부)
-     * @param headerAccessor WebSocket 헤더 접근자 (인증된 사용자 정보 포함)
-     */
-    @MessageMapping("/chat/typing")
-    public void typingStatus(@Payload TypingStatusRequest request, StompHeaderAccessor headerAccessor) {
-        if (request == null || request.roomId() == null) {
-            return;
-        }
-        Long authenticatedUserId = extractUserId(headerAccessor);
-        String userNickname = userNicknameCache.computeIfAbsent(authenticatedUserId,
-                id -> userRepository.findById(id).map(User::getNickname).orElse(null));
-
-        String eventType = Boolean.TRUE.equals(request.isTyping()) ? "TYPING" : "STOP_TYPING";
-        chatMessageBroker.publishRoomEvent(request.roomId(), new TypingBroadcastEvent(
-                1,
-                "typing:" + request.roomId() + ":" + authenticatedUserId + ":" + System.currentTimeMillis(),
-                eventType,
-                request.roomId(),
-                authenticatedUserId,
-                userNickname,
-                request.isTyping()
-        ));
-        log.debug("[WS] typingStatus roomId={}, userId={}, isTyping={}", request.roomId(), authenticatedUserId, request.isTyping());
-    }
-
-    /**
-     * 타이핑 브로드캐스트 이벤트 DTO.
-     * Redis Pub/Sub -> WebSocket 방 토픽(/topic/chat/room/{roomId})으로 전달된다.
-     */
-    private record TypingBroadcastEvent(
-            Integer schemaVersion,
-            String eventId,
-            String eventType,
-            Long chatRoomId,
-            Long userId,
-            String userNickname,
-            Boolean isTyping
-    ) {}
-
-    /**
      * 채팅방 presence ping.
      * 클라이언트가 방을 보고 있는 동안 주기적으로 호출하여 서버 presence TTL을 갱신한다.
      */


### PR DESCRIPTION
## Summary
- PR #58 머지 과정에서 리팩토링된 UseCase 버전과 구버전(Repository 직접 사용)이 동시에 존재하게 되어 **884개의 컴파일 에러** 발생
- `ChatMessageController`: 중복 `getMediaGallery()` 메서드 제거 (구버전이 Repository 직접 참조)
- `ChatWebSocketController`: 중복 `typingStatus()` 메서드 및 불필요한 `TypingBroadcastEvent` record 제거

## Test plan
- [x] `./gradlew compileJava` 빌드 성공 확인
- [x] `./gradlew test` 전체 테스트 통과 확인
- [ ] CI 빌드 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)