### PR TITLE
[REFACTOR] Redis 메시징·WebSocket 개선 및 Prometheus 알림 추가

### DIFF
--- a/docker/prometheus/alert-rules.yml
+++ b/docker/prometheus/alert-rules.yml
@@ -121,3 +121,58 @@ groups:
         annotations:
           summary: "WebSocket 연결 급증"
           description: "5분 내에 WebSocket 연결이 100개 이상 증가했습니다."
+
+      # ===========================================
+      # 메시지 전달 파이프라인 알림
+      # ===========================================
+      - alert: RedisPublishFailureRate
+        expr: |
+          sum(rate(cotalk_redis_publish_total{result="failure"}[5m]))
+          / (sum(rate(cotalk_redis_publish_total[5m])) > 0) > 0.01
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Redis Pub/Sub 발행 실패율 증가"
+          description: "Redis 메시지 발행 실패율이 1%를 초과합니다. 현재: {{ $value | printf \"%.2f\" }}%"
+
+      - alert: WebSocketDeliveryFailureRate
+        expr: |
+          sum(rate(cotalk_websocket_delivery_total{result="failure"}[5m]))
+          / (sum(rate(cotalk_websocket_delivery_total[5m])) > 0) > 0.01
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "WebSocket 메시지 전달 실패율 증가"
+          description: "WebSocket 메시지 전달 실패율이 1%를 초과합니다. 현재: {{ $value | printf \"%.2f\" }}%"
+
+      - alert: MessageDeliveryPipelineDown
+        expr: |
+          sum(rate(cotalk_redis_publish_total{result="failure"}[5m]))
+          / (sum(rate(cotalk_redis_publish_total[5m])) > 0) > 0.1
+          or
+          sum(rate(cotalk_websocket_delivery_total{result="failure"}[5m]))
+          / (sum(rate(cotalk_websocket_delivery_total[5m])) > 0) > 0.1
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "메시지 전달 파이프라인 장애"
+          description: "Redis 발행 또는 WebSocket 전달 실패율이 10%를 초과합니다. 즉시 확인이 필요합니다."
+
+      - alert: MessageDeliveryImbalance
+        expr: |
+          abs(
+            sum by (instance) (rate(cotalk_websocket_delivery_total{type="message",result="success"}[5m]))
+            - ignoring(instance) group_left
+            avg(sum by (instance) (rate(cotalk_websocket_delivery_total{type="message",result="success"}[5m])))
+          )
+          / (avg(sum by (instance) (rate(cotalk_websocket_delivery_total{type="message",result="success"}[5m]))) > 0)
+          > 0.5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "인스턴스 간 메시지 전달 불균형"
+          description: "인스턴스 {{ $labels.instance }}의 메시지 전달량이 평균 대비 50% 이상 차이납니다. 단방향 전달 실패 가능성이 있습니다."

--- a/src/main/java/com/cotalk/infrastructure/messaging/RedisChatMessageBroker.java
+++ b/src/main/java/com/cotalk/infrastructure/messaging/RedisChatMessageBroker.java
@@ -3,6 +3,7 @@ package com.cotalk.infrastructure.messaging;
 import com.cotalk.domain.exception.MessageBrokerException;
 import com.cotalk.domain.port.outbound.ChatMessageBroker;
 import com.cotalk.infrastructure.config.properties.AppProperties;
+import com.cotalk.infrastructure.metrics.CustomMetrics;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +29,7 @@ public class RedisChatMessageBroker implements ChatMessageBroker {
 
     private final RedisTemplate<String, String> redisTemplate;
     private final ObjectMapper objectMapper;
+    private final CustomMetrics customMetrics;
     private final String channelPrefix;
 
     /**
@@ -36,14 +38,17 @@ public class RedisChatMessageBroker implements ChatMessageBroker {
      * @param redisTemplate Redis 템플릿
      * @param objectMapper  JSON 직렬화용 ObjectMapper
      * @param appProperties 앱 설정 프로퍼티
+     * @param customMetrics 커스텀 메트릭
      */
     public RedisChatMessageBroker(
             RedisTemplate<String, String> redisTemplate,
             ObjectMapper objectMapper,
-            AppProperties appProperties) {
+            AppProperties appProperties,
+            CustomMetrics customMetrics) {
         this.redisTemplate = redisTemplate;
         this.objectMapper = objectMapper;
         this.channelPrefix = appProperties.redis().channelPrefix();
+        this.customMetrics = customMetrics;
     }
 
     /**
@@ -60,10 +65,16 @@ public class RedisChatMessageBroker implements ChatMessageBroker {
         try {
             String jsonMessage = objectMapper.writeValueAsString(message);
             redisTemplate.convertAndSend(channel, jsonMessage);
+            customMetrics.recordRedisPublish("message", true);
             log.debug("Published message to channel {}: messageId={}", channel, message.messageId());
         } catch (JsonProcessingException e) {
+            customMetrics.recordRedisPublish("message", false);
             log.error("Failed to serialize chat message: {}", message, e);
             throw MessageBrokerException.serializationFailed(e);
+        } catch (Exception e) {
+            customMetrics.recordRedisPublish("message", false);
+            log.error("Failed to publish message to Redis channel {}: messageId={}", channel, message.messageId(), e);
+            throw e;
         }
     }
 
@@ -81,10 +92,16 @@ public class RedisChatMessageBroker implements ChatMessageBroker {
         try {
             String jsonMessage = objectMapper.writeValueAsString(reactionEvent);
             redisTemplate.convertAndSend(channel, jsonMessage);
+            customMetrics.recordRedisPublish("reaction", true);
             log.debug("Published reaction event to channel {}: {}", channel, reactionEvent);
         } catch (JsonProcessingException e) {
+            customMetrics.recordRedisPublish("reaction", false);
             log.error("Failed to serialize reaction event: {}", reactionEvent, e);
             throw MessageBrokerException.reactionSerializationFailed(e);
+        } catch (Exception e) {
+            customMetrics.recordRedisPublish("reaction", false);
+            log.error("Failed to publish reaction to Redis channel {}", channel, e);
+            throw e;
         }
     }
 
@@ -101,10 +118,16 @@ public class RedisChatMessageBroker implements ChatMessageBroker {
         try {
             String jsonMessage = objectMapper.writeValueAsString(event);
             redisTemplate.convertAndSend(channel, jsonMessage);
+            customMetrics.recordRedisPublish("event", true);
             log.debug("Published room event to channel {}: {}", channel, event);
         } catch (JsonProcessingException e) {
+            customMetrics.recordRedisPublish("event", false);
             log.error("Failed to serialize room event: {}", event, e);
             throw MessageBrokerException.serializationFailed(e);
+        } catch (Exception e) {
+            customMetrics.recordRedisPublish("event", false);
+            log.error("Failed to publish room event to Redis channel {}", channel, e);
+            throw e;
         }
     }
 }

--- a/src/main/java/com/cotalk/infrastructure/messaging/RedisChatMessageSubscriber.java
+++ b/src/main/java/com/cotalk/infrastructure/messaging/RedisChatMessageSubscriber.java
@@ -4,6 +4,7 @@ import com.cotalk.domain.port.outbound.ChatMessageBroker.ChatBroadcastMessage;
 import com.cotalk.domain.port.outbound.ChatMessageBroker.ReactionBroadcastEvent;
 import com.cotalk.domain.util.HtmlSanitizer;
 import com.cotalk.infrastructure.config.properties.AppProperties;
+import com.cotalk.infrastructure.metrics.CustomMetrics;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -33,16 +34,19 @@ public class RedisChatMessageSubscriber implements MessageListener {
 
     private final SimpMessagingTemplate messagingTemplate;
     private final ObjectMapper objectMapper;
+    private final CustomMetrics customMetrics;
     private final String channelPrefix;
     private static final String ROOM_TOPIC_PREFIX = "/topic/chat/room/";
 
     public RedisChatMessageSubscriber(
             SimpMessagingTemplate messagingTemplate,
             ObjectMapper objectMapper,
-            AppProperties appProperties) {
+            AppProperties appProperties,
+            CustomMetrics customMetrics) {
         this.messagingTemplate = messagingTemplate;
         this.objectMapper = objectMapper;
         this.channelPrefix = appProperties.redis().channelPrefix();
+        this.customMetrics = customMetrics;
     }
 
     /**
@@ -81,57 +85,72 @@ public class RedisChatMessageSubscriber implements MessageListener {
             WebSocketChatMessage wsMessage = toWebSocketMessage(chatMessage);
             String destination = ROOM_TOPIC_PREFIX + chatMessage.roomId();
             messagingTemplate.convertAndSend(destination, wsMessage);
+            customMetrics.recordWebsocketDelivery("message", true);
             log.debug("Broadcasted message to WebSocket: destination={}, messageId={}",
                     destination, chatMessage.messageId());
 
         } catch (JsonProcessingException e) {
+            customMetrics.recordWebsocketDelivery("message", false);
             log.error("Failed to deserialize chat message from Redis", e);
         } catch (Exception e) {
+            customMetrics.recordWebsocketDelivery("message", false);
             log.error("Failed to process chat message from Redis", e);
         }
     }
 
     private void handleReaction(Long roomId, String jsonMessage) throws JsonProcessingException {
-        ReactionBroadcastEvent reactionEvent = objectMapper.readValue(jsonMessage, ReactionBroadcastEvent.class);
-        String destination = ROOM_TOPIC_PREFIX + roomId;
-        messagingTemplate.convertAndSend(destination, reactionEvent);
-        log.debug("Broadcasted reaction to WebSocket: destination={}, messageId={}",
-                destination, reactionEvent.messageId());
+        try {
+            ReactionBroadcastEvent reactionEvent = objectMapper.readValue(jsonMessage, ReactionBroadcastEvent.class);
+            String destination = ROOM_TOPIC_PREFIX + roomId;
+            messagingTemplate.convertAndSend(destination, reactionEvent);
+            customMetrics.recordWebsocketDelivery("reaction", true);
+            log.debug("Broadcasted reaction to WebSocket: destination={}, messageId={}",
+                    destination, reactionEvent.messageId());
+        } catch (Exception e) {
+            customMetrics.recordWebsocketDelivery("reaction", false);
+            throw e;
+        }
     }
 
     private void handleRoomEvent(Long roomId, String jsonMessage) throws JsonProcessingException {
-        JsonNode root = objectMapper.readTree(jsonMessage);
-        String eventType = root.has("eventType") ? root.get("eventType").asText() : null;
+        try {
+            JsonNode root = objectMapper.readTree(jsonMessage);
+            String eventType = root.has("eventType") ? root.get("eventType").asText() : null;
 
-        String destination = ROOM_TOPIC_PREFIX + roomId;
-        if ("MESSAGE_DELETED".equals(eventType)) {
-            MessageDeletedEventMessage event =
-                    objectMapper.treeToValue(root, MessageDeletedEventMessage.class);
-            messagingTemplate.convertAndSend(destination, event);
-            log.debug("Broadcasted message deleted event to WebSocket: destination={}, messageId={}",
-                    destination, event.messageId());
-        } else if ("MESSAGE_UPDATED".equals(eventType)) {
-            MessageUpdatedEventMessage event =
-                    objectMapper.treeToValue(root, MessageUpdatedEventMessage.class);
-            messagingTemplate.convertAndSend(destination, event);
-            log.debug("Broadcasted message updated event to WebSocket: destination={}, messageId={}",
-                    destination, event.messageId());
-        } else if ("TYPING".equals(eventType) || "STOP_TYPING".equals(eventType)) {
-            TypingEventMessage event = objectMapper.treeToValue(root, TypingEventMessage.class);
-            messagingTemplate.convertAndSend(destination, event);
-            log.debug("Broadcasted typing event to WebSocket: destination={}, userId={}",
-                    destination, event.userId());
-        } else if ("LINK_PREVIEW_UPDATED".equals(eventType)) {
-            LinkPreviewUpdatedEventMessage event =
-                    objectMapper.treeToValue(root, LinkPreviewUpdatedEventMessage.class);
-            messagingTemplate.convertAndSend(destination, event);
-            log.debug("Broadcasted link preview updated event to WebSocket: destination={}, messageId={}",
-                    destination, event.messageId());
-        } else {
-            ChatRoomEventMessage event = objectMapper.treeToValue(root, ChatRoomEventMessage.class);
-            messagingTemplate.convertAndSend(destination, event);
-            log.debug("Broadcasted room event to WebSocket: destination={}, eventType={}",
-                    destination, event.eventType());
+            String destination = ROOM_TOPIC_PREFIX + roomId;
+            if ("MESSAGE_DELETED".equals(eventType)) {
+                MessageDeletedEventMessage event =
+                        objectMapper.treeToValue(root, MessageDeletedEventMessage.class);
+                messagingTemplate.convertAndSend(destination, event);
+                log.debug("Broadcasted message deleted event to WebSocket: destination={}, messageId={}",
+                        destination, event.messageId());
+            } else if ("MESSAGE_UPDATED".equals(eventType)) {
+                MessageUpdatedEventMessage event =
+                        objectMapper.treeToValue(root, MessageUpdatedEventMessage.class);
+                messagingTemplate.convertAndSend(destination, event);
+                log.debug("Broadcasted message updated event to WebSocket: destination={}, messageId={}",
+                        destination, event.messageId());
+            } else if ("TYPING".equals(eventType) || "STOP_TYPING".equals(eventType)) {
+                TypingEventMessage event = objectMapper.treeToValue(root, TypingEventMessage.class);
+                messagingTemplate.convertAndSend(destination, event);
+                log.debug("Broadcasted typing event to WebSocket: destination={}, userId={}",
+                        destination, event.userId());
+            } else if ("LINK_PREVIEW_UPDATED".equals(eventType)) {
+                LinkPreviewUpdatedEventMessage event =
+                        objectMapper.treeToValue(root, LinkPreviewUpdatedEventMessage.class);
+                messagingTemplate.convertAndSend(destination, event);
+                log.debug("Broadcasted link preview updated event to WebSocket: destination={}, messageId={}",
+                        destination, event.messageId());
+            } else {
+                ChatRoomEventMessage event = objectMapper.treeToValue(root, ChatRoomEventMessage.class);
+                messagingTemplate.convertAndSend(destination, event);
+                log.debug("Broadcasted room event to WebSocket: destination={}, eventType={}",
+                        destination, event.eventType());
+            }
+            customMetrics.recordWebsocketDelivery("event", true);
+        } catch (Exception e) {
+            customMetrics.recordWebsocketDelivery("event", false);
+            throw e;
         }
     }
 

--- a/src/main/java/com/cotalk/infrastructure/metrics/CustomMetrics.java
+++ b/src/main/java/com/cotalk/infrastructure/metrics/CustomMetrics.java
@@ -24,6 +24,8 @@ import java.util.concurrent.atomic.AtomicLong;
  *   <li>cotalk.auth.login.failure - 로그인 실패 수</li>
  *   <li>cotalk.websocket.connections - 활성 WebSocket 연결 수</li>
  *   <li>cotalk.chatrooms.active - 활성 채팅방 수</li>
+ *   <li>cotalk.redis.publish{type,result} - Redis Pub/Sub 발행 성공/실패 (태그: type=message|reaction|event, result=success|failure)</li>
+ *   <li>cotalk.websocket.delivery{type,result} - WebSocket 전달 성공/실패 (태그: type=message|reaction|event, result=success|failure)</li>
  * </ul>
  *
  * @author seunggu.lee
@@ -31,6 +33,8 @@ import java.util.concurrent.atomic.AtomicLong;
 @Component
 @Getter
 public class CustomMetrics implements MetricsPort {
+
+    private final MeterRegistry meterRegistry;
 
     /** 전송된 메시지 카운터 */
     private final Counter messagesSentCounter;
@@ -56,6 +60,8 @@ public class CustomMetrics implements MetricsPort {
      * @param meterRegistry Micrometer 메트릭 레지스트리
      */
     public CustomMetrics(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+
         // 메시지 관련 메트릭
         this.messagesSentCounter = Counter.builder("cotalk.messages.sent")
                 .description("Total number of messages sent")
@@ -174,5 +180,32 @@ public class CustomMetrics implements MetricsPort {
     @Override
     public void stopMessageProcessingTimer(Object sample) {
         ((Timer.Sample) sample).stop(messageProcessingTimer);
+    }
+
+    /**
+     * Redis Pub/Sub 발행 결과를 기록한다.
+     *
+     * @param type    메시지 유형 (message, reaction, event)
+     * @param success 발행 성공 여부
+     */
+    public void recordRedisPublish(String type, boolean success) {
+        meterRegistry.counter("cotalk.redis.publish",
+                "type", type,
+                "result", success ? "success" : "failure"
+        ).increment();
+    }
+
+    /**
+     * WebSocket 전달 결과를 기록한다.
+     * Redis에서 수신한 메시지를 WebSocket으로 클라이언트에게 전달한 결과를 추적한다.
+     *
+     * @param type    메시지 유형 (message, reaction, event)
+     * @param success 전달 성공 여부
+     */
+    public void recordWebsocketDelivery(String type, boolean success) {
+        meterRegistry.counter("cotalk.websocket.delivery",
+                "type", type,
+                "result", success ? "success" : "failure"
+        ).increment();
     }
 }

--- a/src/main/java/com/cotalk/infrastructure/websocket/WebSocketExceptionHandler.java
+++ b/src/main/java/com/cotalk/infrastructure/websocket/WebSocketExceptionHandler.java
@@ -118,6 +118,20 @@ public class WebSocketExceptionHandler {
     }
 
     /**
+     * 인증/권한 등으로 인한 IllegalArgumentException을 처리한다.
+     * (예: WebSocketAuthInterceptor에서 토큰 없음, 접근 권한 없음)
+     *
+     * @param e IllegalArgumentException
+     * @return 에러 응답
+     */
+    @MessageExceptionHandler(IllegalArgumentException.class)
+    @SendToUser("/queue/errors")
+    public WebSocketErrorResponse handleIllegalArgumentException(IllegalArgumentException e) {
+        log.warn("WebSocket validation/authorization error: {}", e.getMessage());
+        return new WebSocketErrorResponse("BAD_REQUEST", e.getMessage(), LocalDateTime.now());
+    }
+
+    /**
      * 예상하지 못한 예외를 처리한다.
      *
      * @param e 예외

--- a/src/test/java/com/cotalk/infrastructure/messaging/RedisChatMessageBrokerTest.java
+++ b/src/test/java/com/cotalk/infrastructure/messaging/RedisChatMessageBrokerTest.java
@@ -4,6 +4,7 @@ import com.cotalk.domain.exception.MessageBrokerException;
 import com.cotalk.domain.port.outbound.ChatMessageBroker.ChatBroadcastMessage;
 import com.cotalk.domain.port.outbound.ChatMessageBroker.ReactionBroadcastEvent;
 import com.cotalk.infrastructure.config.properties.AppProperties;
+import com.cotalk.infrastructure.metrics.CustomMetrics;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -35,6 +36,9 @@ class RedisChatMessageBrokerTest {
     @Mock
     private RedisTemplate<String, String> redisTemplate;
 
+    @Mock
+    private CustomMetrics customMetrics;
+
     private ObjectMapper objectMapper;
     private RedisChatMessageBroker broker;
     private AppProperties appProperties;
@@ -44,7 +48,7 @@ class RedisChatMessageBrokerTest {
         objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
         appProperties = createTestAppProperties();
-        broker = new RedisChatMessageBroker(redisTemplate, objectMapper, appProperties);
+        broker = new RedisChatMessageBroker(redisTemplate, objectMapper, appProperties, customMetrics);
     }
 
     private AppProperties createTestAppProperties() {
@@ -136,7 +140,7 @@ class RedisChatMessageBrokerTest {
         void should_throwException_when_serializationFails() throws Exception {
             // given
             ObjectMapper mockMapper = mock(ObjectMapper.class);
-            RedisChatMessageBroker brokerWithMockMapper = new RedisChatMessageBroker(redisTemplate, mockMapper, appProperties);
+            RedisChatMessageBroker brokerWithMockMapper = new RedisChatMessageBroker(redisTemplate, mockMapper, appProperties, customMetrics);
 
             Long roomId = 1L;
             ChatBroadcastMessage message = new ChatBroadcastMessage(
@@ -184,7 +188,7 @@ class RedisChatMessageBrokerTest {
         void should_throwException_when_reactionSerializationFails() throws Exception {
             // given
             ObjectMapper mockMapper = mock(ObjectMapper.class);
-            RedisChatMessageBroker brokerWithMockMapper = new RedisChatMessageBroker(redisTemplate, mockMapper, appProperties);
+            RedisChatMessageBroker brokerWithMockMapper = new RedisChatMessageBroker(redisTemplate, mockMapper, appProperties, customMetrics);
 
             Long roomId = 1L;
             ReactionBroadcastEvent reactionEvent = new ReactionBroadcastEvent(

--- a/src/test/java/com/cotalk/infrastructure/messaging/RedisChatMessageSubscriberTest.java
+++ b/src/test/java/com/cotalk/infrastructure/messaging/RedisChatMessageSubscriberTest.java
@@ -2,6 +2,7 @@ package com.cotalk.infrastructure.messaging;
 
 import com.cotalk.infrastructure.config.properties.AppProperties;
 import com.cotalk.infrastructure.messaging.RedisChatMessageSubscriber.WebSocketChatMessage;
+import com.cotalk.infrastructure.metrics.CustomMetrics;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,6 +35,9 @@ class RedisChatMessageSubscriberTest {
     @Mock
     private SimpMessagingTemplate messagingTemplate;
 
+    @Mock
+    private CustomMetrics customMetrics;
+
     @Captor
     private ArgumentCaptor<WebSocketChatMessage> messageCaptor;
 
@@ -46,7 +50,7 @@ class RedisChatMessageSubscriberTest {
         objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
         appProperties = createTestAppProperties();
-        subscriber = new RedisChatMessageSubscriber(messagingTemplate, objectMapper, appProperties);
+        subscriber = new RedisChatMessageSubscriber(messagingTemplate, objectMapper, appProperties, customMetrics);
     }
 
     private AppProperties createTestAppProperties() {

--- a/src/test/java/com/cotalk/infrastructure/websocket/WebSocketConfigTest.java
+++ b/src/test/java/com/cotalk/infrastructure/websocket/WebSocketConfigTest.java
@@ -26,7 +26,11 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.messaging.converter.MappingJackson2MessageConverter;
-import org.springframework.messaging.simp.stomp.*;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompFrameHandler;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
 import org.springframework.web.socket.WebSocketHttpHeaders;
 
 import java.lang.reflect.Type;
@@ -37,6 +41,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
@@ -141,11 +146,48 @@ class WebSocketConfigTest {
     }
 
     @Test
+    @DisplayName("유효하지 않은 토큰으로 WebSocket 연결 시 실패한다")
+    void should_failConnection_when_invalidToken() throws Exception {
+        String invalidToken = "invalid.jwt.token";
+
+        WebSocketStompClient stompClient = new WebSocketStompClient(new StandardWebSocketClient());
+        stompClient.setMessageConverter(new MappingJackson2MessageConverter());
+        StompHeaders connectHeaders = new StompHeaders();
+        connectHeaders.add("Authorization", "Bearer " + invalidToken);
+
+        CompletableFuture<Throwable> errorFuture = new CompletableFuture<>();
+        stompClient.connectAsync(
+                String.format("ws://localhost:%d/ws", port),
+                new WebSocketHttpHeaders(),
+                connectHeaders,
+                new StompSessionHandlerAdapter() {
+                    @Override
+                    public void handleTransportError(StompSession session, Throwable exception) {
+                        errorFuture.complete(exception);
+                    }
+
+                    @Override
+                    public void handleException(StompSession session, StompCommand command,
+                                                StompHeaders headers, byte[] payload, Throwable exception) {
+                        errorFuture.complete(exception);
+                    }
+                }
+        );
+
+        Throwable t = errorFuture.get(5, TimeUnit.SECONDS);
+        assertThat(t).isNotNull();
+        String message = t.getMessage() != null ? t.getMessage() : (t.getCause() != null ? t.getCause().getMessage() : "");
+        assertThat(message.contains("유효하지 않은") || message.contains("Connection closed")).isTrue();
+    }
+
+    @Test
     @DisplayName("유효한 토큰으로 채팅방 구독 성공")
     void should_subscribeSuccessfully_when_validToken() throws Exception {
-        // given
+        // given: room 1 멤버로 user 1 허용 (인터셉터 권한 검사)
+        given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(1L, 1L)).willReturn(true);
+
         String token = jwtTokenProvider.generateToken(1L);
-        
+
         WebSocketStompClient stompClient = new WebSocketStompClient(new StandardWebSocketClient());
         stompClient.setMessageConverter(new MappingJackson2MessageConverter());
 

--- a/src/test/java/com/cotalk/integration/WebSocketChatInMemoryBrokerIntegrationTest.java
+++ b/src/test/java/com/cotalk/integration/WebSocketChatInMemoryBrokerIntegrationTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.context.annotation.Import;
 import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompFrameHandler;
 import org.springframework.messaging.simp.stomp.StompHeaders;
 import org.springframework.messaging.simp.stomp.StompSession;
@@ -103,6 +104,7 @@ class WebSocketChatInMemoryBrokerIntegrationTest {
                     received.complete((Map<String, Object>) payload);
                 }
             });
+            awaitSubscriptionReady();
 
             sessionA.send("/app/chat/message", Map.of(
                     "senderId", 1L,
@@ -110,7 +112,7 @@ class WebSocketChatInMemoryBrokerIntegrationTest {
                     "content", "hi"
             ));
 
-            Map<String, Object> payload = received.get(10, TimeUnit.SECONDS);
+            Map<String, Object> payload = received.get(15, TimeUnit.SECONDS);
             assertThat(payload.get("content")).isEqualTo("hi");
             assertThat(payload).containsKeys("schemaVersion", "eventId");
         } finally {
@@ -291,6 +293,160 @@ class WebSocketChatInMemoryBrokerIntegrationTest {
         }
     }
 
+    @Test
+    @Timeout(value = 15)
+    @DisplayName("A가 타이핑 상태를 보내면, B는 방 토픽에서 TYPING 이벤트를 수신한다")
+    void should_broadcastTypingEvent_toRoomTopic() throws Exception {
+        Long roomId = idGenerator.nextId();
+        chatRoomRepository.save(ChatRoom.builder().id(roomId).type(ChatRoom.ChatRoomType.DIRECT).build());
+        chatRoomMemberRepository.save(ChatRoomMember.builder().id(idGenerator.nextId()).chatRoomId(roomId).userId(1L).build());
+        chatRoomMemberRepository.save(ChatRoomMember.builder().id(idGenerator.nextId()).chatRoomId(roomId).userId(2L).build());
+
+        StompSession sessionA = connectWithToken(jwtTokenProvider.generateToken(1L));
+        StompSession sessionB = connectWithToken(jwtTokenProvider.generateToken(2L));
+
+        try {
+            BlockingQueue<Map<String, Object>> roomEvents = new LinkedBlockingQueue<>();
+            sessionB.subscribe("/topic/chat/room/" + roomId, new StompFrameHandler() {
+                @Override
+                public Type getPayloadType(StompHeaders headers) {
+                    return Map.class;
+                }
+
+                @SuppressWarnings("unchecked")
+                @Override
+                public void handleFrame(StompHeaders headers, Object payload) {
+                    roomEvents.add((Map<String, Object>) payload);
+                }
+            });
+            awaitSubscriptionReady();
+
+            sessionA.send("/app/chat/typing", Map.of("roomId", roomId, "isTyping", true));
+
+            Map<String, Object> typing = pollEventByType(roomEvents, "TYPING", 10);
+            assertThat(typing.get("eventType")).isEqualTo("TYPING");
+            assertThat(((Number) typing.get("chatRoomId")).longValue()).isEqualTo(roomId);
+            assertThat(((Number) typing.get("userId")).longValue()).isEqualTo(1L);
+        } finally {
+            sessionA.disconnect();
+            sessionB.disconnect();
+        }
+    }
+
+    @Test
+    @Timeout(value = 10)
+    @DisplayName("멤버가 /app/chat/presence를 보내면 정상 처리된다 (에러 없음)")
+    void should_acceptPresencePing_when_member() throws Exception {
+        Long roomId = idGenerator.nextId();
+        chatRoomRepository.save(ChatRoom.builder().id(roomId).type(ChatRoom.ChatRoomType.DIRECT).build());
+        chatRoomMemberRepository.save(ChatRoomMember.builder().id(idGenerator.nextId()).chatRoomId(roomId).userId(1L).build());
+        chatRoomMemberRepository.save(ChatRoomMember.builder().id(idGenerator.nextId()).chatRoomId(roomId).userId(2L).build());
+
+        StompSession session = connectWithToken(jwtTokenProvider.generateToken(1L));
+        try {
+            session.send("/app/chat/presence", Map.of("roomId", roomId));
+            assertThat(session.isConnected()).as("presence 전송 후에도 세션 유지").isTrue();
+        } finally {
+            session.disconnect();
+        }
+    }
+
+    @Test
+    @Timeout(value = 10)
+    @DisplayName("비멤버가 /topic/chat/room/{roomId} 구독 시 접근 거부된다")
+    void should_rejectSubscribe_when_nonMember() throws Exception {
+        Long roomId = idGenerator.nextId();
+        chatRoomRepository.save(ChatRoom.builder().id(roomId).type(ChatRoom.ChatRoomType.DIRECT).build());
+        chatRoomMemberRepository.save(ChatRoomMember.builder().id(idGenerator.nextId()).chatRoomId(roomId).userId(1L).build());
+        chatRoomMemberRepository.save(ChatRoomMember.builder().id(idGenerator.nextId()).chatRoomId(roomId).userId(2L).build());
+
+        CompletableFuture<Throwable> errorHolder = new CompletableFuture<>();
+        StompSession session3 = connectWithTokenAndErrorCapture(jwtTokenProvider.generateToken(3L), errorHolder);
+        try {
+            session3.subscribe("/topic/chat/room/" + roomId, new StompFrameHandler() {
+                @Override
+                public Type getPayloadType(StompHeaders headers) {
+                    return String.class;
+                }
+
+                @Override
+                public void handleFrame(StompHeaders headers, Object payload) {
+                    // no-op: 이 테스트는 구독 거부(에러)만 검증함
+                }
+            });
+        } catch (Exception e) {
+            errorHolder.complete(e);
+        }
+
+        Throwable t = errorHolder.get(5, TimeUnit.SECONDS);
+        assertThat(t).isNotNull();
+        String msg = t.getMessage() != null ? t.getMessage() : "";
+        assertThat(msg.contains("접근 권한") || msg.contains("Connection closed")).isTrue();
+        if (session3.isConnected()) {
+            session3.disconnect();
+        }
+    }
+
+    @Test
+    @Timeout(value = 15)
+    @DisplayName("비멤버가 /app/chat/message로 메시지 전송 시 /user/queue/errors에 ACCESS_DENIED 수신")
+    void should_receiveAccessDeniedOnErrorsQueue_when_sendMessageAsNonMember() throws Exception {
+        Long roomId = idGenerator.nextId();
+        chatRoomRepository.save(ChatRoom.builder().id(roomId).type(ChatRoom.ChatRoomType.DIRECT).build());
+        chatRoomMemberRepository.save(ChatRoomMember.builder().id(idGenerator.nextId()).chatRoomId(roomId).userId(2L).build());
+        chatRoomMemberRepository.save(ChatRoomMember.builder().id(idGenerator.nextId()).chatRoomId(roomId).userId(3L).build());
+
+        StompSession session1 = connectWithToken(jwtTokenProvider.generateToken(1L));
+        BlockingQueue<Map<String, Object>> errors = new LinkedBlockingQueue<>();
+        session1.subscribe("/user/queue/errors", new StompFrameHandler() {
+            @Override
+            public Type getPayloadType(StompHeaders headers) {
+                return Map.class;
+            }
+
+            @SuppressWarnings("unchecked")
+            @Override
+            public void handleFrame(StompHeaders headers, Object payload) {
+                errors.add((Map<String, Object>) payload);
+            }
+        });
+        awaitSubscriptionReady();
+
+        session1.send("/app/chat/message", Map.of("senderId", 1L, "roomId", roomId, "content", "forbidden"));
+
+        Map<String, Object> err = pollErrorPayload(errors, 10);
+        assertThat(err.get("code")).isEqualTo("ACCESS_DENIED");
+        session1.disconnect();
+    }
+
+    private Map<String, Object> pollEventByType(
+            BlockingQueue<Map<String, Object>> queue,
+            String eventType,
+            int timeoutSeconds
+    ) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(timeoutSeconds);
+        while (System.currentTimeMillis() < deadline) {
+            Map<String, Object> e = queue.poll(1, TimeUnit.SECONDS);
+            if (e == null) continue;
+            if (eventType.equals(e.get("eventType"))) return e;
+        }
+        throw new AssertionError("Event type " + eventType + " not received");
+    }
+
+    private Map<String, Object> pollErrorPayload(BlockingQueue<Map<String, Object>> queue, int timeoutSeconds) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(timeoutSeconds);
+        while (System.currentTimeMillis() < deadline) {
+            Map<String, Object> e = queue.poll(1, TimeUnit.SECONDS);
+            if (e != null && e.get("code") != null) return e;
+        }
+        throw new AssertionError("Error payload not received");
+    }
+
+    /** 구독이 브로커에 반영될 시간을 둠. CI/로컬 타이밍 차이 완화. */
+    private static void awaitSubscriptionReady() throws InterruptedException {
+        Thread.sleep(500);
+    }
+
     private Map<String, Object> pollRoomMessage(
             BlockingQueue<Map<String, Object>> queue,
             String expectedContent
@@ -363,18 +519,38 @@ class WebSocketChatInMemoryBrokerIntegrationTest {
     }
 
     private StompSession connectWithToken(String token) throws Exception {
+        return connectWithTokenAndErrorCapture(token, null);
+    }
+
+    private StompSession connectWithTokenAndErrorCapture(String token, CompletableFuture<Throwable> errorHolder) throws Exception {
         WebSocketStompClient stompClient = new WebSocketStompClient(new StandardWebSocketClient());
         stompClient.setMessageConverter(new MappingJackson2MessageConverter());
 
         StompHeaders connectHeaders = new StompHeaders();
         connectHeaders.add("Authorization", "Bearer " + token);
 
+        StompSessionHandlerAdapter handler = new StompSessionHandlerAdapter() {
+            @Override
+            public void handleException(StompSession session, StompCommand command, StompHeaders headers, byte[] payload, Throwable exception) {
+                if (errorHolder != null) {
+                    errorHolder.complete(exception);
+                }
+            }
+
+            @Override
+            public void handleTransportError(StompSession session, Throwable exception) {
+                if (errorHolder != null && !errorHolder.isDone()) {
+                    errorHolder.complete(exception);
+                }
+            }
+        };
+
         return stompClient.connectAsync(
                 String.format("ws://localhost:%d/ws", port),
                 new WebSocketHttpHeaders(),
                 connectHeaders,
-                new StompSessionHandlerAdapter() {}
-        ).get(5, TimeUnit.SECONDS);
+                handler
+        ).get(10, TimeUnit.SECONDS);
     }
 }
 

--- a/src/test/java/com/cotalk/integration/WebSocketChatIntegrationTest.java
+++ b/src/test/java/com/cotalk/integration/WebSocketChatIntegrationTest.java
@@ -9,7 +9,6 @@ import com.cotalk.infrastructure.security.JwtTokenProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -53,7 +52,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 )
 @ActiveProfiles("test")
 @DisplayName("WebSocket Chat Integration")
-@DisabledIfEnvironmentVariable(named = "CI", matches = "true", disabledReason = "WebSocket tests are flaky in CI due to timing issues")
 class WebSocketChatIntegrationTest {
 
     @Container
@@ -128,6 +126,7 @@ class WebSocketChatIntegrationTest {
                     received.complete((Map<String, Object>) payload);
                 }
             });
+            awaitSubscriptionReady();
 
             // when: A sends message
             sessionA.send("/app/chat/message", Map.of(
@@ -137,9 +136,9 @@ class WebSocketChatIntegrationTest {
             ));
 
             // then
-            Map<String, Object> payload = received.get(10, TimeUnit.SECONDS);
-            assertThat(payload.get("roomId")).isEqualTo(roomId.intValue());
-            assertThat(payload.get("senderId")).isEqualTo(1);
+            Map<String, Object> payload = received.get(15, TimeUnit.SECONDS);
+            assertThat(((Number) payload.get("roomId")).longValue()).isEqualTo(roomId);
+            assertThat(((Number) payload.get("senderId")).longValue()).isEqualTo(1L);
             assertThat(payload.get("content")).isEqualTo("hi");
             assertThat(payload).containsKeys("schemaVersion", "eventId");
         } finally {
@@ -201,6 +200,7 @@ class WebSocketChatIntegrationTest {
                     // no-op
                 }
             });
+            awaitSubscriptionReady();
 
             sessionA.send("/app/chat/message", Map.of(
                     "senderId", 1L,
@@ -289,6 +289,7 @@ class WebSocketChatIntegrationTest {
                     // no-op
                 }
             });
+            awaitSubscriptionReady();
 
             sessionA.send("/app/chat/message", Map.of(
                     "senderId", 1L,
@@ -372,6 +373,7 @@ class WebSocketChatIntegrationTest {
                     bUserEvents.add((Map<String, Object>) payload);
                 }
             });
+            awaitSubscriptionReady();
 
             sessionA.send("/app/chat/message", Map.of(
                     "senderId", 1L,
@@ -413,7 +415,7 @@ class WebSocketChatIntegrationTest {
             Long expectedReaderId,
             Long expectedRoomId
     ) throws InterruptedException {
-        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(10);
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(15);
         while (System.currentTimeMillis() < deadline) {
             Map<String, Object> e = queue.poll(1, TimeUnit.SECONDS);
             if (e == null) continue;
@@ -431,7 +433,7 @@ class WebSocketChatIntegrationTest {
             BlockingQueue<Map<String, Object>> queue,
             String expectedContent
     ) throws InterruptedException {
-        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(10);
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(15);
         while (System.currentTimeMillis() < deadline) {
             Map<String, Object> e = queue.poll(1, TimeUnit.SECONDS);
             if (e == null) continue;
@@ -450,7 +452,7 @@ class WebSocketChatIntegrationTest {
             Long expectedReaderId,
             Long expectedRoomId
     ) throws InterruptedException {
-        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(10);
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(15);
         while (System.currentTimeMillis() < deadline) {
             Map<String, Object> e = queue.poll(1, TimeUnit.SECONDS);
             if (e == null) continue;
@@ -470,7 +472,7 @@ class WebSocketChatIntegrationTest {
             BlockingQueue<Map<String, Object>> queue,
             String expectedLastMessage
     ) throws InterruptedException {
-        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(10);
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(15);
         while (System.currentTimeMillis() < deadline) {
             Map<String, Object> e = queue.poll(1, TimeUnit.SECONDS);
             if (e == null) continue;
@@ -509,7 +511,12 @@ class WebSocketChatIntegrationTest {
                 new WebSocketHttpHeaders(),
                 connectHeaders,
                 new StompSessionHandlerAdapter() {}
-        ).get(5, TimeUnit.SECONDS);
+        ).get(10, TimeUnit.SECONDS);
+    }
+
+    /** 구독이 브로커에 반영될 시간을 주어 CI/로컬 타이밍 불일치를 줄인다. */
+    private static void awaitSubscriptionReady() throws InterruptedException {
+        Thread.sleep(500);
     }
 }
 


### PR DESCRIPTION
## 📋 개요
Redis 메시징·메트릭·WebSocket 예외 핸들러 개선, Prometheus 알림 규칙 추가, 관련 테스트 보강.

## 🎯 변경사항
- **chore**: Prometheus alert-rules.yml 추가
- **refactor**: RedisChatMessageBroker, RedisChatMessageSubscriber, CustomMetrics, WebSocketExceptionHandler 개선
- **test**: RedisChatMessageBrokerTest, RedisChatMessageSubscriberTest, WebSocketConfigTest, WebSocketChatInMemoryBrokerIntegrationTest, WebSocketChatIntegrationTest 보강

## 통계
- 변경 파일: 10개
- 추가: 435줄 / 삭제: 58줄
- 커밋: 3개

## 🔗 관련 이슈
Closes #106

## ✅ 체크리스트
- [x] 코드 리뷰 준비 완료
- [x] 테스트 통과

## 📝 테스트 방법
`./gradlew test` 실행

Made with [Cursor](https://cursor.com)