### PR TITLE
[FIX] ChatRoomRepositoryAdapterTest findById given 절 복원

### DIFF
--- a/src/test/java/com/cotalk/adapter/outbound/persistence/ChatRoomRepositoryAdapterTest.java
+++ b/src/test/java/com/cotalk/adapter/outbound/persistence/ChatRoomRepositoryAdapterTest.java
@@ -121,6 +121,10 @@ class ChatRoomRepositoryAdapterTest {
         @DisplayName("ID로 채팅방을 조회할 수 있다")
         void should_findChatRoom_when_idProvided() {
             // given
+            chatRoomRepository.save(ChatRoom.builder()
+                    .id(100L)
+                    .type(ChatRoomType.DIRECT)
+                    .build());
 
             // when
             Optional<ChatRoom> found = chatRoomRepository.findById(100L);


### PR DESCRIPTION
## 개요
commit `8888e82`(Sonar/lint 정리)에서 실수로 삭제된 `chatRoomRepository.save()` 호출을 복원합니다.

## 변경사항
- `ChatRoomRepositoryAdapterTest.should_findChatRoom_when_idProvided()` 테스트의 given 절에 `chatRoomRepository.save()` 복원
- save() 반환값을 변수에 할당하지 않아 lint 경고 방지

## 원인
- Sonar/lint 경고 대응 중 `chatRoom` 지역 변수가 미사용으로 오인
- 변수 제거 시 save() 호출 자체까지 삭제 → CI 테스트 실패

## 통계
- 변경 파일: 1개
- 추가: 4줄

Closes #140

## 체크리스트
- [x] 테스트 given 절에 save() 호출 복원
- [x] 기존 테스트 로직 변경 없음

## 테스트 방법
```bash
./gradlew test --tests "com.cotalk.adapter.outbound.persistence.ChatRoomRepositoryAdapterTest"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)