### PR TITLE
[CHORE] Grafana 환경변수명 통일

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -44,8 +44,8 @@ services:
     ports:
       - "${GRAFANA_PORT:-13001}:3000"
     environment:
-      - GF_SECURITY_ADMIN_USER=${GRAFANA_USER:-admin}
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD}
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
       - GF_USERS_ALLOW_SIGN_UP=false
       - GF_SERVER_DOMAIN=${NAS_DOMAIN:-localhost}
     volumes:


### PR DESCRIPTION
## 📋 개요
docker-compose.monitoring.yml에서 Grafana 환경변수명을 GRAFANA_ADMIN_USER, GRAFANA_ADMIN_PASSWORD로 통일합니다.

## 🎯 변경사항
- `GRAFANA_USER` → `GRAFANA_ADMIN_USER`
- `GRAFANA_PASSWORD` → `GRAFANA_ADMIN_PASSWORD`
- NAS 등 다른 compose와 네이밍 일관성 유지

## 📊 통계
- 변경 파일: 1개
- 커밋: 1개

## 🔗 관련 이슈
Closes #80

## ✅ 체크리스트
- [x] 코드 리뷰 준비 완료
- [x] Conventional Commits

Made with [Cursor](https://cursor.com)