### PR TITLE
feat(metrics): 인증, 메시지, WebSocket 메트릭 수집 추가

### DIFF
--- a/src/main/java/com/cotalk/adapter/inbound/websocket/ChatWebSocketController.java
+++ b/src/main/java/com/cotalk/adapter/inbound/websocket/ChatWebSocketController.java
@@ -20,6 +20,7 @@ import com.cotalk.domain.port.inbound.message.AddMessageReactionUseCase.Reaction
 import com.cotalk.domain.port.inbound.message.RemoveMessageReactionUseCase;
 import com.cotalk.domain.port.inbound.message.SendMessageUseCase;
 import com.cotalk.domain.port.inbound.message.SendMessageUseCase.FileMessageCommand;
+import com.cotalk.infrastructure.metrics.CustomMetrics;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -68,6 +69,7 @@ public class ChatWebSocketController {
     private final PublishTypingStatusUseCase publishTypingStatusUseCase;
     private final UpdatePresenceStatusUseCase updatePresenceStatusUseCase;
     private final PublishChatListUpdateUseCase publishChatListUpdateUseCase;
+    private final CustomMetrics customMetrics;
 
     /**
      * 텍스트 채팅 메시지를 전송합니다.
@@ -92,6 +94,7 @@ public class ChatWebSocketController {
             return;
         }
 
+        customMetrics.incrementMessagesReceived();
         log.debug("Received message from authenticated user {} to room {}", authenticatedUserId, request.roomId());
 
         // 메시지 저장 + 컨텍스트 조회 (sender, members 한 번만 조회)
@@ -137,6 +140,7 @@ public class ChatWebSocketController {
             return;
         }
 
+        customMetrics.incrementMessagesReceived();
         log.debug("Received file message from authenticated user {} to room {}", authenticatedUserId, request.roomId());
 
         FileMessageCommand command = new FileMessageCommand(

--- a/src/main/java/com/cotalk/application/service/auth/LoginService.java
+++ b/src/main/java/com/cotalk/application/service/auth/LoginService.java
@@ -9,6 +9,7 @@ import com.cotalk.domain.port.inbound.user.UpdateUserOnlineStatusUseCase;
 import com.cotalk.domain.port.outbound.AuthTokenPort;
 import com.cotalk.domain.port.outbound.PasswordEncoderPort;
 import com.cotalk.domain.port.outbound.UserRepository;
+import com.cotalk.infrastructure.metrics.CustomMetrics;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -29,6 +30,7 @@ public class LoginService implements LoginUseCase {
     private final PasswordEncoderPort passwordEncoder;
     private final AuthTokenPort authTokenPort;
     private final UpdateUserOnlineStatusUseCase updateUserOnlineStatusUseCase;
+    private final CustomMetrics customMetrics;
 
     /**
      * 이메일과 비밀번호로 로그인한다.
@@ -47,16 +49,19 @@ public class LoginService implements LoginUseCase {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> {
                     log.warn("Login failed: user not found for email: {}", maskEmail(email));
+                    customMetrics.incrementLoginFailure();
                     return new InvalidCredentialsException();
                 });
 
         if (!passwordEncoder.matches(password, user.getPasswordHash())) {
             log.warn("Login failed: invalid password for userId: {}", user.getId());
+            customMetrics.incrementLoginFailure();
             throw new InvalidCredentialsException();
         }
 
         if (!user.isActive()) {
             log.warn("Login failed: inactive account for userId: {}", user.getId());
+            customMetrics.incrementLoginFailure();
             throw new InvalidCredentialsException("계정이 비활성화 또는 정지되었습니다.");
         }
 
@@ -64,6 +69,7 @@ public class LoginService implements LoginUseCase {
         updateUserOnlineStatusUseCase.setOnline(user.getId());
 
         String accessToken = authTokenPort.generateAccessToken(user.getId());
+        customMetrics.incrementLoginSuccess();
         log.info("Login successful: userId={}", user.getId());
         return new LoginResult(accessToken, user.getId());
     }

--- a/src/main/java/com/cotalk/application/service/auth/OAuthLoginService.java
+++ b/src/main/java/com/cotalk/application/service/auth/OAuthLoginService.java
@@ -5,6 +5,7 @@ import com.cotalk.domain.port.inbound.auth.OAuthLoginUseCase;
 import com.cotalk.domain.port.outbound.AuthTokenPort;
 import com.cotalk.domain.port.outbound.IdGenerator;
 import com.cotalk.domain.port.outbound.UserRepository;
+import com.cotalk.infrastructure.metrics.CustomMetrics;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -25,6 +26,7 @@ public class OAuthLoginService implements OAuthLoginUseCase {
     private final UserRepository userRepository;
     private final AuthTokenPort authTokenPort;
     private final IdGenerator idGenerator;
+    private final CustomMetrics customMetrics;
 
     /**
      * OAuth 로그인을 처리한다.
@@ -54,9 +56,11 @@ public class OAuthLoginService implements OAuthLoginUseCase {
     private OAuthLoginResult loginExistingUser(User user, User.OAuthProvider provider) {
         if (!user.isActive()) {
             log.warn("OAuth login failed: inactive account for userId={}, provider={}", user.getId(), provider);
+            customMetrics.incrementLoginFailure();
             throw new com.cotalk.domain.exception.InvalidCredentialsException("계정이 비활성화 또는 정지되었습니다.");
         }
         String token = authTokenPort.generateAccessToken(user.getId());
+        customMetrics.incrementLoginSuccess();
         log.info("OAuth login successful: userId={}, provider={}", user.getId(), provider);
         return new OAuthLoginResult(token, false, user.getId());
     }
@@ -80,6 +84,8 @@ public class OAuthLoginService implements OAuthLoginUseCase {
         User savedUser = userRepository.save(newUser);
         String token = authTokenPort.generateAccessToken(savedUser.getId());
 
+        customMetrics.incrementUserRegistration();
+        customMetrics.incrementLoginSuccess();
         log.info("OAuth sign-up and login successful: userId={}, provider={}, email={}",
                 savedUser.getId(), provider, maskEmail(email));
         return new OAuthLoginResult(token, true, savedUser.getId());

--- a/src/main/java/com/cotalk/application/service/message/SendMessageService.java
+++ b/src/main/java/com/cotalk/application/service/message/SendMessageService.java
@@ -17,6 +17,7 @@ import com.cotalk.domain.port.outbound.UserEventBroker.ChatListUpdateEvent;
 import com.cotalk.domain.port.outbound.UserRepository;
 import com.cotalk.domain.util.HtmlSanitizer;
 import com.cotalk.domain.validator.ChatRoomMemberValidator;
+import com.cotalk.infrastructure.metrics.CustomMetrics;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -45,6 +46,7 @@ public class SendMessageService implements SendMessageUseCase {
     private final SendPushNotificationUseCase sendPushNotificationUseCase;
     private final ChatRoomMemberValidator chatRoomMemberValidator;
     private final ChatRoomPresenceTracker chatRoomPresenceTracker;
+    private final CustomMetrics customMetrics;
     private final MessageLinkPreviewService messageLinkPreviewService;
     private final ChatMessageBroker chatMessageBroker;
     private final UserEventBroker userEventBroker;
@@ -156,6 +158,7 @@ public class SendMessageService implements SendMessageUseCase {
 
         // 메시지 저장
         Message savedMessage = messageRepository.save(message);
+        customMetrics.incrementMessagesSent();
 
         // 발신자는 자신이 보낸 메시지를 읽은 것으로 간주하여 lastReadMessageId 업데이트
         LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);

--- a/src/main/java/com/cotalk/infrastructure/websocket/WebSocketEventListener.java
+++ b/src/main/java/com/cotalk/infrastructure/websocket/WebSocketEventListener.java
@@ -2,6 +2,7 @@ package com.cotalk.infrastructure.websocket;
 
 import com.cotalk.domain.port.inbound.user.UpdateUserOnlineStatusUseCase;
 import com.cotalk.domain.port.outbound.ChatRoomPresenceTracker;
+import com.cotalk.infrastructure.metrics.CustomMetrics;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -35,6 +36,7 @@ public class WebSocketEventListener {
 
     private final UpdateUserOnlineStatusUseCase updateUserOnlineStatusUseCase;
     private final ChatRoomPresenceTracker chatRoomPresenceTracker;
+    private final CustomMetrics customMetrics;
 
     /**
      * subscriptionId -> roomId 매핑(세션별).
@@ -59,6 +61,7 @@ public class WebSocketEventListener {
             try {
                 Long userId = Long.parseLong(userIdStr);
                 updateUserOnlineStatusUseCase.setOnline(userId);
+                customMetrics.incrementWebSocketConnections();
                 String sessionId = headerAccessor.getSessionId();
                 if (sessionId != null) {
                     userSessions.computeIfAbsent(userId, k -> ConcurrentHashMap.newKeySet()).add(sessionId);
@@ -92,6 +95,7 @@ public class WebSocketEventListener {
 
                 // 멀티 세션 지원: 마지막 세션이 끊어질 때만 오프라인 처리
                 Set<String> sessions = userSessions.get(userId);
+                customMetrics.decrementWebSocketConnections();
                 if (sessions != null) {
                     sessions.remove(sessionId);
                     if (sessions.isEmpty()) {


### PR DESCRIPTION
## 🎯 개요

Prometheus 모니터링을 위해 핵심 비즈니스 메트릭 수집 기능을 추가합니다.

---

## 📦 변경사항

### feat(metrics): 인증, 메시지, WebSocket 메트릭 수집 추가

**변경된 파일 (5개)**
- `LoginService.java`: 로그인 성공/실패 메트릭 추가
- `OAuthLoginService.java`: OAuth 로그인 성공/실패, 사용자 등록 메트릭 추가
- `SendMessageService.java`: 메시지 전송 메트릭 추가
- `ChatWebSocketController.java`: 메시지 수신 메트릭 추가
- `WebSocketEventListener.java`: WebSocket 연결/해제 메트릭 추가

**변경 내용:**
- 인증: 로그인 성공/실패 카운터 추가
- 사용자 등록: OAuth 신규 사용자 등록 카운터 추가
- 메시지: 메시지 전송/수신 카운터 추가
- WebSocket: 연결/해제 카운터 추가

**이유:**
- Prometheus를 통한 모니터링 및 알림 설정을 위해 핵심 비즈니스 메트릭 수집 필요
- 서비스 상태 및 사용량 추적을 위한 메트릭 수집

---

## ✅ 체크리스트
- [x] 원자적 커밋
- [ ] CI 통과
- [ ] 메트릭 엔드포인트에서 메트릭 값 확인

Made with [Cursor](https://cursor.com)