### PR TITLE
[DOCS] CI 테스트 수정 관련 주석 보강

### DIFF
--- a/src/main/java/com/cotalk/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/cotalk/infrastructure/security/SecurityConfig.java
@@ -64,6 +64,7 @@ public class SecurityConfig {
      * @throws Exception 보안 설정 중 오류 발생 시
      */
     @Bean
+    // 테스트 프로파일(ratelimit-test 등)에서 IntegrationTestSecurityConfig만 사용하도록 비활성화 가능
     @ConditionalOnProperty(name = "app.security.default-chain.enabled", matchIfMissing = true)
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http

--- a/src/test/java/com/cotalk/infrastructure/ratelimit/RateLimitIntegrationTest.java
+++ b/src/test/java/com/cotalk/infrastructure/ratelimit/RateLimitIntegrationTest.java
@@ -33,6 +33,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * Rate Limit 통합 테스트.
  * Testcontainers Redis를 사용하여 Rate Limit 동작을 검증합니다.
  *
+ * <p>IP 식별은 {@link RateLimitInterceptor}와 동일하게 X-Real-IP 헤더를 사용한다
+ * (X-Forwarded-For는 클라이언트 조작 가능으로 미사용).</p>
+ *
  * <p><b>주의:</b> Docker가 실행 중이어야 테스트가 실행됩니다.</p>
  *
  * @author seunggu.lee

--- a/src/test/resources/application-ratelimit-test.yml
+++ b/src/test/resources/application-ratelimit-test.yml
@@ -46,6 +46,7 @@ snowflake:
   worker-id: 0
 
 app:
+  # 통합 테스트에서 IntegrationTestSecurityConfig의 테스트용 체인만 사용 (빈 충돌 방지)
   security:
     default-chain:
       enabled: false


### PR DESCRIPTION
## 개요
PR #130 에서 수정한 CI 통합 테스트 관련 코드에 설명 주석/JavaDoc을 보강합니다.

## 변경사항
- `SecurityConfig.java`: `@ConditionalOnProperty` 용도 설명 주석 추가
- `RateLimitIntegrationTest.java`: X-Real-IP 헤더 사용 이유 JavaDoc 추가
- `application-ratelimit-test.yml`: `default-chain.enabled: false` 설정 의도 주석 추가

## 통계
- 변경 파일: 3개
- 추가: +5줄 / 삭제: 0줄
- 커밋: 1개

Closes #131

## 체크리스트
- [x] 주석/문서만 변경 (기능 영향 없음)
- [x] 빌드 통과 확인

## 테스트 방법
- 기능 변경 없음, 주석만 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)