### PR TITLE
fix: CI WebSocket 통합 테스트 Redis Pub/Sub 레이스 컨디션 해결

### DIFF
--- a/src/test/java/com/cotalk/integration/WebSocketChatIntegrationTest.java
+++ b/src/test/java/com/cotalk/integration/WebSocketChatIntegrationTest.java
@@ -15,13 +15,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.context.annotation.Import;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.data.redis.core.RedisCallback;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.simp.stomp.StompFrameHandler;
 import org.springframework.messaging.simp.stomp.StompHeaders;
 import org.springframework.messaging.simp.stomp.StompSession;
@@ -93,42 +87,29 @@ class WebSocketChatIntegrationTest {
     private TestRestTemplate restTemplate;
 
     @Autowired
-    private RedisTemplate<String, String> redisTemplate;
-
-    @Autowired
     private RedisMessageListenerContainer redisMessageListenerContainer;
 
     /**
      * Redis Pub/Sub 리스너가 완전히 초기화될 때까지 대기한다.
      * {@link RedisMessageListenerContainer#start()}는 비동기로 PSUBSCRIBE를 등록하므로,
      * CI 환경에서 테스트 실행 전에 구독이 완료되지 않는 레이스 컨디션이 발생할 수 있다.
-     * Redis 서버의 PUBSUB NUMPAT 명령으로 실제 패턴 구독 등록을 확인한다.
+     *
+     * <p>{@code isListening()}은 내부 상태 머신이 {@code State.listening()}으로 전이된 후에만 true를 반환한다.
+     * 이 전이는 PSUBSCRIBE 명령이 Redis 서버에서 성공적으로 처리된 후 발생하므로,
+     * 서버 측 구독 등록을 신뢰할 수 있게 보장한다.</p>
+     *
+     * <p>참고: 이전에 사용했던 {@code PUBSUB NUMPAT} 방식은 Lettuce 드라이버의
+     * {@code ByteArrayOutput}이 integer 응답을 처리하지 못해 항상 실패했다
+     * (spring-data-redis#2908, lettuce#2849).</p>
      */
     @BeforeEach
     void waitForRedisPubSubReady() {
-        // 1. 컨테이너 running 상태 확인
+        // isListening() = PSUBSCRIBE가 Redis 서버에서 성공 후 State.listening() 전이 완료
+        // isRunning()과 달리 실제 구독 성공을 보장한다.
         await()
-                .atMost(10, TimeUnit.SECONDS)
-                .pollInterval(100, TimeUnit.MILLISECONDS)
-                .until(redisMessageListenerContainer::isRunning);
-
-        // 2. Redis 서버에 PSUBSCRIBE가 실제 등록될 때까지 확인
-        //    PUBSUB NUMPAT: 서버에 등록된 패턴 구독 수 반환
-        await()
-                .atMost(5, TimeUnit.SECONDS)
-                .pollInterval(100, TimeUnit.MILLISECONDS)
-                .until(() -> {
-                    try {
-                        Long numpat = redisTemplate.execute((RedisCallback<Long>) connection -> {
-                            Object result = connection.execute("PUBSUB", "NUMPAT".getBytes());
-                            if (result instanceof Long l) return l;
-                            return 0L;
-                        });
-                        return numpat != null && numpat > 0;
-                    } catch (Exception e) {
-                        return false;
-                    }
-                });
+                .atMost(15, TimeUnit.SECONDS)
+                .pollInterval(200, TimeUnit.MILLISECONDS)
+                .until(redisMessageListenerContainer::isListening);
     }
 
     @Test

--- a/src/test/java/com/cotalk/integration/WebSocketChatIntegrationTest.java
+++ b/src/test/java/com/cotalk/integration/WebSocketChatIntegrationTest.java
@@ -6,6 +6,7 @@ import com.cotalk.domain.port.outbound.ChatRoomMemberRepository;
 import com.cotalk.domain.port.outbound.ChatRoomRepository;
 import com.cotalk.domain.port.outbound.IdGenerator;
 import com.cotalk.infrastructure.security.JwtTokenProvider;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -14,6 +15,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.context.annotation.Import;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -87,6 +91,45 @@ class WebSocketChatIntegrationTest {
 
     @Autowired
     private TestRestTemplate restTemplate;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    private RedisMessageListenerContainer redisMessageListenerContainer;
+
+    /**
+     * Redis Pub/Sub 리스너가 완전히 초기화될 때까지 대기한다.
+     * {@link RedisMessageListenerContainer#start()}는 비동기로 PSUBSCRIBE를 등록하므로,
+     * CI 환경에서 테스트 실행 전에 구독이 완료되지 않는 레이스 컨디션이 발생할 수 있다.
+     * Redis 서버의 PUBSUB NUMPAT 명령으로 실제 패턴 구독 등록을 확인한다.
+     */
+    @BeforeEach
+    void waitForRedisPubSubReady() {
+        // 1. 컨테이너 running 상태 확인
+        await()
+                .atMost(10, TimeUnit.SECONDS)
+                .pollInterval(100, TimeUnit.MILLISECONDS)
+                .until(redisMessageListenerContainer::isRunning);
+
+        // 2. Redis 서버에 PSUBSCRIBE가 실제 등록될 때까지 확인
+        //    PUBSUB NUMPAT: 서버에 등록된 패턴 구독 수 반환
+        await()
+                .atMost(5, TimeUnit.SECONDS)
+                .pollInterval(100, TimeUnit.MILLISECONDS)
+                .until(() -> {
+                    try {
+                        Long numpat = redisTemplate.execute((RedisCallback<Long>) connection -> {
+                            Object result = connection.execute("PUBSUB", "NUMPAT".getBytes());
+                            if (result instanceof Long l) return l;
+                            return 0L;
+                        });
+                        return numpat != null && numpat > 0;
+                    } catch (Exception e) {
+                        return false;
+                    }
+                });
+    }
 
     @Test
     @Timeout(value = 20)

--- a/src/test/java/com/cotalk/integration/WebSocketChatIntegrationTest.java
+++ b/src/test/java/com/cotalk/integration/WebSocketChatIntegrationTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Timeout;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.annotation.Import;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -52,6 +53,7 @@ import static org.awaitility.Awaitility.await;
         }
 )
 @ActiveProfiles("test")
+@Import(IntegrationTestSecurityConfig.class)
 @DisplayName("WebSocket Chat Integration")
 class WebSocketChatIntegrationTest {
 


### PR DESCRIPTION
## Summary
- CI에서 `WebSocketChatIntegrationTest` 4건이 `ConditionTimeoutException`으로 실패하는 문제 해결
- `@Import(IntegrationTestSecurityConfig.class)` 누락으로 인한 `AuthenticationException` 수정
- `PUBSUB NUMPAT` → `isListening()` 방식으로 Redis 구독 대기 로직 변경

## 근본 원인
`connection.execute("PUBSUB", "NUMPAT".getBytes())`가 Lettuce 드라이버에서 **항상 실패**:
- Lettuce의 `ByteArrayOutput`은 `set(long)` 미지원 → `UnsupportedOperationException` 발생
- `catch (Exception e) { return false; }` 블록이 예외를 삼킴 → 영원히 `false` 반환 → 타임아웃
- Refs: [spring-data-redis#2908](https://github.com/spring-projects/spring-data-redis/issues/2908), [lettuce#2849](https://github.com/redis/lettuce/issues/2849)

## 해결 방법
`RedisMessageListenerContainer.isListening()` 사용:
- 내부 상태 머신이 `State.listening()`으로 전이된 후에만 `true` 반환
- PSUBSCRIBE가 Redis 서버에서 성공 처리된 후 상태 전이가 발생하므로 구독 등록을 정확히 보장

## Test plan
- [ ] CI `./gradlew test`에서 `WebSocketChatIntegrationTest` 4건 통과 확인
- [ ] 나머지 1583건 테스트 기존과 동일하게 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)