### PR TITLE
[FIX] CI WebSocket 테스트 Redis Pub/Sub 레이스 컨디션 수정

### DIFF
--- a/src/test/java/com/cotalk/integration/WebSocketChatIntegrationTest.java
+++ b/src/test/java/com/cotalk/integration/WebSocketChatIntegrationTest.java
@@ -6,6 +6,7 @@ import com.cotalk.domain.port.outbound.ChatRoomMemberRepository;
 import com.cotalk.domain.port.outbound.ChatRoomRepository;
 import com.cotalk.domain.port.outbound.IdGenerator;
 import com.cotalk.infrastructure.security.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -14,6 +15,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.context.annotation.Import;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -87,6 +91,45 @@ class WebSocketChatIntegrationTest {
 
     @Autowired
     private TestRestTemplate restTemplate;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    private RedisMessageListenerContainer redisMessageListenerContainer;
+
+    /**
+     * Redis Pub/Sub 리스너가 완전히 초기화될 때까지 대기한다.
+     * {@link RedisMessageListenerContainer#start()}는 비동기로 PSUBSCRIBE를 등록하므로,
+     * CI 환경에서 테스트 실행 전에 구독이 완료되지 않는 레이스 컨디션이 발생할 수 있다.
+     * Redis 서버의 PUBSUB NUMPAT 명령으로 실제 패턴 구독 등록을 확인한다.
+     */
+    @BeforeEach
+    void waitForRedisPubSubReady() {
+        // 1. 컨테이너 running 상태 확인
+        await()
+                .atMost(10, TimeUnit.SECONDS)
+                .pollInterval(100, TimeUnit.MILLISECONDS)
+                .until(redisMessageListenerContainer::isRunning);
+
+        // 2. Redis 서버에 PSUBSCRIBE가 실제 등록될 때까지 확인
+        //    PUBSUB NUMPAT: 서버에 등록된 패턴 구독 수 반환
+        await()
+                .atMost(5, TimeUnit.SECONDS)
+                .pollInterval(100, TimeUnit.MILLISECONDS)
+                .until(() -> {
+                    try {
+                        Long numpat = redisTemplate.execute((RedisCallback<Long>) connection -> {
+                            Object result = connection.execute("PUBSUB", "NUMPAT".getBytes());
+                            if (result instanceof Long l) return l;
+                            return 0L;
+                        });
+                        return numpat != null && numpat > 0;
+                    } catch (Exception e) {
+                        return false;
+                    }
+                });
+    }
 
     @Test
     @Timeout(value = 20)


### PR DESCRIPTION
## 개요

CI 환경에서 `WebSocketChatIntegrationTest` 4건이 `TimeoutException`으로 실패하는 Redis Pub/Sub 레이스 컨디션 수정.

## 원인

`RedisMessageListenerContainer.start()`가 비동기로 PSUBSCRIBE를 등록하므로, CI 환경(느린 스레드 스케줄링)에서 구독 등록이 완료되기 전에 테스트가 메시지를 발행 → Redis에 PUBLISH되지만 아직 SUBSCRIBE가 안 돼서 메시지 유실 → 타임아웃.

```
메시지 흐름: Controller → RedisChatMessageBroker.publish()
  → Redis PUBLISH "chat:room:{id}" → [PSUBSCRIBE 아직 미등록] → 유실 → TimeoutException
```

## 수정사항

`@BeforeEach`에서 Redis `PUBSUB NUMPAT` 명령으로 패턴 구독이 실제 Redis 서버에 등록될 때까지 확인 후 테스트 실행:

1. `RedisMessageListenerContainer.isRunning()` 확인
2. `PUBSUB NUMPAT > 0` 확인 (Redis 서버에 패턴 구독이 등록된 수)

## 연관 PR

- PR #134 (merged): `@Import` 누락 → `AuthenticationException` 수정
- 이번 PR: Redis Pub/Sub 비동기 초기화 → `TimeoutException` 수정

Closes #133

## 테스트

```bash
./gradlew test --rerun --tests "com.cotalk.integration.WebSocketChatIntegrationTest"
```