### PR TITLE
[CHORE] NAS Redis 비밀번호 설정 제거

### DIFF
--- a/docker-compose.nas.yml
+++ b/docker-compose.nas.yml
@@ -36,7 +36,7 @@ services:
       - DB_PASSWORD=${DB_PASSWORD}
       - REDIS_HOST=redis
       - REDIS_PORT=6379
-      - REDIS_PASSWORD=${REDIS_PASSWORD}
+      # REDIS_PASSWORD 제거 - Redis에 비밀번호가 없으므로 설정하지 않음
       - MINIO_ENDPOINT=http://minio:9000
       - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}
       - MINIO_SECRET_KEY=${MINIO_SECRET_KEY}
@@ -93,7 +93,7 @@ services:
       - DB_PASSWORD=${DB_PASSWORD}
       - REDIS_HOST=redis
       - REDIS_PORT=6379
-      - REDIS_PASSWORD=${REDIS_PASSWORD}
+      # REDIS_PASSWORD 제거 - Redis에 비밀번호가 없으므로 설정하지 않음
       - MINIO_ENDPOINT=http://minio:9000
       - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY}
       - MINIO_SECRET_KEY=${MINIO_SECRET_KEY}
@@ -174,13 +174,13 @@ services:
     container_name: cotalk-redis
     restart: unless-stopped
     # 외부 포트 노출 없음 - 도커 내부 네트워크에서 redis:6379로 접근
-    command: redis-server --appendonly yes --maxmemory 128mb --maxmemory-policy allkeys-lru --requirepass ${REDIS_PASSWORD}
+    command: redis-server --appendonly yes --maxmemory 128mb --maxmemory-policy allkeys-lru
     volumes:
       - redis-data:/data
     networks:
       - cotalk-network
     healthcheck:
-      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+      test: ["CMD", "redis-cli", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## 📋 개요
NAS용 docker-compose에서 Redis에 비밀번호가 없으므로 REDIS_PASSWORD 관련 설정만 제거합니다. (main 기준 단일 변경 PR)

## 🎯 변경사항
- **app-blue / app-green**: `REDIS_PASSWORD` 환경변수 제거 (주석으로 사유 명시)
- **redis**: `command`에서 `--requirepass ${REDIS_PASSWORD}` 제거
- **redis**: `healthcheck`에서 `-a ${REDIS_PASSWORD}` 제거

## 📊 통계
- 변경 파일: 1개 (`docker-compose.nas.yml`)
- 커밋: 1개

## 🔗 관련 이슈
Closes #72

## ✅ 체크리스트
- [x] 코드 리뷰 준비 완료
- [x] Conventional Commits

Made with [Cursor](https://cursor.com)