### PR TITLE
[CHORE] Tailscale TS_AUTHKEY로 배포 워크플로 전환

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,7 +78,7 @@ jobs:
   # 2단계: Tailscale VPN으로 NAS에 무중단 배포
   # ===========================================
   # 공개 포트 없이 Tailscale VPN 터널을 통해 SSH 접속.
-  # 필요 secrets: TS_OAUTH_CLIENT_ID, TS_OAUTH_SECRET,
+  # 필요 secrets: TS_AUTHKEY,
   #              NAS_SSH_KEY, NAS_USER, NAS_DEPLOY_PATH,
   #              GHCR_USER, GHCR_TOKEN
   deploy:
@@ -91,9 +91,7 @@ jobs:
       - name: Connect to Tailscale
         uses: tailscale/github-action@v4
         with:
-          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-          tags: tag:ci
+          authkey: ${{ secrets.TS_AUTHKEY }}
 
       - name: Deploy to NAS via Tailscale SSH
         env:


### PR DESCRIPTION
## 개요
GitHub Actions 배포 워크플로에서 Tailscale 인증을 OAuth 기반에서 TS_AUTHKEY(authkey) 기반으로 전환합니다.

## 변경사항
- Tailscale GitHub Action 설정을 `authkey: ${{ secrets.TS_AUTHKEY }}`로 변경
- 워크플로 주석의 필요 secrets 목록을 최신화

## 통계
- 변경 파일: 1개 (`.github/workflows/deploy.yml`)
- 변경 라인: +2 / -4
- 커밋 수: 1

Closes #144

## 체크리스트
- [ ] Actions에서 `TS_AUTHKEY` secret이 설정되어 있는지 확인
- [ ] 배포 잡이 Tailscale 연결 단계에서 정상 통과하는지 확인

## 테스트 방법
- GitHub Actions `deploy` 워크플로를 실행해 Tailscale 연결 단계 로그를 확인

Made with [Cursor](https://cursor.com)