### PR TITLE
[FIX] CI WebSocket 통합 테스트 4건 AuthenticationException 수정

### DIFF
--- a/src/test/java/com/cotalk/integration/WebSocketChatIntegrationTest.java
+++ b/src/test/java/com/cotalk/integration/WebSocketChatIntegrationTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Timeout;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.annotation.Import;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -52,6 +53,7 @@ import static org.awaitility.Awaitility.await;
         }
 )
 @ActiveProfiles("test")
+@Import(IntegrationTestSecurityConfig.class)
 @DisplayName("WebSocket Chat Integration")
 class WebSocketChatIntegrationTest {
 


### PR DESCRIPTION
## 개요

CI 환경에서 `WebSocketChatIntegrationTest` 4건이 `AuthenticationException`으로 실패하는 문제를 수정합니다.

## 원인 분석

`WebSocketChatIntegrationTest`에 `@Import(IntegrationTestSecurityConfig.class)` 누락:

1. `app.security.default-chain.enabled=false` → 프로덕션 SecurityFilterChain 비활성화
2. `@TestConfiguration`은 `@SpringBootTest`에서 자동 스캔 안 됨 → `@Import` 필수
3. 테스트 SecurityConfig 미등록 → Spring Security 기본 폼 로그인 체인 fallback
4. `/ws` 핸드셰이크 시 401 → `AuthenticationException`

## 변경사항

- `WebSocketChatIntegrationTest.java`에 `@Import(IntegrationTestSecurityConfig.class)` 추가 (+2줄)

## 통계

- 변경 파일: 1개
- 추가: 2줄
- 커밋: 1개

Closes #133

## 체크리스트

- [x] 로컬 테스트 통과 (`WebSocketChatIntegrationTest` 4건 모두 통과)
- [x] 전체 테스트 스위트 통과 (`./gradlew test` BUILD SUCCESSFUL)

## 테스트 방법

```bash
./gradlew test --rerun --tests "com.cotalk.integration.WebSocketChatIntegrationTest"
```