### PR TITLE
[DOCS] NAS Blue-Green 롤백 및 Flutter 아키텍처 블로그 복원

### DIFF
--- a/docs/blog-01-realtime-chat-architecture.md
+++ b/docs/blog-01-realtime-chat-architecture.md
@@ -1,0 +1,790 @@
+# 실시간 채팅 아키텍처를 밑바닥부터 쌓아올리기
+
+> Co-Talk 개발기 1편 -- 실시간 채팅 아키텍처 구축
+
+> **시리즈 목차**
+> - 0편: [프로젝트 소개](blog-00-project-introduction.md)
+> - **1편: 실시간 채팅 아키텍처 (현재 글)**
+> - 2편: [헥사고날 아키텍처로 리팩토링하기](blog-02-hexagonal-architecture.md)
+
+---
+
+> "카카오톡 메시지 하나가 전달되기까지 몇 개의 시스템을 거치는 걸까?"
+
+이 질문에 답하려고 프로젝트를 시작한 건 아니었다. 처음에는 단순했다. WebSocket 연결하고, 메시지 DB에 저장하고, 상대방한테 보내주면 되지 않나? 그런데 막상 코드를 짜기 시작하면 질문이 끝없이 쏟아진다. 서버가 2대면 어떡하지? 같은 사람이 폰이랑 태블릿으로 동시 접속하면? 메시지가 DB에는 저장됐는데 WebSocket 전송이 실패하면? 서버가 재시작되는 동안 보낸 메시지는 어디로 가지?
+
+이 글은 Co-Talk 채팅 백엔드의 실시간 메시징 아키텍처를 처음 구축한 과정을 다룬다. [이슈 #1](https://github.com/with-co-talk/co-talk/issues/1)부터 [이슈 #17](https://github.com/with-co-talk/co-talk/issues/17)까지, 2026년 1월 17일부터 22일까지 엿새간의 기록이다. 아직 헥사고날 아키텍처 리팩토링 전이라 구조가 완벽하지는 않지만, 실시간 시스템의 핵심 설계 결정들은 이 시기에 거의 다 내려졌다.
+
+---
+
+## 1. STOMP -- WebSocket 위에 프로토콜이 필요한 이유
+
+### 날것의 WebSocket은 불편하다
+
+WebSocket은 양방향 통신 채널이다. 그런데 "채널을 열었다"는 것과 "메시지를 주고받는 체계가 있다"는 건 다른 이야기다. 날것의 WebSocket은 텍스트 프레임 하나를 주고받을 뿐이다. 이 메시지가 채팅인지, 읽음 확인인지, 타이핑 알림인지 구분하려면 직접 프로토콜을 만들어야 한다. 메시지 포맷, 라우팅, 구독/발행 패턴을 전부 직접 구현해야 하는 거다.
+
+STOMP(Simple Text Oriented Messaging Protocol)는 이걸 대신해준다. HTTP와 비슷한 프레임 구조에 CONNECT, SUBSCRIBE, SEND 같은 명령어가 있고, destination 기반 라우팅을 지원한다. Spring이 STOMP를 1등 시민으로 지원하는 점도 선택 이유였다.
+
+### 엔드포인트와 prefix 설계
+
+[이슈 #1](https://github.com/with-co-talk/co-talk/issues/1)에서 WebSocket 설정을 정리하면서 나름의 규칙을 잡았다.
+
+```java
+@Override
+public void configureMessageBroker(MessageBrokerRegistry config) {
+    // 클라이언트가 구독할 prefix
+    config.enableSimpleBroker("/topic", "/queue");
+    // 클라이언트가 서버로 메시지를 보낼 때 사용하는 prefix
+    config.setApplicationDestinationPrefixes("/app");
+    // 특정 사용자에게 메시지를 보낼 때 사용하는 prefix
+    config.setUserDestinationPrefix("/user");
+}
+```
+
+- `/topic` -- 1:N 브로드캐스트 (채팅방 메시지, 리액션 이벤트)
+- `/queue` -- 1:1 메시지 (개인 알림)
+- `/app` -- 클라이언트 -> 서버 전송 (메시지 발송 요청)
+- `/user` -- 사용자별 개인 피드 (채팅 목록 업데이트)
+
+이 prefix 설계가 왜 중요하냐면, 나중에 구독 권한 검사를 할 때 destination 패턴으로 분기하기 때문이다. `/topic/chat/room/{roomId}`를 구독하면 해당 방의 멤버인지 확인해야 하고, `/topic/user/{userId}`를 구독하면 본인 피드인지 확인해야 한다. prefix가 깔끔해야 이 분기가 자연스러워진다.
+
+### SockJS 폴백
+
+```java
+@Override
+public void registerStompEndpoints(StompEndpointRegistry registry) {
+    // SockJS 지원 엔드포인트
+    registry.addEndpoint("/ws")
+            .setAllowedOriginPatterns(allowedOrigins)
+            .withSockJS();
+
+    // 순수 WebSocket 엔드포인트
+    registry.addEndpoint("/ws")
+            .setAllowedOriginPatterns(allowedOrigins);
+}
+```
+
+같은 `/ws` 엔드포인트에 SockJS 폴백과 순수 WebSocket을 둘 다 등록했다. 모바일 앱은 순수 WebSocket을 쓰고, 웹 브라우저는 SockJS 폴백으로 연결한다. 기업 프록시 뒤에서 WebSocket이 막히는 경우가 있어서 SockJS는 보험이다.
+
+### 전송 제한 -- 느린 클라이언트 대비
+
+[이슈 #8](https://github.com/with-co-talk/co-talk/issues/8)의 코드 리뷰에서 전송 제한 설정을 추가했다.
+
+```java
+@Override
+public void configureWebSocketTransport(WebSocketTransportRegistration registration) {
+    registration
+            // 수신 메시지 최대 크기: 128KB (텍스트 + 파일 메타데이터)
+            .setMessageSizeLimit(128 * 1024)
+            // 클라이언트로 보내는 버퍼 크기: 1MB
+            .setSendBufferSizeLimit(1024 * 1024)
+            // 전송 시간 제한: 20초
+            .setSendTimeLimit(20 * 1000);
+}
+```
+
+`sendBufferSizeLimit`은 기본값(512KB)보다 넉넉하게 1MB로 잡았다. 그룹 채팅방에서 메시지가 동시에 쏟아질 때 일시적으로 버퍼가 차는 경우가 있다. 부족하면 메시지가 유실된다.
+
+`sendTimeLimit`은 20초다. 이 시간 안에 클라이언트로 전송하지 못하면 연결을 끊는다. 네트워크가 끊겼는데 연결이 살아있는 "좀비 연결"을 방지하기 위해서다.
+
+---
+
+## 2. 2단계 인증 -- CONNECT에서 JWT, SUBSCRIBE에서 멤버십
+
+### STOMP CONNECT = 신원 확인
+
+HTTP API는 매 요청마다 Authorization 헤더를 보내고 JWT를 검증한다. WebSocket은 다르다. 한 번 연결되면 커넥션이 유지된다. 그래서 STOMP CONNECT 시점에 한 번만 JWT를 검증하고, 이후 모든 프레임에서는 이미 인증된 Principal을 사용한다.
+
+```java
+if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+    authenticateConnection(accessor);
+}
+```
+
+`authenticateConnection`은 STOMP 헤더에서 `Authorization: Bearer {token}`을 추출하고, `JwtTokenProvider`로 검증한 뒤 `StompPrincipal`을 설정한다.
+
+```java
+private void authenticateConnection(StompHeaderAccessor accessor) {
+    String token = extractToken(accessor)
+            .filter(t -> !t.isBlank())
+            .orElseThrow(() -> {
+                log.warn("WebSocket connection attempt without token");
+                return new IllegalArgumentException("인증 토큰이 필요합니다.");
+            });
+
+    if (!jwtTokenProvider.validateToken(token)) {
+        log.warn("WebSocket connection attempt with invalid token");
+        throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+    }
+
+    Long userId = jwtTokenProvider.getUserIdFromToken(token);
+    accessor.setUser(new StompPrincipal(userId.toString()));
+}
+```
+
+`StompPrincipal`은 `java.security.Principal`을 구현한 record로, userId를 문자열로 저장한다. 이후 모든 STOMP 프레임에서 `accessor.getUser().getName()`으로 사용자 ID를 꺼낼 수 있다.
+
+### STOMP SUBSCRIBE = 권한 확인
+
+JWT 인증만으로는 부족하다. "이 사용자가 이 채팅방의 멤버인가?"는 별도로 확인해야 한다. CONNECT에서 인증된 사용자가 아무 채팅방이나 구독할 수 있으면 안 된다.
+
+[이슈 #10](https://github.com/with-co-talk/co-talk/issues/10)에서 보안을 강화하면서 SUBSCRIBE 단계 인가를 추가했다.
+
+```java
+if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+    authorizeSubscription(accessor);
+}
+```
+
+`authorizeSubscription`은 destination 패턴에 따라 분기한다.
+
+```java
+private static final Pattern ROOM_TOPIC_PATTERN =
+    Pattern.compile("^/topic/chat/room/(\\d+)(/.*)?$");
+private static final Pattern USER_TOPIC_PATTERN =
+    Pattern.compile("^/topic/user/(\\d+)(/.*)?$");
+
+private void authorizeSubscription(StompHeaderAccessor accessor) {
+    // /topic/chat/room/{roomId} -- 채팅방 멤버인지 확인
+    Matcher roomMatcher = ROOM_TOPIC_PATTERN.matcher(destination);
+    if (roomMatcher.matches()) {
+        Long roomId = Long.parseLong(roomMatcher.group(1));
+        if (!chatRoomMemberRepository.existsByChatRoomIdAndUserId(roomId, userId)) {
+            throw new IllegalArgumentException("해당 채널에 대한 접근 권한이 없습니다.");
+        }
+        return;
+    }
+
+    // /topic/user/{userId}/* -- 본인 피드인지 확인
+    Matcher userMatcher = USER_TOPIC_PATTERN.matcher(destination);
+    if (userMatcher.matches()) {
+        Long topicUserId = Long.parseLong(userMatcher.group(1));
+        if (!userId.equals(topicUserId)) {
+            throw new IllegalArgumentException("해당 채널에 대한 접근 권한이 없습니다.");
+        }
+    }
+}
+```
+
+이 2단계 인증 설계가 처음부터 있었던 건 아니다. 초기에는 CONNECT 인증만 있었는데, 채팅방 초대 없이 roomId만 알면 구독할 수 있는 취약점이 있었다. [이슈 #10](https://github.com/with-co-talk/co-talk/issues/10)과 [이슈 #12](https://github.com/with-co-talk/co-talk/issues/12)에서 보안 강화를 하면서 SUBSCRIBE 인가를 추가했다.
+
+```plantuml
+@startuml
+!theme plain
+participant "Client" as Client
+participant "WebSocketAuthInterceptor" as Interceptor
+participant "JwtTokenProvider" as JWT
+participant "ChatRoomMemberRepository" as DB
+
+Client -> Interceptor : STOMP CONNECT\n(Authorization: Bearer {jwt})
+Interceptor -> JWT : validateToken(token)
+JWT --> Interceptor : userId=42
+Interceptor -> Interceptor : accessor.setUser(StompPrincipal("42"))
+Interceptor --> Client : CONNECTED
+
+Client -> Interceptor : STOMP SUBSCRIBE\n/topic/chat/room/7
+Interceptor -> DB : existsByChatRoomIdAndUserId(7, 42)
+DB --> Interceptor : true
+Interceptor --> Client : SUBSCRIBED
+
+Client -> Interceptor : STOMP SUBSCRIBE\n/topic/chat/room/99
+Interceptor -> DB : existsByChatRoomIdAndUserId(99, 42)
+DB --> Interceptor : false
+Interceptor --> Client : ERROR (접근 권한 없음)
+@enduml
+```
+
+---
+
+## 3. 메시지 흐름 -- REST에서 WebSocket까지
+
+### 전체 파이프라인
+
+채팅 메시지 하나가 전송되기까지의 전체 흐름이다.
+
+```plantuml
+@startuml
+!theme plain
+participant "발신자 (REST)" as Sender
+participant "SendMessageService" as Service
+participant "PostgreSQL" as DB
+participant "FCM Push" as FCM
+participant "Redis Pub/Sub" as Redis
+participant "RedisChatMessageSubscriber" as Sub
+participant "WebSocket (/topic)" as WS
+participant "수신자" as Receiver
+
+Sender -> Service : POST /api/v1/messages
+
+group TransactionTemplate 범위 (DB 커넥션 점유)
+    Service -> DB : 멤버 목록 조회
+    Service -> DB : 발신자 정보 조회
+    Service -> DB : 멤버십 검증
+    Service -> DB : 메시지 저장 (Snowflake ID)
+    Service -> DB : lastReadMessageId 업데이트
+end
+
+note over Service, FCM : 트랜잭션 밖 (DB 커넥션 해제됨)
+Service -> FCM : 오프라인 멤버에게 푸시 알림
+Service -> Redis : PUBLISH chat:room:{roomId}
+Redis -> Sub : 메시지 수신 (모든 서버 인스턴스)
+Sub -> WS : convertAndSend(/topic/chat/room/{roomId})
+WS -> Receiver : STOMP MESSAGE
+@enduml
+```
+
+이 흐름에서 가장 중요한 설계 결정이 하나 있다. **TransactionTemplate으로 DB 작업만 트랜잭션으로 감싼 것**이다.
+
+### 왜 @Transactional이 아니라 TransactionTemplate인가
+
+처음에는 당연히 `@Transactional`을 썼다. 서비스 메서드 위에 어노테이션 하나 붙이면 끝이니까. 그런데 문제가 보였다.
+
+`@Transactional`은 메서드 전체를 트랜잭션으로 감싼다. 메시지 저장 후에 FCM 푸시 알림을 보내고, Redis Pub/Sub로 브로드캐스트하는 작업까지 전부 트랜잭션 안에 들어간다. 이게 뭐가 문제냐면:
+
+1. **DB 커넥션 점유 시간이 길어진다.** FCM 호출이 200ms 걸리고, Redis 발행이 10ms 걸리면 DB 커넥션을 210ms 더 잡고 있는 거다. 트래픽이 몰리면 커넥션 풀이 고갈된다.
+2. **외부 시스템 장애가 DB 롤백을 유발한다.** Redis가 잠깐 타임아웃되면? 트랜잭션이 롤백되고, 이미 DB에 저장된 메시지도 사라진다. 사용자는 메시지를 보냈다고 생각하는데 실제로는 증발한 거다.
+
+`TransactionTemplate`은 이 문제를 해결한다. DB 작업만 정확히 감싸고, 나머지는 트랜잭션 밖에서 실행한다.
+
+```java
+private SendResult doSendMessage(Long chatRoomId, Long senderId,
+                                  Message message, String notificationContent) {
+    var timerSample = customMetrics.startMessageProcessingTimer();
+
+    // DB 작업만 트랜잭션으로 래핑 (커넥션 점유 최소화)
+    SendResult result = transactionTemplate.execute(status -> {
+        // Pre-fetch ONCE: 중복 쿼리 방지
+        List<ChatRoomMember> members =
+            chatRoomMemberRepository.findByChatRoomId(chatRoomId);
+        User sender = userRepository.findById(senderId).orElse(null);
+
+        // 멤버십 검증 (사전 조회한 목록에서 확인 -- 별도 쿼리 없음)
+        boolean isMember = members.stream()
+            .anyMatch(m -> m.getUserId().equals(senderId));
+        if (!isMember) {
+            throw new ChatRoomAccessDeniedException(chatRoomId, senderId);
+        }
+
+        message.validateContent();
+        Message savedMessage = messageRepository.save(message);
+
+        // 발신자는 자신이 보낸 메시지를 읽은 것으로 간주
+        chatRoomMemberRepository.updateLastReadMessageIdIfNewer(
+            chatRoomId, senderId, timeProvider.now(), savedMessage.getId());
+
+        return new SendResult(savedMessage, senderNickname, senderAvatarUrl, members);
+    });
+
+    // -- 여기서부터 트랜잭션 밖 --
+    // 푸시 알림 전송 (Redis 호출 -- DB 커넥션 미점유)
+    sendPushNotificationsToOtherMembers(chatRoomId, senderId,
+        notificationContent, result.senderNickname(),
+        result.senderAvatarUrl(), result.members());
+
+    customMetrics.stopMessageProcessingTimer(timerSample);
+    return result;
+}
+```
+
+[이슈 #8](https://github.com/with-co-talk/co-talk/issues/8)의 성능 개선 코드 리뷰에서 이 패턴으로 전환했다. `transactionTemplate.execute()` 블록 안에서 DB 조회와 저장을 한꺼번에 처리하고, 블록이 끝나면 트랜잭션이 커밋되며 DB 커넥션이 반환된다. 이후의 FCM, Redis 호출은 DB 커넥션 없이 실행된다.
+
+### Pre-fetch로 중복 쿼리 제거
+
+위 코드에서 또 하나 주목할 점은 `members`와 `sender`를 트랜잭션 안에서 한 번만 조회하고, 이후 단계(브로드캐스트, 푸시 알림)에서 재사용한다는 것이다.
+
+초기 버전에서는 이랬다.
+
+```
+sendMessage()     -- members 조회 (1회)
+broadcastMessage() -- members 조회 (2회), sender 조회 (1회)
+sendPushNotification() -- members 조회 (3회), sender 조회 (2회)
+```
+
+같은 데이터를 3번씩 조회하고 있었다. `SendResult` record에 조회 결과를 담아서 내려보내는 것으로 해결했다.
+
+```java
+// SendMessageService 내부
+record SendResult(Message message, String senderNickname,
+                  String senderAvatarUrl, List<ChatRoomMember> members) {}
+```
+
+---
+
+## 4. Redis Pub/Sub -- 멀티 인스턴스 브로드캐스트
+
+### 왜 Spring의 SimpleBrokerRelay를 안 쓰나
+
+Spring STOMP에는 `enableStompBrokerRelay()`라는 옵션이 있다. 외부 STOMP 브로커(ActiveMQ, RabbitMQ)에 릴레이하는 방식이다. 써봤다. 그런데 두 가지가 마음에 안 들었다.
+
+첫째, 별도 STOMP 브로커 인프라가 필요하다. 이미 Redis를 캐시와 세션 관리에 쓰고 있는데, STOMP 브로커까지 따로 운영하고 싶지 않았다.
+
+둘째, 메시지 가공이 어렵다. 수신된 Redis 메시지를 WebSocket DTO로 변환하고, HTML 엔티티 언이스케이프를 하고, 스키마 버전을 붙이는 등의 가공이 필요했다. SimpleBrokerRelay는 이런 중간 처리가 쉽지 않다.
+
+결국 직접 Redis Pub/Sub을 쓰기로 했다.
+
+### 3채널 설계
+
+[이슈 #1](https://github.com/with-co-talk/co-talk/issues/1)에서 채팅 메시지 채널만 만들었다가, [이슈 #17](https://github.com/with-co-talk/co-talk/issues/17)에서 채널 체계를 확장했다.
+
+```
+chat:room:{roomId}            -- 채팅 메시지 (TEXT, IMAGE, FILE, 시스템 메시지)
+chat:room:{roomId}:reaction   -- 리액션 이벤트 (ADDED, REMOVED)
+chat:room:{roomId}:event      -- 채팅방 이벤트 (READ, TYPING, MESSAGE_DELETED, MESSAGE_UPDATED)
+```
+
+왜 하나의 채널에 전부 넣지 않았나? 처음에는 그랬다. 그런데 리액션과 타이핑 이벤트는 메시지보다 훨씬 빈번하게 발생한다. 타이핑 이벤트는 초당 수십 건이 될 수 있다. 채널을 분리하면 구독자 쪽에서 관심 없는 이벤트를 파싱할 필요가 없고, 나중에 채널별 처리 우선순위를 다르게 줄 수도 있다.
+
+### Publisher -- RedisChatMessageBroker
+
+```java
+@Component
+@ConditionalOnProperty(name = "spring.data.redis.enabled",
+                       havingValue = "true", matchIfMissing = true)
+public class RedisChatMessageBroker implements ChatMessageBroker {
+
+    @Override
+    public void publish(Long roomId, ChatBroadcastMessage message) {
+        String channel = channelPrefix + roomId;
+        String jsonMessage = objectMapper.writeValueAsString(message);
+        redisTemplate.convertAndSend(channel, jsonMessage);
+    }
+
+    @Override
+    public void publishReaction(Long roomId, ReactionBroadcastEvent reactionEvent) {
+        String channel = channelPrefix + roomId + ":reaction";
+        String jsonMessage = objectMapper.writeValueAsString(reactionEvent);
+        redisTemplate.convertAndSend(channel, jsonMessage);
+    }
+
+    @Override
+    public void publishRoomEvent(Long roomId, Object event) {
+        String channel = channelPrefix + roomId + ":event";
+        String jsonMessage = objectMapper.writeValueAsString(event);
+        redisTemplate.convertAndSend(channel, jsonMessage);
+    }
+}
+```
+
+`channelPrefix`는 `AppProperties`에서 주입받는다. 기본값은 `chat:room:`이다. 나중에 테스트 환경에서 채널 충돌을 피하기 위해 prefix를 바꿀 수 있도록 외부화한 것이다.
+
+### Subscriber -- Redis에서 WebSocket으로
+
+```java
+@Component
+@ConditionalOnProperty(name = "spring.data.redis.enabled",
+                       havingValue = "true", matchIfMissing = true)
+public class RedisChatMessageSubscriber implements MessageListener {
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String channel = new String(message.getChannel());
+        String jsonMessage = new String(message.getBody());
+
+        RoomChannelInfo channelInfo = RoomChannelInfo.parse(channelPrefix, channel);
+
+        // suffix 기반 분기
+        if (channelInfo.isReactionChannel()) {
+            handleReaction(channelInfo.roomId(), jsonMessage);
+            return;
+        }
+        if (channelInfo.isEventChannel()) {
+            handleRoomEvent(channelInfo.roomId(), jsonMessage);
+            return;
+        }
+
+        // 일반 채팅 메시지
+        ChatBroadcastMessage chatMessage =
+            objectMapper.readValue(jsonMessage, ChatBroadcastMessage.class);
+        WebSocketChatMessage wsMessage = toWebSocketMessage(chatMessage);
+        messagingTemplate.convertAndSend(
+            "/topic/chat/room/" + chatMessage.roomId(), wsMessage);
+    }
+}
+```
+
+구독은 `RedisMessageListenerContainer`에서 패턴 구독으로 처리한다.
+
+```java
+// RedisMessagingConfig.java
+String chatChannelPattern = appProperties.redis().channelPrefix() + "*";
+container.addMessageListener(chatMessageSubscriber, new PatternTopic(chatChannelPattern));
+```
+
+`chat:room:*` 패턴 하나로 모든 채팅방의 메시지, 리액션, 이벤트 채널을 구독한다. 채팅방이 새로 생길 때마다 구독을 추가할 필요가 없다.
+
+### InMemory 폴백 -- Redis 없이도 동작하는 채팅
+
+테스트할 때마다 Redis를 띄워야 한다면 개발이 고통스러워진다. [이슈 #3](https://github.com/with-co-talk/co-talk/issues/3)에서 인터페이스를 도입하면서 `@ConditionalOnProperty`로 전략 전환을 구현했다.
+
+```java
+@Component
+@ConditionalOnProperty(name = "spring.data.redis.enabled", havingValue = "false")
+public class InMemoryChatMessageBroker implements ChatMessageBroker {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @Override
+    public void publish(Long roomId, ChatBroadcastMessage message) {
+        // Redis 없이 직접 WebSocket으로 브로드캐스트 (단일 서버 환경)
+        WebSocketChatMessage wsMessage = toWebSocketMessage(message);
+        messagingTemplate.convertAndSend("/topic/chat/room/" + roomId, wsMessage);
+    }
+}
+```
+
+`spring.data.redis.enabled=false`이면 InMemory 구현체가 활성화되고, Redis Pub/Sub 대신 `SimpMessagingTemplate`으로 바로 WebSocket에 전달한다. 단일 서버에서는 완벽하게 동작한다. 단위 테스트와 로컬 개발에서는 이 모드를 쓴다.
+
+```plantuml
+@startuml
+!theme plain
+left to right direction
+
+rectangle "ChatMessageBroker\n인터페이스" as A
+
+rectangle "RedisChatMessageBroker" as C
+rectangle "InMemoryChatMessageBroker" as D
+rectangle "Redis Pub/Sub\n멀티 인스턴스" as E
+rectangle "SimpMessagingTemplate\n단일 서버" as F
+
+A --> C : "redis.enabled = **true**"
+A --> D : "redis.enabled = **false**"
+C --> E
+D --> F
+@enduml
+```
+
+이 패턴은 ChatMessageBroker뿐 아니라 ChatRoomPresenceTracker, UserEventBroker, FileStorage, EmailSender에도 동일하게 적용했다. 인프라 의존성을 전략 패턴으로 감싸면 테스트가 편해지고, 기술 전환 비용이 낮아진다.
+
+---
+
+## 5. Presence 시스템 -- "누가 지금 이 방을 보고 있는가"
+
+### 왜 Presence가 필요한가
+
+카카오톡에서 메시지를 보내면 숫자가 뜬다. "1"이면 한 명이 안 읽은 거다. 이 기능을 구현하려면 "누가 지금 이 채팅방을 보고 있는가"를 알아야 한다. 보고 있는 사람에게는 푸시 알림을 보낼 필요가 없고, 읽음 처리도 즉시 해야 한다.
+
+### Redis ZSet + TTL Score
+
+[이슈 #16](https://github.com/with-co-talk/co-talk/issues/16)에서 presence 시스템을 Redis ZSet으로 구현했다.
+
+```
+키: presence:chat:room:{roomId}:active:z
+타입: ZSet
+멤버: userId
+스코어: expiresAtMillis (현재 시간 + 60초)
+```
+
+ZSet의 score를 만료 시간으로 쓰는 아이디어다. 구독하면 score를 현재 시간 + 60초로 설정하고, 조회할 때 현재 시간보다 score가 작은 엔트리는 만료된 것으로 간주해 제거한다.
+
+```java
+@Override
+public void markActive(Long chatRoomId, Long userId, String sessionId) {
+    long expiresAt = System.currentTimeMillis() + TTL_MILLIS;
+    String roomKey = roomKey(chatRoomId);
+    redisTemplate.opsForZSet().add(roomKey, String.valueOf(userId), expiresAt);
+}
+
+@Override
+public boolean isActive(Long chatRoomId, Long userId) {
+    cleanupExpired(chatRoomId);
+    Double score = redisTemplate.opsForZSet()
+        .score(roomKey(chatRoomId), String.valueOf(userId));
+    return score != null && score > System.currentTimeMillis();
+}
+
+private void cleanupExpired(Long chatRoomId) {
+    redisTemplate.opsForZSet().removeRangeByScore(
+        roomKey(chatRoomId), Double.NEGATIVE_INFINITY, System.currentTimeMillis());
+}
+```
+
+왜 Redis의 KEY TTL 대신 ZSet score를 TTL로 쓸까? KEY TTL은 키 전체에 적용된다. 채팅방에 5명이 있으면 5개의 키를 만들어야 한다. ZSet은 하나의 키에 여러 멤버를 넣고, 멤버별로 개별 만료를 score로 관리할 수 있다. 키 수가 줄어들고, 한 번의 조회로 활성 멤버 전체를 볼 수 있다.
+
+### 멀티 세션 카운팅
+
+같은 사용자가 폰과 태블릿에서 동시에 같은 채팅방을 열 수 있다. 하나의 세션이 나갈 때 바로 비활성으로 처리하면 안 된다. 나머지 세션이 아직 보고 있을 수 있으니까.
+
+```java
+// 구독 시: 세션 카운트 증가
+String countKey = userCountKey(chatRoomId, userId);
+redisTemplate.opsForValue().increment(countKey);
+
+// 구독 해제 시: 세션 카운트 감소 -> 0이면 비활성
+Long count = redisTemplate.opsForValue().decrement(countKey);
+if (count == null || count <= 0) {
+    redisTemplate.opsForZSet().remove(roomKey, userKey);
+    redisTemplate.delete(countKey);
+}
+```
+
+키 설계는 이렇다.
+
+```
+presence:chat:room:{roomId}:active:z              -- ZSet (활성 사용자)
+presence:chat:room:{roomId}:user:count:{userId}   -- String (세션 카운트)
+presence:ws:session:{sessionId}:rooms             -- Set (세션이 구독 중인 방 목록)
+```
+
+세 번째 키(`session:rooms`)는 연결 해제 시 정리용이다. WebSocket이 끊기면 해당 세션이 구독하고 있던 모든 방에서 비활성 처리를 해야 한다. `WebSocketEventListener`가 `SessionSubscribeEvent`와 `SessionDisconnectEvent`를 리스닝해서 `markActive()`/`markInactive()`를 호출하고, 연결 해제 시에는 세션에 매핑된 모든 방을 순회하며 정리한다.
+
+온라인/오프라인 판정도 비슷한 구조다. Redis Set(`ws:user:{userId}:sessions`)에 세션 ID를 관리하고, 마지막 세션이 끊겨야 오프라인으로 전환한다. 같은 사용자가 폰과 태블릿에서 동시에 접속해도, 하나만 끊기면 온라인 상태가 유지된다.
+
+### Pipeline 배치 최적화
+
+메시지를 보낼 때 채팅방의 멤버 전원이 활성 상태인지 확인해야 한다. 멤버가 10명이면 `isActive()`를 10번 호출해야 하고, Redis 왕복이 20회(cleanup 10회 + score 10회)가 된다.
+
+Redis Pipeline으로 한 번에 묶었다.
+
+```java
+@Override
+public Set<Long> getActiveUserIds(Long chatRoomId, List<Long> userIds) {
+    cleanupExpired(chatRoomId);
+    String roomKey = roomKey(chatRoomId);
+    long now = System.currentTimeMillis();
+
+    List<Object> results = redisTemplate.executePipelined(
+        (RedisCallback<Object>) connection -> {
+            byte[] key = roomKey.getBytes(StandardCharsets.UTF_8);
+            for (Long userId : userIds) {
+                connection.zSetCommands().zScore(key,
+                    String.valueOf(userId).getBytes(StandardCharsets.UTF_8));
+            }
+            return null;
+        });
+
+    Set<Long> activeIds = new HashSet<>();
+    for (int i = 0; i < userIds.size(); i++) {
+        Double score = (Double) results.get(i);
+        if (score != null && score > now) {
+            activeIds.add(userIds.get(i));
+        }
+    }
+    return activeIds;
+}
+```
+
+2N회 왕복이 2회(cleanup 1회 + pipeline 1회)로 줄었다. 10명 방이든 100명 방이든 Redis 왕복 횟수가 동일하다.
+
+---
+
+## 6. Snowflake ID -- DB 없이 순서 보장되는 ID
+
+### UUID가 안 되는 이유
+
+UUID v4는 랜덤이다. 정렬이 안 된다. 채팅 앱에서 메시지를 시간순으로 보여주려면 `ORDER BY created_at`이 필요한데, 인덱스가 UUID(PK)와 created_at 두 개 필요해진다. UUID는 128비트라 인덱스 크기도 크다.
+
+Snowflake ID는 64비트 Long이다. 시간 정보가 ID 안에 있어서 ID 순서 = 시간 순서다. PK 인덱스 하나로 정렬과 조회가 모두 된다.
+
+### 64비트 구조
+
+[이슈 #1](https://github.com/with-co-talk/co-talk/issues/1)에서 Twitter Snowflake 알고리즘을 직접 구현했다.
+
+```
+┌────────┬──────────────┬───────────┬──────────┬──────────┐
+│ 1비트   │ 41비트        │ 5비트      │ 5비트     │ 12비트    │
+│ (부호)  │ (타임스탬프)   │ (DC ID)   │ (Worker) │ (시퀀스)  │
+└────────┴──────────────┴───────────┴──────────┴──────────┘
+```
+
+- **41비트 타임스탬프**: 2024-01-01 에포크 기준, 약 69년간 사용 가능
+- **5비트 DC ID**: 최대 32개 데이터센터
+- **5비트 Worker ID**: 데이터센터당 최대 32개 워커
+- **12비트 시퀀스**: 밀리초당 최대 4,096개 ID
+
+```java
+@Override
+public synchronized Long nextId() {
+    long timestamp = currentTimeMillis();
+
+    if (timestamp < lastTimestamp) {
+        throw new IllegalStateException(
+            "Clock moved backwards. Refusing to generate ID.");
+    }
+
+    if (timestamp == lastTimestamp) {
+        sequence = (sequence + 1) & MAX_SEQUENCE;
+        if (sequence == 0) {
+            // 시퀀스 오버플로우, 다음 밀리초까지 대기
+            timestamp = waitNextMillis(lastTimestamp);
+        }
+    } else {
+        sequence = 0L;
+    }
+
+    lastTimestamp = timestamp;
+
+    return ((timestamp - EPOCH) << TIMESTAMP_SHIFT)
+            | (datacenterId << DATACENTER_ID_SHIFT)
+            | (workerId << WORKER_ID_SHIFT)
+            | sequence;
+}
+```
+
+`synchronized`로 스레드 안전성을 보장한다. 같은 밀리초에 여러 스레드가 ID를 요청하면 시퀀스 번호로 구분한다. 시퀀스가 4096을 넘으면 다음 밀리초까지 spin-wait 한다. 현실적으로 밀리초에 4096건을 넘기는 일은 거의 없다.
+
+시계 역행(`timestamp < lastTimestamp`)이면 즉시 예외를 던진다. NTP 동기화 등으로 시계가 뒤로 가면 ID 충돌이 날 수 있어서, 안전하게 거부하는 게 맞다.
+
+### 분산 Worker ID 할당 -- Redis SETNX
+
+서버 인스턴스가 여러 개면 각각 다른 Worker ID를 가져야 한다. 수동으로 환경변수에 넣을 수도 있지만, 오토스케일링 환경에서는 자동 할당이 필요하다.
+
+[이슈 #5](https://github.com/with-co-talk/co-talk/issues/5)에서 Redis 기반 Worker ID 할당기를 구현했다.
+
+```java
+private long allocateWorkerId() {
+    String sequenceKey = String.format(SEQUENCE_KEY_FORMAT, datacenterId);
+
+    for (int retry = 0; retry < MAX_RETRY_COUNT; retry++) {
+        Long sequence = redisTemplate.opsForValue().increment(sequenceKey);
+        long candidateWorkerId = (sequence - 1) % (MAX_WORKER_ID + 1);
+        String candidateLockKey =
+            String.format(LOCK_KEY_FORMAT, datacenterId, candidateWorkerId);
+
+        Boolean acquired = redisTemplate.opsForValue()
+                .setIfAbsent(candidateLockKey, getInstanceId(), LOCK_TTL);
+
+        if (Boolean.TRUE.equals(acquired)) {
+            return candidateWorkerId;
+        }
+    }
+
+    throw new IllegalStateException("사용 가능한 Worker ID가 없습니다.");
+}
+```
+
+동작 방식은 이렇다.
+
+1. Redis INCR로 순차 번호를 받는다
+2. 순차 번호를 0-31 범위로 매핑한다
+3. SETNX로 해당 Worker ID 잠금을 시도한다
+4. 성공하면 그 ID를 사용, 실패하면 다음 ID로 재시도
+5. 잠금은 24시간 TTL로 자동 해제된다 (좀비 잠금 방지)
+
+인스턴스 종료 시에는 `@PreDestroy`로 잠금을 즉시 해제한다.
+
+```java
+@PreDestroy
+public void shutdown() {
+    redisTemplate.delete(lockKey);
+    log.info("Worker ID lock released: {}", lockKey);
+}
+```
+
+---
+
+## 7. 메시지 암호화 -- AES-256-GCM
+
+### 왜 서버 레벨 암호화인가
+
+E2E(End-to-End) 암호화가 이상적이지만, 첫 버전에서는 서버 레벨 암호화를 선택했다. 이유는 단순하다. E2E를 하려면 키 교환 프로토콜(Signal Protocol 등)과 클라이언트 키 관리가 필요하다. 백엔드만 만드는 단계에서 클라이언트까지 설계하는 건 범위 초과였다.
+
+서버 레벨 암호화라도 DB가 탈취되면 평문이 노출되지 않는다. 암호화 키는 환경변수로 관리하고, DB에는 암호문만 저장된다.
+
+### GCM 모드를 선택한 이유
+
+AES에는 여러 모드가 있다. CBC, CTR, GCM 등. [이슈 #5](https://github.com/with-co-talk/co-talk/issues/5)에서 GCM을 선택했다.
+
+- **CBC**: 패딩 오라클 공격에 취약하다. 별도 HMAC으로 무결성을 검증해야 한다.
+- **CTR**: 암호화는 하지만 무결성을 보장하지 않는다. 누군가 암호문을 조작해도 감지 못한다.
+- **GCM**: 암호화 + 무결성 검증(인증 태그)을 동시에 제공한다. Authenticated Encryption이다.
+
+채팅 메시지는 변조 감지가 중요하다. 누군가 DB의 암호문을 직접 수정했을 때 복호화가 성공하면 안 된다. GCM은 인증 태그가 일치하지 않으면 복호화에 실패한다.
+
+### 구현 -- 랜덤 IV + Base64
+
+```java
+public String encrypt(String plainText) {
+    if (!enabled) return plainText;
+
+    byte[] iv = new byte[GCM_IV_LENGTH];  // 12바이트
+    new SecureRandom().nextBytes(iv);
+
+    Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+    GCMParameterSpec parameterSpec = new GCMParameterSpec(GCM_TAG_LENGTH, iv);
+    cipher.init(Cipher.ENCRYPT_MODE, secretKey, parameterSpec);
+    byte[] cipherText = cipher.doFinal(plainText.getBytes(StandardCharsets.UTF_8));
+
+    // IV + 암호문을 합쳐서 Base64 인코딩
+    ByteBuffer byteBuffer = ByteBuffer.allocate(iv.length + cipherText.length);
+    byteBuffer.put(iv);
+    byteBuffer.put(cipherText);
+    return Base64.getEncoder().encodeToString(byteBuffer.array());
+}
+```
+
+매 암호화마다 12바이트 랜덤 IV를 생성한다. 같은 평문이라도 IV가 다르면 암호문이 달라진다. IV는 비밀이 아니라서 암호문 앞에 붙여서 저장한다. 복호화할 때 앞 12바이트를 IV로 쓰고, 나머지를 GCM으로 복호화한다. `enabled` 플래그로 암호화를 끌 수 있어서 테스트 환경에서는 평문 그대로 저장된다.
+
+### JPA AttributeConverter -- 투명 암호화
+
+서비스 코드가 암호화/복호화를 직접 호출하는 건 번거롭고 실수하기 쉽다. JPA의 `AttributeConverter`를 사용하면 DB에 저장될 때 자동으로 암호화되고, 읽을 때 자동으로 복호화된다.
+
+```java
+@Converter
+public class EncryptedStringConverter implements AttributeConverter<String, String> {
+
+    @Override
+    public String convertToDatabaseColumn(String attribute) {
+        if (attribute == null) return null;
+        return EncryptionServiceHolder.getEncryptionService().encrypt(attribute);
+    }
+
+    @Override
+    public String convertToEntityAttribute(String dbData) {
+        if (dbData == null) return null;
+        try {
+            return EncryptionServiceHolder.getEncryptionService().decrypt(dbData);
+        } catch (EncryptionService.EncryptionException e) {
+            // 암호화되지 않은 기존 데이터인 경우 그대로 반환 (마이그레이션 호환)
+            return dbData;
+        }
+    }
+}
+```
+
+엔티티 필드에 `@Convert(converter = EncryptedStringConverter.class)` 하나만 붙이면 끝이다. 서비스 레이어는 항상 평문을 다루고, 암호화의 존재를 알 필요가 없다.
+
+마이그레이션 호환도 고려했다. `convertToEntityAttribute`에서 복호화 실패 시 평문을 그대로 반환한다. 암호화 도입 전에 저장된 데이터도 읽을 수 있게 하기 위해서다.
+
+한 가지 트레이드오프가 있다. 암호화하면 DB 레벨의 LIKE 검색이 불가능해진다. 메시지 검색 기능은 PostgreSQL Full-Text Search로 별도 구현했다.
+
+---
+
+## 돌아보며 -- 엿새간의 결정들
+
+[이슈 #1](https://github.com/with-co-talk/co-talk/issues/1)부터 [이슈 #17](https://github.com/with-co-talk/co-talk/issues/17)까지 엿새 동안 실시간 채팅 시스템의 기반을 만들었다. 돌아보면 몇 가지가 잘된 결정이었고, 몇 가지는 나중에 고쳐야 했다.
+
+### 잘된 결정
+
+**TransactionTemplate으로 트랜잭션 범위 최소화.** 이건 [이슈 #8](https://github.com/with-co-talk/co-talk/issues/8) 코드 리뷰에서 나온 건데, 초기에 적용해서 좋았다. 나중에 브로드캐스트 실패 격리를 설계할 때 이미 트랜잭션이 분리되어 있어서 작업이 수월했다.
+
+**인프라 전략 패턴(`@ConditionalOnProperty`).** Redis/InMemory 전환을 초기부터 설계한 덕에 테스트 환경 구축이 편했다. CI에서 Redis 없이도 대부분의 테스트가 돌아간다.
+
+**2단계 WebSocket 인증.** CONNECT에서 JWT, SUBSCRIBE에서 멤버십 확인. 보안이 초기부터 설계에 녹아있어서 나중에 덕지덕지 붙이는 상황을 피했다.
+
+### 나중에 고친 것
+
+**패키지 구조.** 이 시기에는 아직 전통적인 레이어드 구조였다. Service가 Repository를 직접 참조하고, 도메인 엔티티에 JPA 어노테이션이 섞여 있었다. [이슈 #19](https://github.com/with-co-talk/co-talk/issues/19)에서 헥사고날 아키텍처로 리팩토링하게 된다. 다음 편에서 다룬다.
+
+**브로드캐스트 실패 처리.** 초기에는 Redis Pub/Sub 실패 시 예외가 그대로 전파됐다. 메시지가 DB에 저장된 후에도 브로드캐스트 실패로 사용자에게 에러가 갈 수 있었다. 실패 격리는 나중에 별도로 설계했다.
+
+**예외 처리 체계.** [이슈 #3](https://github.com/with-co-talk/co-talk/issues/3), [이슈 #12](https://github.com/with-co-talk/co-talk/issues/12), [이슈 #14](https://github.com/with-co-talk/co-talk/issues/14)에서 세 차례에 걸쳐 예외 처리를 개선했다. 처음부터 `DomainException` + `HttpStatusHint` 패턴을 잡았으면 좋았을 텐데, 현실적으로는 기능을 만들면서 패턴이 보이기 시작하는 거라 불가피했다고 생각한다.
+
+### 숫자로 보는 이 시기의 결과물
+
+| 항목 | 수치 |
+|------|------|
+| 기간 | 6일 (01/17 ~ 01/22) |
+| 이슈 | 9개 (#1, #3, #5, #8, #10, #12, #14, #16, #17) |
+| WebSocket 인증 | 2단계 (CONNECT + SUBSCRIBE) |
+| Redis Pub/Sub 채널 | 3종 (message, reaction, event) |
+| ID 생성 처리량 | 밀리초당 4,096개 |
+| Presence 조회 최적화 | 2N회 -> 2회 (Pipeline) |
+| 암호화 | AES-256-GCM + JPA AttributeConverter |
+
+---
+
+## 다음 편 -- 헥사고날 아키텍처
+
+엿새간 만든 이 코드는 동작했다. 테스트도 통과했다. 하지만 Service가 Repository를 직접 참조하고, 도메인 엔티티에 `@Entity`가 붙어있고, 인프라 코드와 비즈니스 로직의 경계가 모호했다.
+
+"도메인 로직을 테스트하려는데 왜 Redis가 필요하지?" -- 이 질문이 헥사고날 리팩토링의 시작이었다. [이슈 #19](https://github.com/with-co-talk/co-talk/issues/19)에서 시작된 그 이야기는 [2편: 헥사고날 아키텍처로 리팩토링하기](blog-02-hexagonal-architecture.md)에서 이어진다.

--- a/docs/blog-14-flutter-clean-architecture.md
+++ b/docs/blog-14-flutter-clean-architecture.md
@@ -1,0 +1,460 @@
+# Flutter에서도 Clean Architecture가 필요할까 — Co-Talk 프론트엔드 설계기
+
+> "백엔드는 헥사고날로 깔끔한데, 프론트는 왜 이렇게 스파게티지?"
+
+백엔드에 헥사고날 아키텍처를 적용하고 나서 프론트엔드 코드를 다시 봤을 때 느낌이 묘했다. 도메인 로직과 HTTP 호출이 위젯 안에 뒤섞여 있고, 상태 관리는 `setState`와 전역 변수가 혼재했다. 백엔드에서 그토록 강조한 "관심사 분리"가 프론트엔드에서는 적용되지 않고 있었다.
+
+그래서 Co-Talk Flutter 앱에도 같은 원칙을 적용하기로 했다. 4레이어 Clean Architecture, GetIt + Injectable 기반 DI, GoRouter와 AuthBloc 통합 라우팅, Cubit과 BLoC의 의식적인 선택. 이 글은 그 설계 과정의 기록이다. 시리즈 14편.
+
+---
+
+## 1. 왜 Flutter에서도 Clean Architecture인가
+
+### 프레임워크 독립성
+
+백엔드 헥사고날의 핵심 철학은 "도메인 로직이 프레임워크에 독립적이어야 한다"는 것이다. Flutter에서도 같은 문제가 발생한다. 위젯 트리 안에 HTTP 호출이 들어가면 다음 세 가지가 동시에 불가능해진다.
+
+첫째, 유닛 테스트. HTTP 클라이언트 없이 비즈니스 로직만 검증할 수가 없다.
+
+둘째, 상태 관리 라이브러리 교체. `setState`에서 BLoC으로, 또는 Riverpod으로 전환할 때 UI 코드 전체를 수정해야 한다.
+
+셋째, datasource 변경. REST API를 GraphQL로 교체하거나, 원격 호출을 로컬 캐시로 대체할 때 위젯까지 영향이 전파된다.
+
+### 4레이어 구조
+
+Co-Talk Flutter 앱의 `lib/` 디렉토리는 네 개 레이어와 두 개 횡단 관심사로 구성된다.
+
+```
+lib/
+  core/                    — 네트워크, 테마, 라우터, 설정 (cross-cutting)
+  data/                    — models, datasources (remote/local), repository 구현체
+  domain/                  — entities, repository 인터페이스 (Flutter 의존 없음)
+  presentation/            — pages, BLoC/Cubits, widgets
+  di/                      — injection.dart + injection.config.dart (코드 생성)
+```
+
+각 레이어를 좀 더 펼치면 이런 모습이다.
+
+```
+lib/
+  core/
+    network/               — Dio 클라이언트, 인터셉터
+    router/                — GoRouter 설정
+    theme/                 — ThemeData, 색상 팔레트
+    constants/             — API URL, 타임아웃 상수
+  data/
+    models/                — JSON ↔ Dart 변환용 DTO (freezed)
+    datasources/
+      remote/              — REST API 호출
+      local/               — SQLite (drift), SecureStorage
+    repositories/          — Repository 인터페이스 구현체
+  domain/
+    entities/              — 순수 Dart 클래스 (Flutter import 없음)
+    repositories/          — Repository 인터페이스
+    usecases/              — (간단한 프로젝트라 service로 통합)
+  presentation/
+    blocs/                 — BLoC, Cubit 클래스
+    pages/                 — 전체 화면 위젯
+    widgets/               — 재사용 위젯 컴포넌트
+  di/
+    injection.dart         — GetIt 초기화
+    injection.config.dart  — Injectable이 생성하는 코드
+```
+
+레이어 간 의존 방향은 항상 안쪽(domain)을 향한다.
+
+```plantuml
+@startuml
+!theme plain
+top to bottom direction
+
+rectangle "presentation/" as P
+rectangle "data/" as DA
+rectangle "**domain/**" as D #FFccFF
+rectangle "core/" as C
+rectangle "di/" as DI
+
+P --> D : "uses entities"
+DA --> D : "implements repositories"
+P ..> DA : "via DI only"
+C ..> D : "utilities"
+DI ..> P : "wires"
+DI ..> DA : "wires"
+@enduml
+```
+
+`presentation/`은 `data/`를 직접 import하지 않는다. DI 컨테이너(GetIt)를 통해서만 의존한다. `domain/`은 Flutter SDK조차 import하지 않는다. 순수 Dart 패키지만 의존하므로 Dart 환경이면 어디서든 테스트할 수 있다.
+
+<!-- IMAGE: Flutter 프로젝트 폴더 구조 — lib/ 디렉토리를 펼친 IDE 스크린샷. core/, data/, domain/, presentation/, di/ 다섯 폴더가 보이고 각 하위 디렉토리가 펼쳐진 상태 -->
+
+---
+
+## 2. DI — GetIt + Injectable로 의존성 주입
+
+### 왜 GetIt + Injectable인가
+
+Flutter의 DI 옵션은 여러 가지다. `provider`의 `MultiProvider`, `riverpod`, 그리고 `get_it + injectable`. Co-Talk에서 GetIt + Injectable을 선택한 이유는 두 가지다.
+
+첫째, 컴파일 타임 코드 생성. `@injectable` 어노테이션을 붙이면 `build_runner`가 `injection.config.dart`를 생성한다. 런타임 리플렉션 없이 타입 안전한 DI가 가능하다.
+
+둘째, 플랫폼 조건부 등록. 모바일과 데스크톱에서 다른 구현체를 등록해야 할 때 `environment` 파라미터로 깔끔하게 분기할 수 있다.
+
+### injection.dart — 플랫폼별 환경 분기
+
+```dart
+// lib/di/injection.dart
+final getIt = GetIt.instance;
+
+const mobileEnv = 'mobile';
+const desktopEnv = 'desktop';
+
+@InjectableInit(
+  initializerName: 'init',
+  preferRelativeImports: true,
+  asExtension: true,
+)
+Future<void> configureDependencies() async {
+  final environment = _determineEnvironment();
+  if (environment == mobileEnv) {
+    getIt.registerLazySingleton<FirebaseMessaging>(
+      () => FirebaseMessaging.instance,
+    );
+  }
+  getIt.init(environment: environment);
+}
+
+String _determineEnvironment() {
+  if (kIsWeb) return desktopEnv;
+  if (Platform.isAndroid || Platform.isIOS) return mobileEnv;
+  return desktopEnv;
+}
+```
+
+`FirebaseMessaging`은 모바일에서만 등록한다. 데스크톱 빌드에서 `firebase_messaging` 패키지를 import만 해도 크래시가 나기 때문에, 등록 자체를 조건부로 처리해야 한다. `_determineEnvironment()`가 이 분기를 담당한다.
+
+### RegisterModule — 플랫폼별 옵션 차이
+
+`@module`로 선언한 `RegisterModule`은 `FlutterSecureStorage`와 `AppDatabase`를 등록한다. `FlutterSecureStorage`의 각 플랫폼 옵션이 조금씩 다르다.
+
+```dart
+// lib/di/injection.dart
+@module
+abstract class RegisterModule {
+  @lazySingleton
+  FlutterSecureStorage get secureStorage => const FlutterSecureStorage(
+    aOptions: AndroidOptions(encryptedSharedPreferences: true),
+    iOptions: IOSOptions(accessibility: KeychainAccessibility.first_unlock),
+    mOptions: MacOsOptions(
+      accountName: 'co_talk_flutter',
+      accessibility: KeychainAccessibility.unlocked,
+    ),
+  );
+
+  @lazySingleton
+  AppDatabase get appDatabase => AppDatabase();
+}
+```
+
+Android는 `EncryptedSharedPreferences`, iOS는 키체인 접근성 설정, macOS는 계정명까지 지정한다. 이 차이가 `RegisterModule` 안에 모여 있어서 플랫폼별 저장소 설정이 한 곳에서 관리된다.
+
+---
+
+## 3. 라우팅 — GoRouter와 인증 가드
+
+### AppRouter — BLoC 상태 기반 리다이렉트
+
+GoRouter의 `redirect` 콜백은 라우트 변경마다 실행된다. `AuthBloc`의 현재 상태를 읽어서 미인증 사용자를 로그인 페이지로 보내거나, 이미 로그인한 사용자가 로그인 페이지에 접근할 때 되돌려 보낸다.
+
+```dart
+// lib/core/router/app_router.dart
+@lazySingleton
+class AppRouter {
+  final AuthBloc _authBloc;
+  AppRouter(this._authBloc);
+
+  late final GoRouter router = GoRouter(
+    initialLocation: AppRoutes.splash,
+    redirect: (context, state) {
+      final authState = _authBloc.state;
+      final isLoggedIn = authState.status == AuthStatus.authenticated;
+      final isInitialOrLoading = authState.status == AuthStatus.initial ||
+          authState.status == AuthStatus.loading;
+      final isAuthRoute = state.matchedLocation == AppRoutes.login;
+
+      if (!isLoggedIn && !isAuthRoute && !isInitialOrLoading) {
+        return AppRoutes.login;
+      }
+      if (isLoggedIn && isAuthRoute) return AppRoutes.friends;
+      return null;
+    },
+    refreshListenable: GoRouterRefreshStream(_authBloc.stream),
+    routes: [
+      ShellRoute(
+        builder: (context, state, child) => BlocProvider.value(
+          value: getIt<ChatListBloc>(),
+          child: MainPage(child: child),
+        ),
+        routes: [
+          GoRoute(path: AppRoutes.chatList, ...),
+          GoRoute(path: AppRoutes.friends, ...),
+        ],
+      ),
+      GoRoute(
+        path: AppRoutes.chatRoom,
+        pageBuilder: (context, state) {
+          final roomId = int.parse(state.pathParameters['roomId']!);
+          return MaterialPage(
+            key: ValueKey('chat-room-$roomId'),
+            child: MultiBlocProvider(
+              providers: [
+                BlocProvider(create: (_) => getIt<ChatRoomBloc>()),
+                BlocProvider(create: (_) => getIt<MessageSearchBloc>()),
+              ],
+              child: ChatRoomPage(roomId: roomId),
+            ),
+          );
+        },
+      ),
+    ],
+  );
+}
+```
+
+`ShellRoute`는 탭 네비게이션 구조에서 `ChatListBloc`을 공유하기 위해 사용한다. 탭을 이동해도 채팅 목록 상태가 유지되어야 하기 때문이다. 반면 채팅방 라우트(`AppRoutes.chatRoom`)는 `getIt<ChatRoomBloc>()`으로 라우트마다 새 인스턴스를 생성한다. 채팅방별로 독립적인 상태가 필요하기 때문이다.
+
+### GoRouterRefreshStream — BLoC을 ChangeNotifier로 변환
+
+GoRouter의 `refreshListenable`은 `ChangeNotifier`만 받는다. BLoC의 `Stream<AuthState>`를 그대로 넘길 수 없다. 어댑터 클래스가 필요하다.
+
+```dart
+// lib/core/router/app_router.dart
+class GoRouterRefreshStream extends ChangeNotifier {
+  late final StreamSubscription<AuthState> _subscription;
+  AuthStatus? _lastStatus;
+
+  GoRouterRefreshStream(Stream<AuthState> stream) {
+    _subscription = stream.listen((state) {
+      if (_lastStatus != state.status) {
+        _lastStatus = state.status;
+        notifyListeners();
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _subscription.cancel();
+    super.dispose();
+  }
+}
+```
+
+`_lastStatus`와 비교해서 실제로 `AuthStatus`가 바뀔 때만 `notifyListeners()`를 호출한다. `AuthState`의 다른 필드(예: `user` 프로필 정보)가 바뀌어도 라우터 리다이렉트가 불필요하게 트리거되지 않는다.
+
+<!-- IMAGE: 로그인 → 채팅방 라우팅 흐름 — Flutter DevTools의 Widget Inspector에서 ShellRoute와 GoRoute 구조, 그리고 BLoC Provider 트리가 보이는 스크린샷 -->
+
+---
+
+## 4. 상태 관리 — Cubit vs BLoC 선택 기준
+
+Co-Talk 앱에는 Cubit과 BLoC이 섞여 있다. 섞인 게 아니라 의도적으로 선택한 것이다. 어떤 기준으로 나뉘는지 먼저 표로 정리한다.
+
+| 기준 | Cubit 선택 | BLoC 선택 |
+|------|-----------|----------|
+| 이벤트 종류 | 3~5개 메서드 | 10개+ 이벤트 클래스 |
+| 상태 흐름 | 단방향, 단순 | 복잡한 이벤트 체인 |
+| 내부 위임 | 불필요 | Manager 클래스 위임 |
+| DI 스코프 | `@lazySingleton` (앱 전역) | `@injectable` (라우트별) |
+| 예시 | ThemeCubit, ChatSettingsCubit | ChatRoomBloc, AuthBloc |
+
+### 단순한 Cubit — ThemeCubit
+
+ThemeCubit은 메서드가 3개다. 상태는 `ThemeMode` enum 하나다. 앱 전역에서 하나의 인스턴스를 공유한다.
+
+```dart
+// lib/presentation/blocs/theme/theme_cubit.dart
+@lazySingleton
+class ThemeCubit extends Cubit<ThemeMode> {
+  final ThemeLocalDataSource _dataSource;
+  ThemeCubit(this._dataSource) : super(ThemeMode.system);
+
+  Future<void> loadTheme() async {
+    final savedMode = await _dataSource.getThemeMode();
+    emit(savedMode ?? ThemeMode.system);
+  }
+
+  Future<void> setTheme(ThemeMode mode) async {
+    await _dataSource.saveThemeMode(mode);
+    emit(mode);
+  }
+
+  bool isDarkMode(BuildContext context) {
+    if (state == ThemeMode.system) {
+      return MediaQuery.platformBrightnessOf(context) == Brightness.dark;
+    }
+    return state == ThemeMode.dark;
+  }
+}
+```
+
+이벤트 클래스를 따로 만들 이유가 없다. `loadTheme()`과 `setTheme()`을 직접 호출하는 편이 더 명확하다. `@lazySingleton`이므로 앱 생명주기 동안 하나의 인스턴스만 존재한다.
+
+### 복잡한 BLoC — ChatRoomBloc
+
+ChatRoomBloc은 다르다. 이벤트 핸들러만 25개가 넘고, 내부적으로 네 개의 Manager 클래스에 위임한다. 타이머도 여러 개 관리한다.
+
+```dart
+// lib/presentation/blocs/chat/chat_room_bloc.dart
+@injectable
+class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
+  late final WebSocketSubscriptionManager _subscriptionManager;
+  late final PresenceManager _presenceManager;
+  late final MessageCacheManager _cacheManager;
+  late final MessageHandler _messageHandler;
+
+  final Map<int, Timer> _typingTimeoutTimers = {};
+  Timer? _pendingTimeoutTimer;
+  Timer? _markAsReadDebounceTimer;
+  static const _pendingMessageTimeout = Duration(seconds: 15);
+
+  ChatRoomBloc(
+    this._subscriptionManager,
+    this._presenceManager,
+    this._cacheManager,
+    this._messageHandler,
+  ) : super(const ChatRoomState()) {
+    on<ChatRoomOpened>(_onOpened);
+    on<ChatRoomClosed>(_onClosed);
+    on<MessageSent>(_onMessageSent);
+    on<MessageReceived>(_onMessageReceived);
+    on<MessageDeleted>(_onMessageDeleted);
+    on<TypingStatusChanged>(_onTypingStatusChanged);
+    on<UserStartedTyping>(_onUserStartedTyping);
+    on<ReactionAddRequested>(_onReactionAddRequested);
+    // ... 25개 이상의 이벤트 핸들러
+  }
+}
+```
+
+`@injectable`이므로 `getIt<ChatRoomBloc>()`을 호출할 때마다 새 인스턴스가 생성된다. 채팅방 A에서 채팅방 B로 이동하면 완전히 독립된 상태를 가진 새 BLoC이 만들어진다. 이전 채팅방의 WebSocket 구독, 타이머, 캐시가 섞이지 않는다.
+
+Cubit이었다면 25개의 이벤트를 25개의 메서드로 처리했을 텐데, 그렇게 하면 "이 메서드가 어떤 순서로 호출되는가"를 추적하기 어렵다. BLoC의 이벤트 스트림은 이벤트 흐름을 로그로 남기기 좋고, 이벤트 클래스 자체가 "무슨 일이 일어났는가"를 명확하게 표현한다.
+
+---
+
+## 5. copyWith 함정 — 설정 상태 리셋 버그
+
+### 증상
+
+`ChatSettingsPage`에서 알림 설정을 켠 뒤 메뉴를 나갔다가 돌아오면, 방금 켠 설정이 초기값으로 되돌아가 있었다. `NotificationSettingsPage`도 같은 증상이었다.
+
+### 원인
+
+Dart의 named constructor가 `this()`로 위임할 때 지정하지 않은 필드는 기본값으로 리셋된다는 사실을 놓쳤다.
+
+```dart
+// 잘못된 패턴 — named constructor가 this()로 위임
+class ChatSettingsState {
+  final ChatSettingsStatus status;
+  final ChatSettings settings;
+
+  const ChatSettingsState({
+    this.status = ChatSettingsStatus.initial,
+    this.settings = const ChatSettings(),
+  });
+
+  // ↓ 이 두 named constructor가 문제
+  // settings를 명시하지 않으면 const ChatSettings() 기본값으로 리셋됨
+  const ChatSettingsState.loading() : this(status: ChatSettingsStatus.loading);
+  const ChatSettingsState.clearing() : this(status: ChatSettingsStatus.clearing);
+}
+```
+
+`ChatSettingsCubit`에서 로딩 상태로 전환할 때 `ChatSettingsState.loading()`을 emit했다. 이 시점에 사용자가 이미 설정을 로드한 상태라면, `settings` 필드가 `const ChatSettings()` 기본값으로 되돌아간다. 로드 완료 후 다시 설정을 emit하지만, 그 사이에 UI가 기본값을 잠깐 렌더링하고, 상태 관리 흐름에 따라서는 기본값이 저장되는 경우도 생겼다.
+
+```dart
+// 문제가 발생하는 흐름
+Future<void> clearCache() async {
+  emit(ChatSettingsState.clearing()); // settings가 기본값으로 리셋!
+  try {
+    await _repository.clearCache();
+    emit(ChatSettingsState.loaded(state.settings)); // state.settings는 이미 기본값
+  } catch (e) { ... }
+}
+```
+
+### 해결 — state.copyWith()로 상태 보존
+
+```dart
+// lib/presentation/blocs/settings/chat_settings_cubit.dart
+@lazySingleton
+class ChatSettingsCubit extends Cubit<ChatSettingsState> {
+  final ChatSettingsRepository _repository;
+  ChatSettingsCubit(this._repository) : super(const ChatSettingsState());
+
+  Future<void> loadSettings() async {
+    if (state.status != ChatSettingsStatus.initial) return; // 초기 상태일 때만
+    emit(state.copyWith(status: ChatSettingsStatus.loading)); // 기존 settings 보존
+    try {
+      final settings = await _repository.getChatSettings();
+      emit(ChatSettingsState.loaded(settings));
+    } catch (e) {
+      emit(ChatSettingsState.loaded(const ChatSettings()));
+    }
+  }
+
+  Future<void> updateNotificationEnabled(bool enabled) async {
+    final updated = state.settings.copyWith(notificationEnabled: enabled);
+    await _repository.saveChatSettings(updated);
+    emit(state.copyWith(settings: updated)); // status는 그대로, settings만 교체
+  }
+
+  Future<void> clearCache() async {
+    emit(state.copyWith(status: ChatSettingsStatus.clearing)); // 기존 settings 보존!
+    try {
+      await _repository.clearCache();
+      emit(state.copyWith(status: ChatSettingsStatus.loaded)); // settings 여전히 보존
+    } catch (e) {
+      emit(state.copyWith(status: ChatSettingsStatus.error));
+    }
+  }
+}
+```
+
+`state.copyWith(status: ChatSettingsStatus.clearing)`는 현재 `state`의 `settings`를 그대로 두고 `status`만 바꾼다. named constructor의 `this()` 위임과 달리, 기존 상태에서 원하는 필드만 바꾼다.
+
+`NotificationSettingsCubit`도 동일한 패턴으로 수정했다.
+
+### 추가 수정 — @lazySingleton Cubit의 loadSettings 중복 호출 방지
+
+`ChatSettingsCubit`은 `@lazySingleton`이다. 앱 생명주기 동안 하나만 존재한다. `ChatSettingsPage`를 여러 번 방문하면 `loadSettings()`가 여러 번 호출될 수 있다. 두 번째 호출부터는 이미 로드된 설정을 덮어쓰는 불필요한 API 요청이 발생한다.
+
+```dart
+Future<void> loadSettings() async {
+  if (state.status != ChatSettingsStatus.initial) return; // 초기 상태일 때만 로드
+  // ...
+}
+```
+
+첫 번째 호출이 완료되면 `status`가 `loaded`로 바뀐다. 두 번째 호출부터는 가드 조건에 걸려서 즉시 반환된다. 싱글턴 Cubit에서 반복 초기화를 막는 간단한 패턴이다.
+
+<!-- IMAGE: Flutter DevTools Timeline — ChatSettingsCubit 상태 전환 로그. loading → loaded 순서가 보이고, settings 필드가 유지되는 것을 확인할 수 있는 화면 -->
+
+---
+
+## 6. 교훈
+
+| # | 교훈 |
+|---|------|
+| 1 | **Cubit과 BLoC의 선택 기준**: 이벤트 종류 5개 이하, 단방향 흐름, 전역 공유라면 Cubit. 복잡한 이벤트 체인, 내부 Manager 위임, 라우트 스코프 상태라면 BLoC |
+| 2 | **copyWith 함정**: Dart named constructor의 `this()` 위임은 지정하지 않은 모든 필드를 기본값으로 리셋한다. 상태 전환 시 반드시 `state.copyWith()`를 사용할 것 |
+| 3 | **Platform-aware DI**: `_determineEnvironment()`로 모바일/데스크톱 환경을 구분하고 조건부로 의존성을 등록하면 하나의 코드베이스로 Android, iOS, macOS 3플랫폼 대응이 가능하다 |
+| 4 | **GoRouter + BLoC 통합**: BLoC의 `Stream`을 `ChangeNotifier`로 변환하는 어댑터(`GoRouterRefreshStream`)가 핵심. `_lastStatus` 비교로 불필요한 리다이렉트를 방지한다 |
+| 5 | **@lazySingleton vs @injectable**: 전역 상태(테마, 설정)는 싱글턴, 라우트 스코프 상태(채팅방)는 매번 새로 생성. DI 스코프를 잘못 설정하면 상태 오염이나 메모리 누수로 이어진다 |
+| 6 | **싱글턴 Cubit의 반복 초기화 방지**: `@lazySingleton` Cubit의 `loadSettings()`는 `initial` 상태일 때만 실행하도록 가드 조건을 추가할 것. 페이지를 여러 번 방문해도 API 요청이 한 번만 발생한다 |
+
+---
+
+다음 편에서는 Co-Talk의 실시간 채팅 구현 — WebSocket Facade 패턴과 Optimistic UI를 다룬다.
+
+[다음 편: Flutter 실시간 채팅 — WebSocket Facade 패턴과 Optimistic UI](blog-15-flutter-realtime-websocket.md)

--- a/docs/blog-15-flutter-realtime-websocket.md
+++ b/docs/blog-15-flutter-realtime-websocket.md
@@ -1,0 +1,511 @@
+# Flutter 실시간 채팅 — WebSocket Facade 패턴과 Optimistic UI
+
+> "메시지를 보냈는데 화면에 안 뜬다. 서버 응답을 기다리는 동안 사용자는 뭘 보고 있어야 하지?"
+
+실시간 채팅을 구현할 때 가장 먼저 부딪히는 문제가 이거다. 서버 응답 전까지 메시지가 안 뜨면 사용자는 "전송됐나?" 하고 불안해한다. 반면 즉시 화면에 뜨면 앱이 빠르다고 느낀다. 그 차이가 UX의 전부인 셈이다.
+
+Co-Talk Flutter 앱의 실시간 채팅은 STOMP over WebSocket으로 동작한다. 연결 관리, 재연결, 메시지 중복 제거, Optimistic UI까지 — 구현하다 보니 단순한 WebSocket 클라이언트가 아니라 꽤 복잡한 시스템이 됐다. 이번 15편에서는 그 전체 구조를 정리한다.
+
+---
+
+## 1. WebSocket 아키텍처 — Facade + 4 Manager
+
+처음엔 `WebSocketService` 하나에 다 때려넣었다. 연결, 구독, 발행, 파싱이 한 파일에 뒤섞이니 800줄을 넘어섰다. 수정할 때마다 어디를 건드려야 할지 감이 안 잡혔다. 그래서 Facade 패턴으로 분리했다.
+
+```plantuml
+@startuml
+!theme plain
+left to right direction
+
+rectangle "WebSocketService\n(Facade)" as WS #FFccFF {
+}
+
+rectangle "ConnectionManager\n(STOMP 연결, 재연결)" as CM
+rectangle "SubscriptionManager\n(토픽 구독 관리)" as SM
+rectangle "MessageSender\n(STOMP 발행)" as MS
+rectangle "PayloadParser\n(JSON → 타입 변환)" as PP
+
+WS --> CM
+WS --> SM
+WS --> MS
+WS --> PP
+
+rectangle "ChatRoomBloc" as CRB
+rectangle "ChatListBloc" as CLB
+
+CRB --> WS : "12 typed streams"
+CLB --> WS : "chatRoomUpdates"
+@enduml
+```
+
+`WebSocketService`는 외부에서 보이는 인터페이스만 담당한다. 실제 연결 로직은 `ConnectionManager`, 구독 관리는 `SubscriptionManager`, STOMP 발행은 `MessageSender`, JSON 파싱은 `PayloadParser`가 각각 맡는다.
+
+외부에 노출하는 건 12개의 타입 안전한 broadcast stream이다:
+
+```dart
+// lib/core/network/websocket_service.dart
+@lazySingleton
+class WebSocketService {
+  Stream<WebSocketChatMessage> get messages => _messageController.stream;
+  Stream<WebSocketReactionEvent> get reactions => _reactionController.stream;
+  Stream<WebSocketReadEvent> get readEvents => _readEventController.stream;
+  Stream<WebSocketChatRoomUpdateEvent> get chatRoomUpdates => _chatRoomUpdateController.stream;
+  Stream<WebSocketTypingEvent> get typingEvents => _typingController.stream;
+  Stream<WebSocketOnlineStatusEvent> get onlineStatusEvents => _onlineStatusController.stream;
+  Stream<WebSocketMessageDeletedEvent> get messageDeletedEvents => _messageDeletedController.stream;
+  Stream<WebSocketMessageUpdatedEvent> get messageUpdatedEvents => _messageUpdatedController.stream;
+  Stream<WebSocketLinkPreviewUpdatedEvent> get linkPreviewUpdatedEvents => _linkPreviewController.stream;
+  Stream<WebSocketProfileUpdateEvent> get profileUpdateEvents => _profileUpdateController.stream;
+  Stream<WebSocketErrorEvent> get errors => _errorController.stream;
+  Stream<void> get reconnected => _reconnectedController.stream;
+}
+```
+
+BLoC은 이 stream만 보면 된다. 내부가 어떻게 굴러가는지 알 필요가 없다. `ChatRoomBloc`은 `messages`, `reactions`, `readEvents`를 구독하고, `ChatListBloc`은 `chatRoomUpdates`를 구독한다. 이게 Facade의 핵심이다 — 복잡성을 뒤로 숨기고 깔끔한 인터페이스만 앞에 내놓는 것.
+
+<!-- IMAGE: WebSocketService가 4개 Manager를 조합하는 구조 다이어그램 — 클래스 다이어그램 스크린샷 -->
+
+---
+
+## 2. STOMP 토픽 설계
+
+STOMP 토픽은 크게 두 레벨로 나뉜다. 채팅방 레벨과 사용자 레벨.
+
+```dart
+// lib/core/network/websocket/websocket_config.dart
+class WebSocketConfig {
+  static const int maxReconnectAttempts = 20;
+  static const Duration initialReconnectDelay = Duration(seconds: 1);
+  static const Duration maxReconnectDelay = Duration(seconds: 30);
+
+  // STOMP 발행 목적지
+  static const String sendMessageDestination = '/app/chat/message';
+  static const String sendTypingDestination = '/app/chat/typing';
+  static const String sendPresenceDestination = '/app/chat/presence';
+
+  // STOMP 구독 토픽
+  static String chatRoomTopic(int roomId) => '/topic/chat/room/$roomId';
+  static String userChatListTopic(int userId) => '/topic/user/$userId/chat-list';
+  static String userReadReceiptTopic(int userId) => '/topic/user/$userId/read-receipt';
+  static String userOnlineStatusTopic(int userId) => '/topic/user/$userId/online-status';
+  static String userProfileUpdateTopic(int userId) => '/topic/user/$userId/profile-update';
+  static const String userErrorQueue = '/user/queue/errors';
+
+  static const Duration dedupeCacheTtl = Duration(seconds: 15);
+  static const int dedupeCacheMaxSize = 500;
+}
+```
+
+채팅방에 입장하면 `/topic/chat/room/{roomId}`를 구독한다. 이 토픽으로 메시지, 반응(이모지), 읽음 처리, 타이핑 상태가 모두 흘러온다. 이벤트 타입 필드로 구분하는 방식이다.
+
+사용자 레벨 토픽은 개인 알림용이다. `/topic/user/{userId}/chat-list`는 채팅 목록 업데이트(새 메시지 미리보기, 안 읽은 수), `/topic/user/{userId}/read-receipt`는 상대방이 내 메시지를 읽었을 때, `/topic/user/{userId}/online-status`는 온라인 상태 변경이다.
+
+`/user/queue/errors`는 STOMP 세션 전용 에러 큐다. 서버에서 메시지 처리 실패 시 이 큐로 에러를 보낸다. 브로드캐스트 토픽이 아니라 개인 큐라서 해당 사용자에게만 전달된다.
+
+채팅방 토픽과 사용자 토픽을 분리한 이유가 있다. 채팅방 메시지는 방에 있는 모든 사람이 받아야 하고, 읽음 확인이나 온라인 상태는 나만 알면 되는 정보다. 한 토픽에 몰아넣으면 불필요한 메시지를 너무 많이 받게 된다.
+
+---
+
+## 3. Exponential Backoff 재연결
+
+네트워크가 끊겼다가 다시 연결될 때 모든 클라이언트가 동시에 재연결을 시도하면 서버가 죽는다. 그래서 재연결 간격을 지수적으로 늘리고, 거기다 랜덤 지터(jitter)를 더한다.
+
+```dart
+// lib/core/network/websocket/websocket_connection_manager.dart
+void _attemptReconnect() {
+  if (_isIntentionalDisconnect) return;
+  if (_reconnectAttempts >= WebSocketConfig.maxReconnectAttempts) {
+    _updateConnectionState(WebSocketConnectionState.failed);
+    return;
+  }
+
+  final baseMs = WebSocketConfig.initialReconnectDelay.inMilliseconds;
+  final maxMs = WebSocketConfig.maxReconnectDelay.inMilliseconds;
+  final exponentialMs = min(baseMs * (1 << _reconnectAttempts), maxMs);
+  final jitterMs = _random.nextInt(1000);
+  final delay = Duration(milliseconds: exponentialMs + jitterMs);
+
+  _reconnectTimer = Timer(delay, () {
+    _reconnectAttempts++;
+    _updateConnectionState(WebSocketConnectionState.reconnecting);
+    _doReconnect();
+  });
+}
+
+Future<void> _doReconnect() async {
+  if (_needsTokenRefresh && onTokenRefreshNeeded != null) {
+    await onTokenRefreshNeeded!();
+    _needsTokenRefresh = false;
+  }
+  connect();
+}
+```
+
+`1 << _reconnectAttempts`는 비트 시프트다. 0번째 시도는 1초, 1번째는 2초, 2번째는 4초, 3번째는 8초, 4번째는 16초, 5번째부터는 30초(max)로 고정된다. `min()`으로 상한을 걸어놨다.
+
+재연결 흐름을 시퀀스로 보면 이렇다:
+
+```plantuml
+@startuml
+!theme plain
+participant "App" as A
+participant "ConnectionManager" as CM
+participant "Server" as S
+
+A -> CM : connect()
+CM -> S : STOMP CONNECT\n(JWT in headers)
+S --> CM : CONNECTED
+
+... 네트워크 끊김 ...
+
+CM -> CM : _attemptReconnect()\n1초 + jitter 대기
+CM -> S : STOMP CONNECT (재연결 #1)
+S --x CM : 실패
+
+CM -> CM : _attemptReconnect()\n2초 + jitter 대기
+CM -> S : STOMP CONNECT (재연결 #2)
+S --> CM : CONNECTED
+
+CM -> A : reconnected stream 발행
+A -> A : gap recovery\n(REST로 놓친 메시지 조회)
+@enduml
+```
+
+몇 가지 세부 사항을 짚고 넘어간다.
+
+**jitter(0~1000ms)**: 수백 명이 동시에 네트워크가 끊겼다 복구됐을 때, 지수 증가만으로는 부족하다. 모든 클라이언트가 정확히 같은 시간에 재연결을 시도하면 그 순간만 스파이크가 생긴다. 지터로 재연결 시점을 흩뜨려야 서버 부하가 분산된다.
+
+**토큰 갱신**: STOMP 헤더에 JWT를 실어 보내는데, 연결이 끊긴 사이에 토큰이 만료됐을 수 있다. `_needsTokenRefresh` 플래그를 보고 재연결 전에 토큰 갱신을 먼저 한다. 이걸 빠뜨리면 재연결 → 401 → 재연결 → 401 무한루프가 생긴다.
+
+**`_isIntentionalDisconnect`**: 사용자가 로그아웃하거나 앱을 끄는 경우 연결을 의도적으로 끊는다. 이 플래그가 true이면 재연결을 시도하지 않는다. 없으면 로그아웃 후에도 계속 재연결을 시도하는 촌극이 벌어진다.
+
+**최대 재연결 횟수 20회**: 지수 증가 + 30초 상한이면 20번째 시도는 연결 끊김 후 몇 분 뒤다. 그래도 안 되면 `failed` 상태로 전환하고 UI에 "연결 실패, 다시 시도" 버튼을 보여준다.
+
+<!-- IMAGE: 재연결 간격을 보여주는 그래프 — 1초, 2초, 4초, 8초, 16초, 30초(max) -->
+
+---
+
+## 4. Event Deduplication
+
+재연결할 때 서버가 최근 메시지를 다시 보내는 경우가 있다. 혹은 네트워크 문제로 같은 STOMP 프레임이 두 번 도달하기도 한다. 이걸 방치하면 채팅 목록에 똑같은 메시지가 두 개 뜬다.
+
+```dart
+// lib/core/network/websocket_service.dart
+void _handleRoomMessage(StompFrame frame, int roomId) {
+  final parsed = _payloadParser.parseRoomPayload(body: frame.body!, roomId: roomId);
+  switch (parsed) {
+    case ParsedChatMessagePayload(:final message):
+      if (_dedupeCache.isDuplicate(message.eventId)) return;  // 중복 제거!
+      _messageController.add(message);
+    case ParsedReadPayload(:final event):
+      _readEventController.add(event);
+    case ParsedReactionPayload(:final event):
+      if (_dedupeCache.isDuplicate(event.eventId)) return;
+      _reactionController.add(event);
+    case ParsedTypingPayload(:final event):
+      _typingController.add(event);
+    case ParsedMessageDeletedPayload(:final event):
+      if (_dedupeCache.isDuplicate(event.eventId)) return;
+      _messageDeletedController.add(event);
+    case ParsedMessageUpdatedPayload(:final event):
+      if (_dedupeCache.isDuplicate(event.eventId)) return;
+      _messageUpdatedController.add(event);
+    case ParsedUnknownPayload():
+      break;
+  }
+}
+```
+
+서버는 모든 이벤트에 `eventId`를 붙여 보낸다. `EventDedupeCache`는 이 `eventId`를 TTL 15초 동안 기억한다. 같은 `eventId`가 15초 내에 다시 오면 `isDuplicate()`가 true를 반환하고, 그냥 버린다.
+
+읽음 이벤트(`ParsedReadPayload`)는 중복 제거를 안 한다. 읽음 이벤트는 상태 업데이트라 중복으로 와도 결과가 같기 때문이다. 중복 메시지와 달리 중복 읽음은 UI 버그를 일으키지 않는다.
+
+`EventDedupeCache`의 설계 포인트:
+- **TTL 15초**: 너무 짧으면 중복을 못 잡고, 너무 길면 메모리를 많이 쓴다. 재연결 후 서버가 보내는 재전송 윈도우가 보통 10초 이내라 15초면 충분하다.
+- **최대 500개**: 무제한으로 쌓으면 메모리 누수다. 500개를 초과하면 오래된 항목부터 제거한다.
+- **타이머 기반 만료**: 각 eventId에 Timer를 달아 TTL이 지나면 자동으로 캐시에서 삭제한다.
+
+타이핑 이벤트는 중복 제거 대상이 아니다. 타이핑은 eventId 자체가 없고, 같은 사용자의 타이핑 이벤트가 연속으로 와도 "아직 입력 중"이라는 의미라 버리면 안 된다.
+
+<!-- IMAGE: EventDedupeCache 동작 — eventId 저장, TTL 만료, 중복 감지 흐름 -->
+
+---
+
+## 5. Optimistic UI — 보내는 즉시 화면에 표시
+
+카카오톡이나 Slack처럼 메시지가 "즉시" 뜨는 것처럼 느껴지는 이유가 Optimistic UI다. 사실 서버 응답을 기다리지 않고 로컬에서 먼저 메시지를 화면에 추가한다. 서버가 응답하면 그때 실제 데이터로 교체한다.
+
+흐름을 보면 이렇다:
+
+```plantuml
+@startuml
+!theme plain
+participant "UI" as UI
+participant "ChatRoomBloc" as B
+participant "WebSocket" as WS
+participant "Server" as S
+
+UI -> B : MessageSent(content)
+B -> B : pseudo-ID 생성\n메시지 리스트에 추가\n(status: pending)
+B --> UI : 즉시 화면에 표시
+
+B -> WS : send(message)
+WS -> S : STOMP /app/chat/message
+
+S --> WS : 서버 응답\n(실제 ID, timestamp)
+WS --> B : MessageReceived
+
+B -> B : pseudo-ID 메시지 찾아서\n실제 메시지로 교체\n(status: sent)
+B --> UI : 화면 갱신
+
+note right of B
+  15초 타임아웃 시
+  status → failed
+  재전송 버튼 표시
+end note
+@enduml
+```
+
+pseudo-ID는 로컬에서 생성하는 임시 ID다. 서버가 채번하는 실제 ID와 겹치지 않도록 음수 값이나 UUID를 쓴다. Co-Talk에서는 `_pendingIdCounter`를 음수로 시작해서 하나씩 줄여나간다.
+
+```dart
+// lib/presentation/blocs/chat/chat_room_bloc.dart
+int _pendingIdCounter = -1;
+Timer? _pendingTimeoutTimer;
+static const _pendingMessageTimeout = Duration(seconds: 15);
+
+Future<void> _onMessageSent(MessageSent event, Emitter<ChatRoomState> emit) async {
+  final pseudoId = _pendingIdCounter--;
+  final optimisticMessage = ChatMessage(
+    id: pseudoId,
+    content: event.content,
+    senderId: _currentUserId,
+    status: MessageStatus.pending,
+    createdAt: DateTime.now(),
+  );
+
+  // 즉시 UI에 추가
+  final updatedMessages = [optimisticMessage, ...state.messages];
+  emit(state.copyWith(messages: updatedMessages));
+
+  // STOMP 발행
+  _webSocketService.sendMessage(
+    roomId: event.roomId,
+    content: event.content,
+    pseudoId: pseudoId,
+  );
+
+  // 15초 타임아웃 설정
+  _pendingTimeoutTimer?.cancel();
+  _pendingTimeoutTimer = Timer(_pendingMessageTimeout, () {
+    _markMessageFailed(pseudoId);
+  });
+}
+
+void _onMessageReceived(WebSocketChatMessage message, Emitter<ChatRoomState> emit) {
+  // pseudo-ID 메시지가 있으면 실제 메시지로 교체
+  if (message.pseudoId != null) {
+    final updatedMessages = state.messages.map((m) {
+      if (m.id == message.pseudoId) {
+        return message.toModel();
+      }
+      return m;
+    }).toList();
+    emit(state.copyWith(messages: updatedMessages));
+    _pendingTimeoutTimer?.cancel();
+  } else {
+    // 다른 사람의 메시지
+    emit(state.copyWith(messages: [message.toModel(), ...state.messages]));
+  }
+}
+
+void _markMessageFailed(int pseudoId) {
+  final updatedMessages = state.messages.map((m) {
+    if (m.id == pseudoId) {
+      return m.copyWith(status: MessageStatus.failed);
+    }
+    return m;
+  }).toList();
+  // emit은 BLoC 내부에서만 가능하므로 add()로 이벤트 발행
+  add(MessageFailed(pseudoId: pseudoId));
+}
+```
+
+서버는 응답 메시지에 `pseudoId`를 그대로 포함시켜 보낸다. 클라이언트가 어떤 pending 메시지와 매핑해야 하는지 알 수 있게. 서버가 `pseudoId`를 에코해주지 않으면 클라이언트는 "어떤 메시지가 전송됐나"를 알 수가 없다.
+
+**`MessageStatus.failed` 처리**: 15초 내에 서버 응답이 없으면 pending 메시지를 failed로 표시하고 재전송 버튼을 노출한다. 실제 전송 실패인지 응답만 늦은 건지 알 수 없지만, 사용자에게 선택권을 주는 게 맞다. 재전송 버튼을 누르면 새 pseudo-ID로 다시 시도한다.
+
+**낙관적 업데이트의 순서 문제**: pending 메시지를 목록 맨 위에 놓고, 서버 응답으로 실제 메시지가 오면 교체한다. 이 사이에 다른 사람의 메시지가 오면 순서가 뒤바뀔 수 있다. `createdAt`으로 정렬하면 해결되지만, pending 메시지의 `createdAt`은 로컬 시간이라 서버 시간과 살짝 다를 수 있다. Co-Talk에서는 pending 메시지를 항상 목록 맨 아래(최신)에 고정하고, 서버 응답 후 `createdAt` 기준으로 재정렬한다.
+
+<!-- IMAGE: 메시지 전송 → pending 표시 → sent 전환 화면 캡처 -->
+
+---
+
+## 6. Gap Recovery — 재연결 후 놓친 메시지 복구
+
+재연결에 성공하면 `reconnected` stream이 발행된다. 이때 WebSocket이 끊겨 있던 동안 못 받은 메시지들을 REST API로 조회해야 한다.
+
+```dart
+// lib/presentation/blocs/chat/chat_room_bloc.dart
+void _setupReconnectHandler() {
+  _webSocketService.reconnected.listen((_) {
+    add(const GapRecoveryRequested());
+  });
+}
+
+Future<void> _onGapRecoveryRequested(
+  GapRecoveryRequested event,
+  Emitter<ChatRoomState> emit,
+) async {
+  final lastMessageId = state.messages.isNotEmpty ? state.messages.first.id : null;
+  if (lastMessageId == null || lastMessageId < 0) return; // pending 메시지는 제외
+
+  final result = await _chatRepository.getMessagesSince(
+    roomId: _roomId,
+    afterId: lastMessageId,
+  );
+
+  result.fold(
+    onSuccess: (newMessages) {
+      if (newMessages.isEmpty) return;
+      // 중복 제거 후 병합
+      final existingIds = state.messages.map((m) => m.id).toSet();
+      final uniqueNew = newMessages.where((m) => !existingIds.contains(m.id)).toList();
+      if (uniqueNew.isEmpty) return;
+      emit(state.copyWith(
+        messages: [...uniqueNew, ...state.messages],
+      ));
+    },
+    onFailure: (_) {
+      // Gap recovery 실패는 치명적이지 않음 — 조용히 무시
+    },
+  );
+}
+```
+
+`lastMessageId`가 음수면 pending 메시지다. pending 메시지의 ID를 기준으로 `getMessagesSince`를 호출하면 안 된다. 서버에 없는 ID라 이상한 결과가 나온다. 그래서 `lastMessageId < 0` 체크를 먼저 한다.
+
+Gap recovery 실패는 조용히 넘긴다. 재연결 직후 추가로 REST 요청까지 실패하면 사용자를 혼란스럽게 만들 뿐이다. 어차피 스크롤을 올리면 페이지네이션으로 이전 메시지를 로드할 수 있다.
+
+`ChatListBloc`도 비슷한 패턴이다. 재연결 시 REST로 채팅 목록을 다시 가져와 안 읽은 수와 마지막 메시지 미리보기를 갱신한다.
+
+<!-- IMAGE: 재연결 후 Gap recovery 흐름 — 로그 또는 디버그 화면 캡처 -->
+
+---
+
+## 7. SubscriptionManager — 토픽 생명주기 관리
+
+채팅방을 오갈 때 구독을 제대로 정리하지 않으면 메모리 누수가 생기고, 나간 방의 메시지가 계속 수신된다.
+
+```dart
+// lib/core/network/websocket/websocket_subscription_manager.dart
+class WebSocketSubscriptionManager {
+  final Map<String, StompUnsubscribe> _subscriptions = {};
+
+  void subscribe({
+    required StompClient client,
+    required String destination,
+    required void Function(StompFrame) callback,
+  }) {
+    // 이미 구독 중이면 스킵
+    if (_subscriptions.containsKey(destination)) return;
+
+    final unsubscribe = client.subscribe(
+      destination: destination,
+      callback: callback,
+    );
+    _subscriptions[destination] = unsubscribe;
+  }
+
+  void unsubscribe(String destination) {
+    final unsubscribe = _subscriptions.remove(destination);
+    unsubscribe?.call();
+  }
+
+  void unsubscribeAll() {
+    for (final unsubscribe in _subscriptions.values) {
+      unsubscribe();
+    }
+    _subscriptions.clear();
+  }
+
+  bool isSubscribed(String destination) => _subscriptions.containsKey(destination);
+}
+```
+
+채팅방에 입장하면 해당 방의 토픽을 구독하고, 나가면 `unsubscribe(destination)`으로 정리한다. 앱 전체 종료나 로그아웃 시에는 `unsubscribeAll()`로 다 정리한다.
+
+재연결 후에는 기존 구독이 모두 무효화된다. STOMP 세션이 새로 시작되기 때문이다. `ConnectionManager`가 CONNECTED 프레임을 받으면 `SubscriptionManager.unsubscribeAll()`을 호출하고, `SubscriptionManager`가 필요한 토픽들을 다시 구독한다. 이 재구독 목록은 어딘가에 저장해둬야 한다. Co-Talk에서는 `_activeRoomId`와 `_currentUserId`를 기억해두고 재연결 시 자동으로 재구독한다.
+
+---
+
+## 8. PayloadParser — 타입 안전한 디스패치
+
+STOMP 프레임의 body는 JSON 문자열이다. 이걸 파싱해서 올바른 타입으로 변환하는 책임이 `PayloadParser`에 있다. sealed class로 파싱 결과를 표현한다.
+
+```dart
+// lib/core/network/websocket/websocket_payload_parser.dart
+sealed class ParsedRoomPayload {}
+
+final class ParsedChatMessagePayload extends ParsedRoomPayload {
+  final WebSocketChatMessage message;
+  const ParsedChatMessagePayload(this.message);
+}
+
+final class ParsedReadPayload extends ParsedRoomPayload {
+  final WebSocketReadEvent event;
+  const ParsedReadPayload(this.event);
+}
+
+final class ParsedReactionPayload extends ParsedRoomPayload {
+  final WebSocketReactionEvent event;
+  const ParsedReactionPayload(this.event);
+}
+
+final class ParsedTypingPayload extends ParsedRoomPayload {
+  final WebSocketTypingEvent event;
+  const ParsedTypingPayload(this.event);
+}
+
+final class ParsedMessageDeletedPayload extends ParsedRoomPayload {
+  final WebSocketMessageDeletedEvent event;
+  const ParsedMessageDeletedPayload(this.event);
+}
+
+final class ParsedMessageUpdatedPayload extends ParsedRoomPayload {
+  final WebSocketMessageUpdatedEvent event;
+  const ParsedMessageUpdatedPayload(this.event);
+}
+
+final class ParsedUnknownPayload extends ParsedRoomPayload {
+  const ParsedUnknownPayload();
+}
+```
+
+`parseRoomPayload()`는 JSON의 `type` 필드를 읽어 적절한 sealed class 인스턴스를 반환한다. 호출부에서는 `switch`로 exhaustive 패턴 매칭을 하면 된다. 컴파일러가 모든 케이스를 처리했는지 검증해준다.
+
+`ParsedUnknownPayload`는 모르는 이벤트 타입에 대한 fallback이다. 서버 측에서 새 이벤트 타입을 추가했는데 클라이언트가 아직 모를 때, 조용히 무시하는 대신 타입 시스템으로 명시적으로 다룬다.
+
+---
+
+## 9. 교훈
+
+**1. Facade 패턴의 힘**: 800줄짜리 God Object를 4개 Manager로 분리하면 각각이 단일 책임을 갖게 된다. `ConnectionManager`는 연결만, `SubscriptionManager`는 구독만, `MessageSender`는 발행만, `PayloadParser`는 파싱만. 수정할 때 어느 파일을 열어야 할지 명확해진다.
+
+**2. Exponential Backoff + Jitter**: 재연결 시 지수 증가만으론 부족하다. 랜덤 지터가 없으면 클라이언트들이 동일한 간격으로 동시에 재연결을 시도해 서버에 주기적인 스파이크가 생긴다. `_random.nextInt(1000)` 한 줄이 그 문제를 해결한다.
+
+**3. Event Deduplication은 필수**: 재연결 후 중복 메시지가 반드시 온다. "설마 중복이 오겠어"하고 넘기면 반드시 사용자가 같은 메시지가 두 번 뜬다고 신고한다. TTL 기반 캐시로 미리 방어하는 게 맞다.
+
+**4. Optimistic UI가 체감 속도를 결정**: 서버 응답 대기 없이 즉시 표시하면 사용자는 "빠르다"고 느낀다. 실제 RTT가 200ms든 500ms든 사용자 입장에서는 "보낸 즉시 뜬다"는 경험을 하게 된다. pseudo-ID와 timeout 처리가 조금 복잡하지만 그 가치가 있다.
+
+**5. 재연결 전 토큰 갱신**: JWT를 STOMP 헤더로 보내는 구조라면, 재연결 전에 반드시 토큰 유효성을 확인해야 한다. `_needsTokenRefresh` 플래그와 `onTokenRefreshNeeded` 콜백으로 처리했다. 없으면 401 → 재연결 무한루프가 생긴다.
+
+**6. `_isIntentionalDisconnect` 플래그**: 로그아웃, 앱 종료, 방 퇴장 등 의도적인 연결 해제 시 재연결을 막는 플래그가 없으면 엉뚱한 타이밍에 재연결이 일어난다. 연결 해제 의도를 명시적으로 표현하는 플래그 하나가 버그를 여러 개 막는다.
+
+**7. sealed class로 파싱 결과 표현**: `dynamic`이나 `Map<String, dynamic>`을 들고 다니면 런타임 에러가 잠복한다. sealed class + switch 패턴 매칭으로 컴파일 타임에 모든 케이스를 강제로 처리하게 만들면 새 이벤트 타입이 추가돼도 빠짐없이 대응하게 된다.
+
+---
+
+다음 편에서는 Co-Talk Flutter 앱의 UX 기능 — 테마 시스템, 생체인증, 오프라인 캐시를 다룬다.
+
+[다음 편: Flutter UX — 테마, 생체인증, 오프라인 캐시](blog-16-flutter-ux-features.md)

--- a/docs/blog-16-flutter-ux-features.md
+++ b/docs/blog-16-flutter-ux-features.md
@@ -1,0 +1,661 @@
+# Flutter UX 깊이 파기 — 테마, 생체인증, 오프라인 캐시
+
+> "앱이 잠금 해제될 때마다 비밀번호를 치게 할 순 없잖아?"
+
+채팅 앱에서 사용자 경험을 결정짓는 요소는 생각보다 많다. 메시지 전송 속도나 알림 정확도처럼 눈에 띄는 기능만이 아니라, "앱이 어두운 방에서도 눈이 안 아프냐", "자리를 잠깐 비웠다 돌아왔을 때 매번 잠금을 풀어야 하냐", "인터넷이 끊겼을 때 이전 대화를 볼 수 있냐" 같은 것들이 실제 사용 만족도를 좌우한다.
+
+이번 편은 co-talk Flutter 앱에서 구현한 세 가지 UX 기능을 다룬다.
+
+1. **테마 시스템** — Light/Dark/System 전환 + TextScaler로 전역 폰트 크기 조절
+2. **생체인증 & 앱 잠금** — Grace Period와 Hybrid 동기/비동기 캐시
+3. **Drift(SQLite) 오프라인 캐시** — FTS5 전문 검색과 syncStatus 관리
+
+그리고 마지막에 이 과정에서 발견한 설정 상태 리셋 버그 — `copyWith`의 함정도 정리한다.
+
+시리즈 16편이다.
+
+---
+
+## 1. 테마 시스템 — Light/Dark/System + TextScaler
+
+### Material 3 기반 테마 정의
+
+Flutter 3.8부터 Material 3가 기본이다. `useMaterial3: true`를 명시하고, `ColorScheme`으로 색상 팔레트를 한 곳에서 관리한다.
+
+```dart
+// lib/core/theme/app_theme.dart
+class AppTheme {
+  static ThemeData get lightTheme {
+    return ThemeData(
+      useMaterial3: true,
+      brightness: Brightness.light,
+      primaryColor: AppColors.primary,
+      colorScheme: const ColorScheme.light(
+        primary: AppColors.primary,
+        secondary: AppColors.secondary,
+        surface: AppColors.surface,
+        error: AppColors.error,
+      ),
+      appBarTheme: const AppBarTheme(
+        backgroundColor: AppColors.primary,
+        foregroundColor: Colors.white,
+        elevation: 0,
+        centerTitle: true,
+      ),
+    );
+  }
+
+  static ThemeData get darkTheme {
+    return ThemeData(
+      useMaterial3: true,
+      brightness: Brightness.dark,
+      scaffoldBackgroundColor: AppColors.backgroundDark,
+      colorScheme: const ColorScheme.dark(
+        surface: AppColors.surfaceDark,
+      ),
+    );
+  }
+}
+```
+
+`AppColors`는 별도 파일로 분리해서 색상값을 한 곳에서 관리한다. 테마 파일에서 직접 `Color(0xFF...)` 를 쓰면 나중에 브랜드 컬러가 바뀔 때 여러 파일을 수정해야 한다.
+
+### ThemeCubit — 설정 저장 + 시스템 테마 판별
+
+```dart
+// lib/presentation/blocs/theme/theme_cubit.dart
+@lazySingleton
+class ThemeCubit extends Cubit<ThemeMode> {
+  final ThemeLocalDataSource _dataSource;
+  ThemeCubit(this._dataSource) : super(ThemeMode.system);
+
+  Future<void> loadTheme() async {
+    final savedMode = await _dataSource.getThemeMode();
+    emit(savedMode ?? ThemeMode.system);
+  }
+
+  Future<void> setTheme(ThemeMode mode) async {
+    await _dataSource.saveThemeMode(mode);
+    emit(mode);
+  }
+
+  bool isDarkMode(BuildContext context) {
+    if (state == ThemeMode.system) {
+      return MediaQuery.platformBrightnessOf(context) == Brightness.dark;
+    }
+    return state == ThemeMode.dark;
+  }
+}
+```
+
+`@lazySingleton`이 붙어 있어서 GetIt이 첫 번째 요청 시 인스턴스를 생성하고 이후로는 같은 인스턴스를 재사용한다. `loadTheme()`은 앱 시작 시 한 번만 호출하면 된다.
+
+`isDarkMode(context)`가 필요한 이유: `ThemeMode.system`일 때 현재 실제로 다크인지 라이트인지 알려면 OS 밝기를 확인해야 한다. `MediaQuery.platformBrightnessOf(context)`가 그 값을 준다.
+
+### TextScaler — 전역 폰트 크기 조절
+
+사용자가 설정에서 폰트 크기를 0.8~1.4 사이로 설정할 수 있게 했다. 이 값을 모든 위젯에 적용하는 방법은 `MaterialApp.router`의 `builder` 콜백에서 `MediaQuery`를 감싸는 것이다.
+
+```dart
+// lib/app.dart
+MaterialApp.router(
+  theme: AppTheme.lightTheme,
+  darkTheme: AppTheme.darkTheme,
+  themeMode: themeMode,
+  builder: (context, child) {
+    return MediaQuery(
+      data: MediaQuery.of(context).copyWith(
+        textScaler: TextScaler.linear(chatSettingsState.settings.fontSize),
+      ),
+      child: _AppLifecycleHandler(
+        child: Stack(
+          children: [
+            child ?? const SizedBox.shrink(),
+            BlocBuilder<AppLockCubit, AppLockState>(
+              builder: (context, lockState) {
+                if (lockState.status == AppLockStatus.unlocked) {
+                  return const SizedBox.shrink();
+                }
+                return const AppLockPage();
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  },
+),
+```
+
+`builder` 콜백에서 `MediaQuery`를 새로 만들어 씌우면 모든 하위 위젯이 덮어쓴 값을 읽는다. `Text`, `RichText`, `TextField` 등 폰트를 사용하는 모든 위젯에 자동으로 적용된다. 개별 위젯마다 스타일을 바꿀 필요가 없다.
+
+`Stack`의 구조를 보면 앱 본체(`child`)와 `AppLockPage`가 겹쳐 있다. 잠금 상태일 때 `AppLockPage`가 화면 전체를 덮는 방식이다. 이 구조에 대해서는 다음 섹션에서 자세히 다룬다.
+
+<!-- IMAGE: 테마 설정 화면 스크린샷 — Light/Dark/System 토글과 폰트 크기 슬라이더 -->
+
+---
+
+## 2. 생체인증 & 앱 잠금
+
+### 앱 잠금 생명주기
+
+앱 잠금은 두 가지 진입점이 있다: 앱 시작(`checkLockOnLaunch`)과 백그라운드에서 포그라운드 복귀(`checkLockOnResume`). 두 경우의 동작이 다르다.
+
+```plantuml
+@startuml
+!theme plain
+start
+:앱 시작 (main.dart);
+:checkLockOnLaunch();
+
+if (biometric 활성화?) then (yes)
+  :잠금 화면 표시;
+  :생체인증 시도;
+  if (성공?) then (yes)
+    :_lastAuthenticatedAt = now;
+    :잠금 해제;
+  else (no)
+    :잠금 유지\n수동 재시도 버튼;
+  endif
+else (no)
+  :바로 앱 진입;
+endif
+
+... 앱 사용 중 ...
+
+:앱 백그라운드 → 포그라운드;
+:checkLockOnResume();
+
+if (_cachedBiometricEnabled?) then (yes)
+  if (Grace Period 30초 이내?) then (yes)
+    :잠금 건너뜀;
+  else (no)
+    :즉시 잠금 (캐시 기반);
+    :생체인증 시도;
+  endif
+else (no)
+  :_refreshCache()\nSecureStorage 확인;
+endif
+stop
+@enduml
+```
+
+앱 시작 시에는 Grace Period가 없다. 재부팅 후 앱을 처음 여는 경우에는 반드시 인증해야 한다. 반면 포그라운드 복귀 시에는 30초 유예 기간을 준다. 사진 앱에서 사진을 고른 뒤 돌아올 때마다 지문을 찍어야 한다면 아무도 안 쓴다.
+
+### Hybrid 동기/비동기 캐시 전략
+
+```dart
+// lib/presentation/blocs/app/app_lock_cubit.dart
+@lazySingleton
+class AppLockCubit extends Cubit<AppLockState> {
+  bool _cachedBiometricEnabled = false;
+  bool _cacheLoaded = false;
+  DateTime? _lastAuthenticatedAt;
+  static const _authGracePeriod = Duration(seconds: 30);
+
+  Future<void> checkLockOnResume() async {
+    // 1단계: 동기 캐시로 즉시 판단
+    if (_cacheLoaded && _cachedBiometricEnabled) {
+      if (_isWithinGracePeriod()) return;
+      emit(const AppLockState.locked());
+      return;
+    }
+    // 2단계: 비동기 SecureStorage 확인 (fallback)
+    await _refreshCache();
+    if (!_cachedBiometricEnabled) return;
+    if (_isWithinGracePeriod()) return;
+    emit(const AppLockState.locked());
+  }
+
+  Future<void> checkLockOnLaunch() async {
+    await _refreshCache();
+    if (!_cachedBiometricEnabled) return;
+    emit(const AppLockState.locked());  // 앱 시작 시 grace period 없음
+  }
+
+  Future<void> authenticate() async {
+    emit(const AppLockState.authenticating());
+    final success = await _biometricService.authenticate();
+    if (success) {
+      _lastAuthenticatedAt = DateTime.now();
+      emit(const AppLockState.unlocked());
+    } else {
+      emit(const AppLockState.locked());
+    }
+  }
+
+  bool _isWithinGracePeriod() {
+    if (_lastAuthenticatedAt == null) return false;
+    return DateTime.now().difference(_lastAuthenticatedAt!) < _authGracePeriod;
+  }
+
+  Future<void> _refreshCache() async {
+    _cachedBiometricEnabled =
+        await _secureStorage.read(key: 'biometric_enabled') == 'true';
+    _cacheLoaded = true;
+  }
+
+  void updateBiometricEnabledCache(bool enabled) {
+    _cachedBiometricEnabled = enabled;
+    _cacheLoaded = true;
+  }
+}
+```
+
+왜 동기 캐시(`_cachedBiometricEnabled`)가 필요한지 설명하겠다.
+
+`WidgetsBindingObserver.didChangeAppLifecycleState`는 앱 생명주기 변화를 감지하는 콜백이다. 이 콜백에서 `SecureStorage`를 읽으면 문제가 생긴다. `SecureStorage`는 iOS Keychain, Android Keystore를 통해 데이터를 읽는 비동기 작업이다. `await`로 기다리는 동안 약 0.5초 정도 지연이 발생한다.
+
+이 0.5초가 보안 구멍이 된다. 포그라운드로 전환되고 나서 잠금 화면이 뜨기까지 반 박자 늦는 것이다. 그 사이에 화면이 잠깐 보인다.
+
+해결책이 Hybrid 전략이다. 메모리에 동기 캐시를 유지해서 즉시 잠금 여부를 판단하고, 비동기 `SecureStorage` 확인은 캐시가 없을 때만 fallback으로 사용한다. 설정 화면에서 생체인증을 켜거나 끌 때 `updateBiometricEnabledCache()`를 호출해서 캐시를 즉시 업데이트한다.
+
+### AppLockPage — 자동 생체인증 트리거
+
+```dart
+// lib/presentation/pages/app_lock/app_lock_page.dart
+class AppLockPage extends StatefulWidget {
+  const AppLockPage({super.key});
+
+  @override
+  State<AppLockPage> createState() => _AppLockPageState();
+}
+
+class _AppLockPageState extends State<AppLockPage> {
+  bool _autoAuthTriggered = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _tryAutoAuthenticate();
+    });
+  }
+
+  Future<void> _tryAutoAuthenticate() async {
+    if (_autoAuthTriggered) return;
+    _autoAuthTriggered = true;
+    await context.read<AppLockCubit>().authenticate();
+  }
+
+  void _onUnlockSuccess() {
+    _autoAuthTriggered = false; // 다음 잠금 시 다시 자동 시도
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<AppLockCubit, AppLockState>(
+      listener: (context, state) {
+        if (state.status == AppLockStatus.unlocked) {
+          _onUnlockSuccess();
+        }
+      },
+      child: Scaffold(
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(Icons.lock_outline, size: 64),
+              const SizedBox(height: 24),
+              const Text('앱이 잠겨 있습니다'),
+              const SizedBox(height: 32),
+              ElevatedButton.icon(
+                onPressed: _tryAutoAuthenticate,
+                icon: const Icon(Icons.fingerprint),
+                label: const Text('생체인증으로 잠금 해제'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+```
+
+`_autoAuthTriggered` 플래그가 핵심이다. 잠금 화면이 표시되면 `initState`에서 자동으로 생체인증을 시도한다. 실패했을 때 다시 `_tryAutoAuthenticate()`를 호출하면 `_autoAuthTriggered`가 이미 `true`라서 무시된다. 이렇게 무한 루프를 방지한다.
+
+잠금이 해제되면(`AppLockStatus.unlocked`) `_autoAuthTriggered`를 `false`로 리셋한다. 다음에 다시 잠길 때 자동 인증이 작동하도록.
+
+<!-- IMAGE: 앱 잠금 화면 스크린샷 — 지문 아이콘과 잠금 해제 버튼 -->
+
+---
+
+## 3. Drift 오프라인 캐시
+
+### 왜 Drift인가
+
+처음에는 `shared_preferences`로 메시지를 JSON 직렬화해서 저장했다. 방 하나에 메시지 수백 개가 생기면 JSON 파싱에만 수십 밀리초가 걸렸다. 인덱스가 없으니 특정 메시지를 찾으려면 전체를 순회해야 했다.
+
+Drift는 Flutter용 SQLite 래퍼다. 타입 안전한 Dart API를 제공하고, 컴파일 타임에 SQL을 검증한다. 그리고 FTS5(Full-Text Search 5) 확장으로 전문 검색을 지원한다.
+
+### 테이블 정의
+
+```dart
+// lib/data/datasources/local/database/tables.dart
+class Messages extends Table {
+  IntColumn get id => integer()();
+  IntColumn get chatRoomId => integer()();
+  IntColumn get senderId => integer()();
+  TextColumn get senderNickname => text().nullable()();
+  TextColumn get content => text()();
+  TextColumn get type => text().withDefault(const Constant('TEXT'))();
+  TextColumn get fileUrl => text().nullable()();
+  IntColumn get replyToMessageId => integer().nullable()();
+  BoolColumn get isDeleted => boolean().withDefault(const Constant(false))();
+  IntColumn get createdAt => integer()();  // Unix ms
+  TextColumn get syncStatus =>
+      text().withDefault(const Constant('synced'))();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+class ChatRooms extends Table {
+  IntColumn get id => integer()();
+  TextColumn get type => text().withDefault(const Constant('DIRECT'))();
+  TextColumn get lastMessage => text().nullable()();
+  IntColumn get unreadCount => integer().withDefault(const Constant(0))();
+  IntColumn get otherUserId => integer().nullable()();
+  BoolColumn get isOtherUserOnline =>
+      boolean().withDefault(const Constant(false))();
+  IntColumn get lastSyncAt => integer().nullable()();
+}
+
+class MessageReactions extends Table {
+  IntColumn get messageId => integer()();
+  IntColumn get userId => integer()();
+  TextColumn get emoji => text()();
+}
+```
+
+`syncStatus` 컬럼이 오프라인 지원의 핵심이다. `synced`, `pending`, `failed` 세 값을 갖는다.
+
+- `synced`: 서버와 동기화 완료
+- `pending`: 오프라인 중 전송 대기
+- `failed`: 전송 시도했지만 실패
+
+앱이 온라인으로 전환될 때 `syncStatus = 'pending'`인 메시지를 찾아 재전송한다.
+
+### 데이터베이스 초기화와 백그라운드 Isolate
+
+```dart
+// lib/data/datasources/local/database/app_database.dart
+@DriftDatabase(tables: [Messages, ChatRooms, MessageReactions])
+class AppDatabase extends _$AppDatabase {
+  AppDatabase() : super(_openConnection());
+
+  @override
+  int get schemaVersion => 3;
+
+  @override
+  MigrationStrategy get migration {
+    return MigrationStrategy(
+      onCreate: (Migrator m) async {
+        await m.createAll();
+        await _createFtsTable(m);
+      },
+      onUpgrade: (Migrator m, int from, int to) async {
+        if (from < 2) {
+          await m.addColumn(messages, messages.syncStatus);
+        }
+        if (from < 3) {
+          await _createFtsTable(m);
+        }
+      },
+    );
+  }
+}
+
+QueryExecutor _openConnection() {
+  return NativeDatabase.createInBackground(
+    File(path.join(documentsDirectory, 'co_talk.db')),
+    logStatements: kDebugMode,
+  );
+}
+```
+
+`NativeDatabase.createInBackground`가 중요하다. SQLite 작업을 별도 Isolate에서 실행해서 UI 스레드를 블로킹하지 않는다. 메시지 수천 개를 한 번에 INSERT하더라도 앱이 멈추지 않는다.
+
+### FTS5 전문 검색
+
+```dart
+// lib/data/datasources/local/database/app_database.dart
+Future<void> _createFtsTable(Migrator m) async {
+  await customStatement('''
+    CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+      content, file_name,
+      content='messages', content_rowid='id'
+    )
+  ''');
+
+  await customStatement('''
+    CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
+      INSERT INTO messages_fts(rowid, content, file_name)
+      VALUES (NEW.id, NEW.content, NEW.file_name);
+    END
+  ''');
+
+  await customStatement('''
+    CREATE TRIGGER IF NOT EXISTS messages_ad AFTER DELETE ON messages BEGIN
+      INSERT INTO messages_fts(messages_fts, rowid, content, file_name)
+      VALUES ('delete', OLD.id, OLD.content, OLD.file_name);
+    END
+  ''');
+
+  await customStatement('''
+    CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
+      INSERT INTO messages_fts(messages_fts, rowid, content, file_name)
+      VALUES ('delete', OLD.id, OLD.content, OLD.file_name);
+      INSERT INTO messages_fts(rowid, content, file_name)
+      VALUES (NEW.id, NEW.content, NEW.file_name);
+    END
+  ''');
+}
+```
+
+FTS5 Virtual Table은 일반 테이블과 연결(`content='messages'`)되어 있다. INSERT/DELETE/UPDATE 트리거 세 개가 `messages` 테이블 변경 시 자동으로 FTS 인덱스를 동기화한다. 이후 DAO에서는 검색할 때만 FTS 테이블을 조인하면 된다.
+
+### 검색 쿼리
+
+```dart
+// lib/data/datasources/local/database/daos/message_dao.dart
+Future<List<Message>> searchMessages(String query, {int? chatRoomId}) async {
+  final escaped = query.replaceAll('"', '""');
+  String sql = '''
+    SELECT m.* FROM messages m
+    INNER JOIN messages_fts ON m.id = messages_fts.rowid
+    WHERE messages_fts MATCH ?
+  ''';
+  final variables = <Variable>[Variable.withString('"$escaped"*')];
+
+  if (chatRoomId != null) {
+    sql += ' AND m.chat_room_id = ?';
+    variables.add(Variable.withInt(chatRoomId));
+  }
+
+  sql += ' AND m.is_deleted = 0 ORDER BY m.created_at DESC LIMIT 50';
+
+  final rows = await customSelect(sql, variables: variables).get();
+  return rows.map((row) => Message.fromData(row.data)).toList();
+}
+```
+
+`"$escaped"*`가 prefix wildcard 검색이다. `"안녕"*`으로 검색하면 "안녕하세요", "안녕하십니까"가 모두 매칭된다. 쌍따옴표 안의 공백은 구문(phrase) 검색이 되므로, 사용자 입력에서 쌍따옴표를 이스케이프(`"` → `""`)해야 한다.
+
+### 로컬-리모트 동기화 전략
+
+```dart
+// lib/data/repositories/chat_message_repository_impl.dart
+@override
+Stream<List<ChatMessage>> watchMessages(int chatRoomId) async* {
+  // 1. 로컬 DB에서 즉시 데이터 반환
+  yield await _localDataSource.getMessages(chatRoomId);
+
+  // 2. 백그라운드에서 서버 동기화
+  _syncFromServer(chatRoomId).ignore();
+
+  // 3. 이후로는 로컬 DB 변경 스트림을 구독
+  yield* _localDataSource.watchMessages(chatRoomId);
+}
+
+Future<void> _syncFromServer(int chatRoomId) async {
+  try {
+    final lastSyncAt = await _localDataSource.getLastSyncAt(chatRoomId);
+    final remoteMessages = await _remoteDataSource.getMessages(
+      chatRoomId,
+      after: lastSyncAt,
+    );
+    await _localDataSource.upsertMessages(remoteMessages);
+    await _localDataSource.updateLastSyncAt(chatRoomId, DateTime.now());
+  } catch (e) {
+    // 네트워크 오류는 무시 — 로컬 캐시로 계속 서비스
+  }
+}
+```
+
+이 패턴이 "stale-while-revalidate"다. 로컬 데이터를 즉시 보여주고, 백그라운드에서 서버와 동기화한 뒤 차이가 있으면 UI가 자동으로 업데이트된다. Drift의 `watchMessages()`는 `Stream`을 반환해서 DB 변경이 생기면 자동으로 새 데이터를 방출한다.
+
+<!-- IMAGE: 오프라인 상태에서 채팅방 접속 — 로컬 캐시로 이전 메시지 표시되는 스크린샷 -->
+
+---
+
+## 4. 설정 상태 리셋 버그 — copyWith의 함정
+
+### 버그 발견
+
+어느 날 다크 모드를 켜고 채팅 설정으로 들어갔더니 폰트 크기가 기본값으로 초기화되어 있었다. 설정을 바꾼 적도 없는데.
+
+코드를 추적하니 `ChatSettingsCubit`의 named constructor가 문제였다.
+
+```dart
+// 문제 있는 코드
+class ChatSettingsState {
+  final ChatSettings settings;
+  final ChatSettingsStatus status;
+
+  const ChatSettingsState({
+    required this.settings,
+    required this.status,
+  });
+
+  // 이 생성자가 문제
+  const ChatSettingsState.loading() : this(
+    settings: ChatSettings.defaults(),  // 기본값으로 리셋!
+    status: ChatSettingsStatus.loading,
+  );
+}
+
+// Cubit에서
+Future<void> saveSettings(ChatSettings newSettings) async {
+  emit(ChatSettingsState.loading());  // settings가 기본값으로 리셋됨
+  await _repository.save(newSettings);
+  emit(ChatSettingsState.loaded(newSettings));
+}
+```
+
+`ChatSettingsState.loading()`이 `this()`로 생성자를 위임할 때 `settings: ChatSettings.defaults()`를 명시했다. 즉 로딩 상태로 전환하는 순간 현재 설정이 기본값으로 날아간다.
+
+저장 완료 전에 에러가 나거나, 로딩 상태가 UI에 잠깐이라도 반영되면 사용자는 설정이 초기화된 것을 본다.
+
+### 해결: copyWith 사용
+
+```dart
+// lib/presentation/blocs/settings/chat_settings_cubit.dart
+Future<void> saveSettings(ChatSettings newSettings) async {
+  // 기존 settings를 유지하면서 status만 변경
+  emit(state.copyWith(status: ChatSettingsStatus.loading));
+
+  try {
+    await _repository.save(newSettings);
+    emit(state.copyWith(
+      settings: newSettings,
+      status: ChatSettingsStatus.loaded,
+    ));
+  } catch (e) {
+    emit(state.copyWith(status: ChatSettingsStatus.error));
+  }
+}
+```
+
+`state.copyWith(status: newStatus)`는 현재 상태의 모든 필드를 복사하고 지정한 필드만 바꾼다. `settings`는 건드리지 않으니 기존 값이 유지된다.
+
+`@lazySingleton` Cubit에서 `loadSettings()`는 초기 상태일 때만 호출해야 한다는 것도 배웠다. 싱글턴이라 앱 생명주기 동안 같은 인스턴스가 유지되는데, 화면에 들어올 때마다 `loadSettings()`를 부르면 이미 설정을 불러온 상태에서 다시 로딩 상태로 전환된다.
+
+```dart
+@override
+void initState() {
+  super.initState();
+  final cubit = context.read<ChatSettingsCubit>();
+  // 초기 상태일 때만 로드 (싱글턴 중복 로드 방지)
+  if (cubit.state.status == ChatSettingsStatus.initial) {
+    cubit.loadSettings();
+  }
+}
+```
+
+### NotificationSettingsCubit — Optimistic Update
+
+알림 설정에서는 한 발 더 나아가 낙관적 업데이트(Optimistic Update)를 적용했다.
+
+```dart
+// lib/presentation/blocs/settings/notification_settings_cubit.dart
+Future<void> _updateSetting(NotificationSettings newSettings) async {
+  final previousSettings = state.settings;
+
+  // UI 즉시 업데이트 (낙관적)
+  emit(state.copyWith(settings: newSettings));
+
+  try {
+    await _repository.updateNotificationSettings(newSettings);
+  } catch (e) {
+    // 실패 시 이전 설정으로 롤백
+    emit(state.copyWith(
+      status: NotificationSettingsStatus.error,
+      settings: previousSettings,
+    ));
+  }
+}
+```
+
+토글을 누르면 서버 응답을 기다리지 않고 즉시 UI가 반응한다. 서버 저장이 실패하면 이전 설정으로 되돌린다. 설정 화면에서 이 정도 latency 최적화가 필요한가 싶겠지만, 네트워크가 느린 환경에서 토글이 0.5초 후에 반응한다면 "내가 제대로 누른 건지" 확신이 안 선다.
+
+---
+
+## 5. 교훈
+
+이번에 세 기능을 구현하면서 얻은 것들을 정리한다.
+
+**1. TextScaler는 builder에서 덮어써라**
+
+`MaterialApp.router`의 `builder` 콜백에서 `MediaQuery`를 감싸면 모든 하위 위젯에 사용자 폰트 크기가 적용된다. 개별 위젯마다 `fontSize`를 주입할 필요가 없다. 전역 설정은 전역적으로 적용하는 것이 맞다.
+
+**2. 앱 잠금은 동기 캐시가 핵심**
+
+`SecureStorage`는 비동기라 `didChangeAppLifecycleState`에서 바로 쓸 수 없다. `await`로 기다리는 0.5초 동안 잠금 화면이 늦게 뜨는 보안 구멍이 생긴다. 동기 메모리 캐시(`_cachedBiometricEnabled`)로 즉시 잠금하고, 비동기 `SecureStorage` 확인은 캐시가 없을 때만 fallback으로 사용하라.
+
+**3. Grace Period가 UX를 결정한다**
+
+사진 앱에서 파일을 고르고 돌아올 때, 카메라를 켰다 끄고 돌아올 때마다 생체인증을 요구하면 사용자가 떠난다. 30초 유예 기간이 보안과 편의성 사이의 현실적인 타협점이다. 카카오톡도 이 패턴을 쓴다.
+
+**4. FTS5 트리거는 설정하면 잊어도 된다**
+
+INSERT/DELETE/UPDATE 트리거로 검색 인덱스를 자동 동기화하면 DAO에서 별도로 FTS 테이블을 관리할 필요가 없다. 트리거 세 개가 데이터 일관성을 보장한다. 검색할 때만 FTS 테이블을 조인하면 끝이다.
+
+**5. named constructor의 `this()` 위임을 의심하라**
+
+Dart의 생성자 위임(`this()`)은 명시하지 않은 필드를 기본값으로 리셋한다. 상태 전환 시(`loading`, `saving` 등) 반드시 `state.copyWith()`를 사용해서 기존 필드를 보존하라. 특히 `@lazySingleton` Cubit에서 이 버그는 재현이 어렵다. 화면에 처음 들어갈 때는 괜찮고 두 번째 이후 동작에서만 문제가 나타나기 때문이다.
+
+**6. Drift의 `NativeDatabase.createInBackground`는 필수**
+
+메인 스레드에서 SQLite를 돌리면 대용량 INSERT 시 UI가 버벅인다. `createInBackground`로 별도 Isolate에서 실행하는 것이 기본값이어야 한다.
+
+**7. 오프라인 캐시의 stale-while-revalidate 패턴**
+
+로컬 데이터를 즉시 보여주고, 백그라운드에서 서버와 동기화한다. 차이가 생기면 Drift의 `watch()` 스트림이 자동으로 UI를 업데이트한다. 사용자는 네트워크 상태에 상관없이 앱을 쓸 수 있다.
+
+---
+
+다음 편에서는 Fastlane으로 iOS, macOS, Android 세 플랫폼을 한 번에 배포하는 과정을 다룬다.
+
+[다음 편: Fastlane으로 iOS·macOS·Android 한 번에 배포하기](blog-17-fastlane-multiplatform.md)

--- a/docs/blog-17-fastlane-multiplatform.md
+++ b/docs/blog-17-fastlane-multiplatform.md
@@ -1,0 +1,638 @@
+# Fastlane으로 iOS·macOS·Android 한 번에 배포하기 — Co-Talk 멀티플랫폼 자동화
+
+> "flutter build ios, flutter build macos, flutter build appbundle… 이걸 매번 수동으로?"
+
+Flutter 앱을 iOS, macOS, Android 세 플랫폼에 동시에 배포해야 할 때, 수동 빌드는 금방 한계에 부딪힌다. 각 플랫폼마다 빌드 명령이 다르고, 코드 서명 방식이 다르고, 업로드 도구도 다르다. Co-Talk 프로젝트를 운영하면서 이 세 가지를 하나의 Fastfile로 통합한 경험을 정리했다. 특히 macOS 코드 서명은 iOS보다 훨씬 복잡해서 별도 섹션으로 다뤘다. 시리즈 17편이다.
+
+---
+
+## 1. 통합 Fastfile 설계
+
+세 플랫폼을 하나의 Fastfile로 관리하는 핵심 아이디어는 레인(lane) 계층화다. 최상위 레인이 하위 레인을 호출하는 구조로, 각 플랫폼별 레인은 독립적으로도 실행 가능하고, 통합 레인에서도 호출된다.
+
+<!-- IMAGE: Fastlane 레인 계층 구조 다이어그램 -->
+
+```plantuml
+@startuml
+!theme plain
+top to bottom direction
+
+rectangle "deploy_all_platforms" as DAP #FFccFF {
+}
+
+rectangle "deploy_all\n(iOS + macOS)" as DA {
+  rectangle "bump_build" as BB
+  rectangle "deploy_ios" as DI
+  rectangle "deploy_macos" as DM
+}
+
+rectangle "deploy_android" as DAN
+
+DAP --> DA
+DAP --> DAN
+
+DI --> "build_ios\n(flutter build ipa)" as BI
+DI --> "upload_ios\n(upload_to_testflight)" as UI
+
+DM --> "setup_macos_signing\n(cert + sigh)" as SMS
+DM --> "build_macos_signed\n(flutter build + resign)" as BMS
+DM --> "upload_macos\n(productbuild + testflight)" as UM
+
+DAN --> "build_android\n(flutter build appbundle)" as BA
+DAN --> "upload_android\n(upload_to_play_store)" as UA
+@enduml
+```
+
+실제 Fastfile의 상위 레인 구조는 다음과 같다.
+
+```ruby
+# fastlane/Fastfile
+default_platform(:ios)
+
+desc "iOS + macOS + Android 모두 배포"
+lane :deploy_all_platforms do |options|
+  deploy_all(skip_bump: options[:skip_bump])
+
+  UI.header("Android 빌드 시작")
+  deploy_android(track: options[:track] || "internal")
+
+  UI.success("모든 플랫폼 배포 완료!")
+end
+
+desc "iOS와 macOS 모두 빌드 및 TestFlight 업로드"
+lane :deploy_all do |options|
+  bump_build unless options[:skip_bump]
+
+  UI.header("iOS 빌드 시작")
+  deploy_ios(skip_build: options[:skip_build], skip_bump: true)
+
+  UI.header("macOS 빌드 시작")
+  deploy_macos(skip_build: options[:skip_build], skip_bump: true)
+
+  UI.success("iOS + macOS 배포 완료!")
+end
+```
+
+`bump_build`가 한 번만 실행되고 iOS/macOS에 동일한 빌드 넘버가 적용되는 구조다. `skip_bump: true`를 하위 레인에 전달해서 빌드 넘버가 이중으로 증가하는 것을 막는다.
+
+레인 구조를 이렇게 설계한 이유는 유연성 때문이다. iOS만 배포하고 싶으면 `fastlane deploy_ios`, Android만 배포하고 싶으면 `fastlane deploy_android`로 독립 실행이 가능하다. 전체 배포가 필요하면 `fastlane deploy_all_platforms`를 쓰면 된다.
+
+---
+
+## 2. App Store Connect API Key 인증
+
+예전에는 Apple ID와 비밀번호로 fastlane이 App Store Connect에 로그인했다. 2FA가 도입되면서 이 방식이 CI 환경에서 불안정해졌다. 지금은 API Key 방식이 표준이다.
+
+이유는 명확하다.
+
+- 2FA 우회 로직 불필요 (2FA 팝업을 자동화하는 코드는 언제 깨질지 모른다)
+- CI 서버에서도 안정적으로 동작
+- 토큰 유효기간 20분, Fastlane이 자동 갱신
+- 팀 멤버가 바뀌어도 인증 정보 교체 불필요
+
+```ruby
+# fastlane/Fastfile
+def get_api_key
+  app_store_connect_api_key(
+    key_id: ENV["APP_STORE_CONNECT_API_KEY_KEY_ID"],
+    issuer_id: ENV["APP_STORE_CONNECT_API_KEY_ISSUER_ID"],
+    key_filepath: ENV["APP_STORE_CONNECT_API_KEY_KEY_FILEPATH"],
+    duration: 1200,  # 20분
+    in_house: false
+  )
+end
+```
+
+`.env.example` 파일에 필요한 환경변수를 문서화해 두었다.
+
+```bash
+# fastlane/.env.example
+APPLE_ID=your-apple-id@example.com
+TEAM_ID=YOUR_TEAM_ID
+ITC_TEAM_ID=YOUR_ITC_TEAM_ID
+APP_STORE_CONNECT_API_KEY_KEY_ID=YOUR_KEY_ID
+APP_STORE_CONNECT_API_KEY_ISSUER_ID=YOUR_ISSUER_ID
+APP_STORE_CONNECT_API_KEY_KEY_FILEPATH=./fastlane/keys/AuthKey_YOUR_KEY_ID.p8
+```
+
+`.p8` 파일은 App Store Connect에서 한 번만 다운로드할 수 있다. 분실하면 재발급이 필요하다. `fastlane/keys/` 디렉토리에 보관하되, `.gitignore`에 반드시 추가해야 한다. 이 파일이 Git에 올라가는 순간 즉시 폐기하고 재발급해야 한다.
+
+API Key 발급 경로: App Store Connect → 사용자 및 액세스 → 통합 → App Store Connect API → 팀 키 생성. 역할은 최소한으로 설정한다. 배포 자동화에는 "앱 관리자" 역할이면 충분하다.
+
+---
+
+## 3. iOS 빌드 & 배포
+
+iOS 배포는 세 플랫폼 중 가장 간단하다. Flutter가 대부분의 코드 서명 작업을 자동으로 처리한다.
+
+```ruby
+# fastlane/Fastfile
+desc "iOS 빌드만"
+lane :build_ios do
+  UI.message("Flutter iOS 빌드 중...")
+  project_root = File.expand_path("..", Dir.pwd)
+
+  cocoapods(
+    podfile: "#{project_root}/ios/Podfile",
+    use_bundle_exec: false
+  )
+
+  system(
+    "cd #{project_root} && flutter build ipa --release --dart-define=ENVIRONMENT=prod"
+  ) || UI.user_error!("Flutter iOS 빌드 실패")
+
+  UI.success("iOS 빌드 완료")
+end
+
+desc "iOS TestFlight 업로드"
+lane :upload_ios do
+  project_root = File.expand_path("..", Dir.pwd)
+  ipa_path = Dir["#{project_root}/build/ios/ipa/*.ipa"].first
+
+  if ipa_path.nil?
+    UI.user_error!("IPA 파일을 찾을 수 없습니다.")
+  end
+
+  api_key = get_api_key
+  upload_to_testflight(
+    api_key: api_key,
+    ipa: ipa_path,
+    skip_waiting_for_build_processing: true,
+    skip_submission: true
+  )
+end
+
+desc "iOS 빌드 + TestFlight 업로드"
+lane :deploy_ios do |options|
+  build_ios unless options[:skip_build]
+  upload_ios
+end
+```
+
+`flutter build ipa`가 ExportOptions.plist를 자동 생성한다. Xcode에서 수동으로 Archive → Distribute를 하는 것과 동일한 결과물이 나온다. `--dart-define=ENVIRONMENT=prod`로 빌드 타임에 환경을 구분한다. Flutter 코드에서 `const String env = String.fromEnvironment('ENVIRONMENT', defaultValue: 'dev')`로 읽을 수 있다.
+
+`skip_waiting_for_build_processing: true`는 TestFlight 업로드 후 Apple 서버의 처리를 기다리지 않는다는 의미다. 처리 시간이 10~30분인데, CI에서 이걸 기다리면 자원 낭비다. 처리 완료 알림은 이메일로 받는다.
+
+---
+
+## 4. macOS 코드 서명 심화 — 가장 까다로운 부분
+
+솔직히 말하면 macOS 배포 자동화가 이 프로젝트에서 가장 오래 걸린 부분이다. 이틀 넘게 `codesign` 오류와 씨름했다.
+
+왜 macOS가 iOS보다 복잡한가:
+
+- `flutter build macos`는 ad-hoc 서명을 생성한다. App Store 제출이 불가능한 서명이다.
+- Apple Distribution 인증서로 수동 재서명이 필요하다.
+- 앱 번들 내부의 프레임워크까지 안에서 밖으로 순서대로 서명해야 한다. 순서가 틀리면 검증이 실패한다.
+- `.pkg` 파일로 패키징 후 업로드해야 한다. iOS처럼 `.ipa`가 아니다.
+
+<!-- IMAGE: macOS 코드 서명 순서 — 프레임워크 내부부터 앱 번들까지 -->
+
+**cert + sigh 설정**
+
+두 종류의 인증서가 필요하다. 앱 자체를 서명하는 Apple Distribution 인증서와, `.pkg`를 서명하는 Mac Installer Distribution 인증서다.
+
+```ruby
+# fastlane/Fastfile
+lane :setup_macos_signing do
+  api_key = get_api_key
+
+  # 1. Apple Distribution 인증서 (앱 서명용)
+  cert(
+    platform: "macos",
+    team_id: ENV["TEAM_ID"] || "{yourTeamId}",
+    api_key: api_key,
+    generate_apple_certs: true
+  )
+
+  app_cert_id = lane_context[SharedValues::CERT_CERTIFICATE_ID]
+
+  # 2. Mac Installer Distribution 인증서 (pkg 서명용)
+  cert(
+    platform: "macos",
+    type: "mac_installer_distribution",
+    team_id: ENV["TEAM_ID"] || "{yourTeamId}",
+    api_key: api_key,
+    generate_apple_certs: true
+  )
+
+  # 3. App Store 프로비저닝 프로필
+  sigh(
+    platform: "macos",
+    app_identifier: "com.cotalk.coTalkFlutter",
+    team_id: ENV["TEAM_ID"] || "{yourTeamId}",
+    api_key: api_key,
+    cert_id: app_cert_id,
+    force: true
+  )
+end
+```
+
+`cert` 액션이 키체인에 인증서를 설치하고, `sigh`가 프로비저닝 프로필을 다운로드한다. CI 환경에서는 임시 키체인을 만들어 사용하는 것이 안전하다. 로컬 개발자 키체인을 건드리지 않기 위해서다.
+
+**재서명 스크립트**
+
+이 스크립트가 핵심이다. Flutter가 생성한 ad-hoc 서명을 Apple Distribution 서명으로 교체한다.
+
+```bash
+#!/bin/bash
+# scripts/resign_for_appstore.sh
+set -e
+
+APP_PATH="$1"
+ENTITLEMENTS="$2"
+PROFILE_PATH="$3"
+SIGN_IDENTITY="Apple Distribution: {YourName} ({yourTeamId})"
+
+echo "재서명 대상: $APP_PATH"
+echo "서명 ID: $SIGN_IDENTITY"
+
+# 1. 프로비저닝 프로필 복사
+cp "$PROFILE_PATH" "$APP_PATH/Contents/embedded.provisionprofile"
+echo "프로비저닝 프로필 복사 완료"
+
+# 2. 프레임워크 내부 실행파일 서명 (가장 깊은 곳부터)
+FRAMEWORKS_PATH="$APP_PATH/Contents/Frameworks"
+for framework in "$FRAMEWORKS_PATH"/*.framework; do
+  if [ -d "$framework" ]; then
+    framework_name=$(basename "$framework" .framework)
+    executable="$framework/Versions/A/$framework_name"
+    if [ -f "$executable" ]; then
+      echo "프레임워크 실행파일 서명: $framework_name"
+      codesign --force --timestamp --options runtime \
+        --sign "$SIGN_IDENTITY" "$executable"
+    fi
+  fi
+done
+
+# 3. 프레임워크 번들 전체 서명
+for framework in "$FRAMEWORKS_PATH"/*.framework; do
+  if [ -d "$framework" ]; then
+    framework_name=$(basename "$framework" .framework)
+    echo "프레임워크 번들 서명: $framework_name"
+    codesign --force --timestamp --options runtime \
+      --sign "$SIGN_IDENTITY" "$framework"
+  fi
+done
+
+# 4. 메인 실행파일 서명 (entitlements 포함)
+echo "메인 실행파일 서명..."
+codesign --force --timestamp --options runtime \
+  --entitlements "$ENTITLEMENTS" \
+  --sign "$SIGN_IDENTITY" "$APP_PATH/Contents/MacOS/Co Talk"
+
+# 5. 앱 번들 전체 서명
+echo "앱 번들 전체 서명..."
+codesign --force --timestamp --options runtime \
+  --entitlements "$ENTITLEMENTS" \
+  --sign "$SIGN_IDENTITY" "$APP_PATH"
+
+# 6. 검증
+echo "서명 검증 중..."
+codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+echo "서명 검증 완료"
+```
+
+서명 순서가 왜 중요한지 설명하면:
+
+- `codesign --verify --deep`은 앱 번들 내부 모든 서명을 재귀적으로 검증한다.
+- 바깥 번들을 먼저 서명하면, 나중에 내부를 서명할 때 바깥 번들의 서명이 깨진다. macOS는 번들 내용이 바뀌면 서명을 무효로 본다.
+- 따라서 반드시 가장 안쪽(프레임워크 내부 실행파일)부터 서명하고 바깥으로 나와야 한다.
+
+각 플래그의 의미:
+
+- `--options runtime`: Hardened Runtime 활성화. App Store 제출 필수 조건이다.
+- `--timestamp`: Apple 타임스탬프 서버를 통해 서명 시각을 인증한다. 공증(Notarization)에 필요하다.
+- `--entitlements`: 앱이 사용하는 권한을 선언한다. 네트워크 접근, 샌드박스 등.
+- `--force`: 기존 서명을 덮어쓴다.
+
+**Entitlements 파일**
+
+macOS 앱에 필요한 권한을 선언한다.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- macos/Runner/Release.entitlements -->
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.app-sandbox</key>
+  <true/>
+  <key>com.apple.security.network.client</key>
+  <true/>
+  <key>com.apple.security.network.server</key>
+  <true/>
+  <key>com.apple.security.files.user-selected.read-write</key>
+  <true/>
+</dict>
+</plist>
+```
+
+**Fastfile에서 재서명 스크립트 호출**
+
+```ruby
+# fastlane/Fastfile
+lane :build_macos_signed do
+  project_root = File.expand_path("..", Dir.pwd)
+
+  # Flutter 빌드 (ad-hoc 서명)
+  system(
+    "cd #{project_root} && flutter build macos --release --dart-define=ENVIRONMENT=prod"
+  ) || UI.user_error!("Flutter macOS 빌드 실패")
+
+  app_path = "#{project_root}/build/macos/Build/Products/Release/Co Talk.app"
+  entitlements = "#{project_root}/macos/Runner/Release.entitlements"
+  profile_path = Dir[
+    "#{ENV['HOME']}/Library/MobileDevice/Provisioning Profiles/*.provisionprofile"
+  ].first
+
+  if profile_path.nil?
+    UI.user_error!("프로비저닝 프로필을 찾을 수 없습니다. setup_macos_signing을 먼저 실행하세요.")
+  end
+
+  resign_script = "#{project_root}/scripts/resign_for_appstore.sh"
+  sh("bash '#{resign_script}' '#{app_path}' '#{entitlements}' '#{profile_path}'")
+
+  UI.success("macOS 재서명 완료")
+end
+```
+
+**macOS 업로드**
+
+```ruby
+# fastlane/Fastfile
+lane :upload_macos do
+  project_root = File.expand_path("..", Dir.pwd)
+  app_path = "#{project_root}/build/macos/Build/Products/Release/Co Talk.app"
+  pkg_path = "#{project_root}/build/macos/CoTalk.pkg"
+
+  # .app → .pkg 변환 및 Installer 인증서로 서명
+  sh(
+    "productbuild --component '#{app_path}' /Applications " \
+    "--sign '3rd Party Mac Developer Installer: {yourName}({yourTeamId})' " \
+    "'#{pkg_path}'"
+  )
+
+  api_key = get_api_key
+  upload_to_testflight(
+    api_key: api_key,
+    pkg: pkg_path,
+    skip_waiting_for_build_processing: true,
+    skip_submission: true,
+    app_platform: "osx"
+  )
+
+  UI.success("macOS TestFlight 업로드 완료")
+end
+
+desc "macOS 전체 배포"
+lane :deploy_macos do |options|
+  setup_macos_signing
+  build_macos_signed unless options[:skip_build]
+  upload_macos
+end
+```
+
+macOS는 IPA가 아니라 `.pkg`로 업로드한다. `productbuild`가 `.app`을 `.pkg`로 패키징한다. 여기서 "3rd Party Mac Developer Installer" 인증서가 사용된다. App Distribution 인증서와 다른 인증서다. 두 인증서 모두 `setup_macos_signing`에서 준비된다.
+
+---
+
+## 5. Android — Google Play 업로드
+
+Android는 상대적으로 단순하다. Flutter 빌드가 코드 서명까지 처리하고, Fastlane이 Google Play에 업로드한다.
+
+```ruby
+# fastlane/Fastfile
+desc "Android 빌드만"
+lane :build_android do
+  project_root = File.expand_path("..", Dir.pwd)
+  system(
+    "cd #{project_root} && flutter build appbundle --release --dart-define=ENVIRONMENT=prod"
+  ) || UI.user_error!("Flutter Android 빌드 실패")
+
+  UI.success("Android 빌드 완료")
+end
+
+desc "Google Play 업로드"
+lane :upload_android do |options|
+  project_root = File.expand_path("..", Dir.pwd)
+  aab_path = "#{project_root}/build/app/outputs/bundle/release/app-release.aab"
+  track = options[:track] || "internal"
+
+  unless File.exist?(aab_path)
+    UI.user_error!("AAB 파일을 찾을 수 없습니다: #{aab_path}")
+  end
+
+  upload_to_play_store(
+    package_name: "com.cotalk.co_talk_flutter",
+    aab: aab_path,
+    track: track,
+    release_status: "draft",
+    json_key: "#{Dir.pwd}/keys/play-store-key.json",
+    skip_upload_metadata: true,
+    skip_upload_images: true,
+    skip_upload_screenshots: true
+  )
+
+  UI.success("Android #{track} 트랙 업로드 완료")
+end
+
+desc "Android 빌드 + Play Store 업로드"
+lane :deploy_android do |options|
+  build_android
+  upload_android(track: options[:track] || "internal")
+end
+```
+
+몇 가지 중요한 결정들이다.
+
+**`release_status: "draft"`**: 업로드만 하고 실제 출시는 하지 않는다. Google Play Console에서 수동으로 출시 버튼을 누르는 방식이다. 자동화 실수로 프로덕션에 잘못된 빌드가 배포되는 사고를 방지한다. 처음에는 `release_status: "completed"`로 완전 자동화를 시도했다가, 리뷰 미통과 상태에서 배포되는 아찔한 경험 후 draft로 바꿨다.
+
+**트랙 전략**: internal → alpha → beta → production 순서로 승격한다. CI에서는 항상 internal로 올리고, 수동 검증 후 더 넓은 트랙으로 승격한다. `fastlane deploy_android track:alpha`처럼 트랙을 파라미터로 받아서 유연하게 운영한다.
+
+**서비스 계정 JSON**: Google Cloud Console에서 서비스 계정을 만들고 JSON 키를 다운로드한다. Google Play API 접근 권한은 최소한으로 부여한다. `fastlane/keys/play-store-key.json`에 보관하고 `.gitignore`에 추가한다.
+
+**metadata skip**: `skip_upload_metadata: true`로 스토어 설명, 이미지, 스크린샷 업로드를 생략한다. Google Play Console에서 직접 관리하는 것이 더 편하다. 특히 스크린샷은 여러 기기 크기로 준비해야 하는데, 이걸 CI에서 자동화하는 것은 득보다 실이 많다.
+
+---
+
+## 6. 빌드 넘버 동기화
+
+iOS와 macOS는 같은 Apple 개발자 계정에 같은 앱 번들 ID를 쓴다. App Store Connect에서는 두 플랫폼을 하나의 앱으로 관리하는데, 빌드 넘버가 다르면 충돌이 생긴다. 두 플랫폼의 빌드 넘버를 항상 동기화해야 한다.
+
+```ruby
+# fastlane/Fastfile
+desc "iOS + macOS 빌드 넘버 동기화 증가"
+lane :bump_build do |options|
+  project_root = File.expand_path("..", Dir.pwd)
+
+  if options[:build]
+    new_build = options[:build].to_s
+  else
+    current_build = get_build_number(
+      xcodeproj: "#{project_root}/ios/Runner.xcodeproj"
+    ).to_i
+    new_build = (current_build + 1).to_s
+  end
+
+  UI.message("빌드 번호 #{new_build}로 업데이트 중...")
+
+  # iOS 빌드 넘버
+  increment_build_number(
+    build_number: new_build,
+    xcodeproj: "#{project_root}/ios/Runner.xcodeproj"
+  )
+
+  # macOS 빌드 넘버 (iOS와 동일하게)
+  increment_build_number(
+    build_number: new_build,
+    xcodeproj: "#{project_root}/macos/Runner.xcodeproj"
+  )
+
+  UI.success("빌드 번호 #{new_build}로 업데이트 완료")
+  new_build
+end
+```
+
+`options[:build]`로 특정 빌드 넘버를 지정할 수도 있다. CI에서 GitHub Actions의 런 번호를 빌드 넘버로 쓰면 일관성이 높아진다.
+
+```bash
+# GitHub Actions에서 특정 빌드 넘버 지정
+fastlane bump_build build:${{ github.run_number }}
+```
+
+Android의 빌드 넘버는 `pubspec.yaml`의 `version: 1.0.0+빌드번호`에서 관리한다. `flutter build appbundle`이 이 값을 읽어서 `versionCode`로 사용한다. iOS/macOS와는 별도로 관리되므로 동기화 이슈가 없다.
+
+---
+
+## 7. App Store 심사 제출
+
+TestFlight 배포 후 App Store 심사 제출까지 자동화한다. 스토어 카피(설명, 키워드, 릴리스 노트)를 코드로 관리하는 것이 핵심이다.
+
+```ruby
+# fastlane/Fastfile
+desc "App Store 심사 제출 (iOS)"
+lane :submit_ios do |options|
+  api_key = get_api_key
+
+  deliver(
+    api_key: api_key,
+    app_identifier: "com.cotalk.coTalkFlutter",
+    skip_binary_upload: true,
+    submit_for_review: true,
+    automatic_release: options[:auto_release] || false,
+    metadata_path: "#{Dir.pwd}/metadata",
+    screenshots_path: "#{Dir.pwd}/screenshots",
+    force: true
+  )
+end
+```
+
+metadata 디렉토리 구조:
+
+```
+fastlane/
+  metadata/
+    en-US/
+      name.txt
+      subtitle.txt
+      description.txt
+      keywords.txt
+      release_notes.txt
+      promotional_text.txt
+      support_url.txt
+      privacy_url.txt
+    ko/
+      name.txt
+      subtitle.txt
+      description.txt
+      keywords.txt
+      release_notes.txt
+```
+
+`release_notes.txt`에 버전별 변경사항을 적고, Git에 커밋하면 된다. 스토어 카피 변경 이력이 Git 로그에 남는다. 다국어 관리도 파일 구조로 자연스럽게 된다. `automatic_release: false`로 설정해서 심사 통과 후 수동으로 출시 시점을 결정한다.
+
+---
+
+## 8. 전체 Fastfile 실행 명령 정리
+
+자주 쓰는 명령을 정리했다.
+
+```bash
+# 전체 플랫폼 배포 (iOS + macOS + Android internal)
+fastlane deploy_all_platforms
+
+# iOS + macOS만 배포
+fastlane deploy_all
+
+# iOS만 배포
+fastlane deploy_ios
+
+# macOS만 배포
+fastlane deploy_macos
+
+# Android internal 트랙 배포
+fastlane deploy_android
+
+# Android alpha 트랙 배포
+fastlane deploy_android track:alpha
+
+# 빌드 넘버만 증가 (배포 없이)
+fastlane bump_build
+
+# 특정 빌드 넘버로 설정
+fastlane bump_build build:100
+
+# App Store 심사 제출
+fastlane submit_ios
+
+# macOS 서명 설정만 실행
+fastlane setup_macos_signing
+```
+
+배포 전 로컬에서 한 번 dry run으로 확인하는 습관이 좋다.
+
+```bash
+# 환경변수 로드 확인
+fastlane run app_store_connect_api_key \
+  key_id:$APP_STORE_CONNECT_API_KEY_KEY_ID \
+  issuer_id:$APP_STORE_CONNECT_API_KEY_ISSUER_ID \
+  key_filepath:$APP_STORE_CONNECT_API_KEY_KEY_FILEPATH
+```
+
+---
+
+## 9. 교훈
+
+세 플랫폼 배포를 자동화하면서 얻은 교훈들이다.
+
+**1. macOS 코드 서명이 iOS보다 훨씬 복잡하다**
+
+Flutter가 ad-hoc 서명을 생성하기 때문에 수동 재서명 스크립트가 필수다. 서명 순서(안에서 밖으로)를 틀리면 `codesign --verify --deep`에서 실패한다. `resign_for_appstore.sh`를 프로젝트에 포함시키고 버전 관리하는 것이 맞다.
+
+**2. API Key 인증이 비밀번호 인증보다 훨씬 안정적이다**
+
+App Store Connect API Key(.p8)는 2FA 없이 동작하고, CI에서도 안정적이다. 한 번 설정하면 유지보수가 거의 없다. 비밀번호 기반 인증은 Apple 계정 보안 정책이 바뀔 때마다 깨진다. 더 이상 쓸 이유가 없다.
+
+**3. `draft` 릴리스 전략이 안전하다**
+
+Google Play에 `release_status: "draft"`로 올리면 실수로 프로덕션 배포되는 사고를 방지한다. 자동화의 편의성과 안전성을 균형 있게 가져가려면, 마지막 출시 버튼은 수동으로 누르는 것이 낫다. CI에서 draft까지 올리고, 검증 후 수동 출시하는 패턴을 추천한다.
+
+**4. 빌드 넘버는 반드시 동기화하라**
+
+같은 앱 식별자를 쓰는 iOS/macOS는 빌드 넘버가 다르면 App Store Connect에서 혼란이 생긴다. `bump_build` 레인이 두 Xcode 프로젝트를 동시에 업데이트하고, 하위 레인에는 `skip_bump: true`를 전달해서 이중 증가를 막는 것이 핵심이다.
+
+**5. Metadata-as-code로 스토어 카피를 버전 관리하라**
+
+스토어 설명과 릴리스 노트를 `fastlane/metadata/` 디렉토리에서 파일로 관리하면 변경 이력 추적과 다국어 관리가 쉬워진다. "언제 이 문구를 바꿨더라?"를 Git 로그에서 확인할 수 있다. 스크린샷은 자동화보다 수동 관리가 현실적이다.
+
+**6. 레인 계층화로 유연성을 확보하라**
+
+최상위 레인이 하위 레인을 호출하는 구조를 만들면, 전체 배포와 개별 배포 모두 가능하다. CI에서는 전체를 실행하고, 로컬 디버깅 시에는 특정 레인만 실행한다. 레인을 너무 큰 단위로 만들면 중간 단계만 재실행하기 어려워진다.
+
+---
+
+다음 편에서는 이 Fastlane 파이프라인을 GitHub Actions로 자동화하는 CI/CD 구성을 다룬다.
+
+[다음 편: Flutter CI/CD — GitHub Actions로 테스트부터 스토어 배포까지](blog-18-flutter-cicd-github-actions.md)

--- a/docs/blog-18-flutter-cicd-github-actions.md
+++ b/docs/blog-18-flutter-cicd-github-actions.md
@@ -1,0 +1,551 @@
+# Flutter CI/CD 설계하기 — GitHub Actions로 테스트부터 스토어 배포까지
+
+> "로컬에서 fastlane deploy_all_platforms 치면 되긴 한다. 근데 내 맥북이 2시간 동안 먹통이 되는 건?"
+
+백엔드는 이미 GitHub Actions + GHCR + 카나리아 배포 파이프라인이 완성돼 있다(blog-07). 코드 푸시 → 자동 빌드 → 자동 배포, 다 된다. 근데 Flutter 앱은 아직도 내 맥북에서 `fastlane deploy_all_platforms` 를 직접 치고 있다. 이 명령 한 번이면 iOS, Android, macOS 세 플랫폼이 빌드되고 TestFlight + Google Play로 올라가는데, 그 2시간 동안 맥북으로 다른 일을 못 한다.
+
+Fastlane은 이미 준비돼 있다(blog-17). lane도 다 짜놨다. 이제 할 일은 GitHub Actions에서 그 Fastlane을 호출하는 구조를 설계하는 것. 그게 이번 편의 전부다. Co-Talk 시리즈 18편.
+
+---
+
+## 1. CI/CD 파이프라인 전체 설계
+
+먼저 뭘 만들 건지부터 그려봤다.
+
+```plantuml
+@startuml
+!theme plain
+left to right direction
+
+rectangle "Push / PR" as trigger
+
+rectangle "Test Workflow" as test {
+  rectangle "flutter analyze" as fa
+  rectangle "flutter test" as ft
+}
+
+rectangle "Build Workflows\n(병렬 실행)" as builds {
+  rectangle "iOS Build\n(macOS runner)" as ios
+  rectangle "Android Build\n(Ubuntu runner)" as android
+  rectangle "macOS Build\n(macOS runner)" as macos
+}
+
+rectangle "Deploy" as deploy {
+  rectangle "TestFlight\n(iOS + macOS)" as tf
+  rectangle "Google Play\n(internal)" as gp
+}
+
+trigger --> test
+test --> builds : "테스트 통과 시"
+builds --> deploy : "main 브랜치 + 수동 승인"
+@enduml
+```
+
+<!-- IMAGE: Flutter CI/CD 전체 파이프라인 흐름도 -->
+
+크게 두 단계로 나눴다.
+
+**Phase 1: 테스트 (PR마다 자동 실행)**
+PR을 열거나 main에 푸시할 때마다 자동으로 `flutter analyze` + `flutter test` 를 돌린다. Ubuntu runner에서 돌리니까 빠르고 저렴하다. 이 단계가 실패하면 머지 못 한다.
+
+**Phase 2: 빌드 + 배포 (main 머지 후, 수동 또는 태그)**
+실제 빌드는 무거우니까 매 PR마다 돌리지 않는다. `v*` 태그를 푸시하거나 GitHub Actions UI에서 수동으로 트리거했을 때만 실행된다. iOS와 macOS는 macOS runner, Android는 Ubuntu runner에서 병렬로 실행한다.
+
+이 설계의 핵심은 **테스트와 빌드를 분리**한 것이다. 테스트는 싸고 빠른 Ubuntu runner로, 비싼 macOS runner는 실제 배포할 때만 쓴다.
+
+---
+
+## 2. 재사용 가능한 테스트 워크플로우
+
+```yaml
+# .github/workflows/flutter-test.yml
+name: Flutter Test
+
+on:
+  pull_request:
+    paths:
+      - 'co-talk-flutter/**'
+      - '.github/workflows/flutter-test.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'co-talk-flutter/**'
+
+defaults:
+  run:
+    working-directory: co-talk-flutter
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.8.0'
+          channel: 'stable'
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Analyze
+        run: flutter analyze --no-fatal-infos
+
+      - name: Run tests
+        run: flutter test --coverage
+
+      - name: Check coverage
+        uses: VeryGoodOpenSource/very_good_coverage@v3
+        with:
+          path: co-talk-flutter/coverage/lcov.info
+          min_coverage: 60
+```
+
+몇 가지 포인트를 짚자면:
+
+**`paths` 필터**: Flutter 관련 파일이 변경됐을 때만 이 워크플로우가 실행된다. 백엔드 Java 코드만 수정한 PR에서 Flutter CI가 돌 필요가 없다. 모노레포 구조에서 이 필터가 없으면 CI 비용이 두 배가 된다.
+
+**`subosito/flutter-action`**: Flutter SDK를 캐싱해주는 공식(에 준하는) 액션이다. `cache: true` 한 줄로 Flutter SDK 다운로드 시간 2분을 10초로 줄인다.
+
+**`--no-fatal-infos`**: `flutter analyze` 는 기본적으로 info 레벨 경고도 exit code 1을 반환한다. info는 스타일 제안 같은 거라 PR을 블락하기엔 너무 가혹하다. `--no-fatal-infos` 로 warning 이상만 실패 처리한다.
+
+**커버리지 60%**: 처음부터 80%, 90% 잡으려 하면 테스트 작성이 너무 부담스러워진다. 60%로 시작해서 팀이 익숙해지면 올리는 게 현실적이다.
+
+---
+
+## 3. iOS 빌드 워크플로우
+
+```yaml
+# .github/workflows/flutter-build-ios.yml
+name: Flutter iOS Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      upload_to_testflight:
+        description: 'Upload to TestFlight'
+        type: boolean
+        default: false
+  push:
+    tags:
+      - 'v*'
+
+defaults:
+  run:
+    working-directory: co-talk-flutter
+
+jobs:
+  build-ios:
+    runs-on: macos-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.8.0'
+          channel: 'stable'
+          cache: true
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+          working-directory: co-talk-flutter
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Decode App Store Connect API Key
+        env:
+          API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
+        run: |
+          mkdir -p fastlane/keys
+          echo "$API_KEY_BASE64" | base64 --decode > fastlane/keys/AuthKey.p8
+
+      - name: Build iOS
+        run: |
+          cd fastlane
+          bundle exec fastlane build_ios
+
+      - name: Upload to TestFlight
+        if: inputs.upload_to_testflight || startsWith(github.ref, 'refs/tags/v')
+        env:
+          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_KEY_FILEPATH: ./fastlane/keys/AuthKey.p8
+        run: |
+          cd fastlane
+          bundle exec fastlane upload_ios
+
+      - name: Upload IPA artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-ipa
+          path: co-talk-flutter/build/ios/ipa/*.ipa
+          retention-days: 14
+```
+
+설계할 때 고민한 것들:
+
+**`macos-latest` runner**: iOS 빌드는 macOS에서만 가능하다. Xcode가 macOS에만 있으니까. 비용은 분당 $0.08로, Linux runner($0.008)의 10배다. iOS 빌드 한 번에 40분 걸린다면 $3.20. 이게 쌓이면 무시 못 할 금액이 된다.
+
+**시크릿 관리 - `.p8` 파일**: App Store Connect API Key는 `.p8` 확장자의 바이너리 파일이다. GitHub Secrets는 텍스트만 저장할 수 있어서 바이너리 파일을 직접 넣을 수 없다. base64로 인코딩해서 저장하고, 런타임에 디코딩해서 파일로 복원하는 게 표준 패턴이다.
+
+```bash
+# 로컬에서 시크릿 생성
+base64 -i AuthKey_XXXXXXXX.p8 | pbcopy
+# 클립보드에 복사된 문자열을 GitHub Secrets에 붙여넣기
+```
+
+**`workflow_dispatch` + `tags` 조합**: 수동 트리거와 태그 자동 트리거를 모두 지원한다. 긴급하게 배포해야 할 때는 GitHub Actions UI에서 수동으로 실행하고, 정기 릴리스는 `git tag v1.2.3 && git push --tags` 로 자동화한다.
+
+**artifact 업로드**: TestFlight 업로드를 건너뛰더라도 IPA 파일을 14일간 보관한다. 나중에 수동으로 Transporter 앱으로 업로드하거나, QA 팀에 파일을 공유할 때 유용하다.
+
+---
+
+## 4. Android 빌드 워크플로우
+
+```yaml
+# .github/workflows/flutter-build-android.yml
+name: Flutter Android Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      track:
+        description: 'Google Play track'
+        type: choice
+        options:
+          - internal
+          - alpha
+          - beta
+          - production
+        default: internal
+  push:
+    tags:
+      - 'v*'
+
+defaults:
+  run:
+    working-directory: co-talk-flutter
+
+jobs:
+  build-android:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.8.0'
+          channel: 'stable'
+          cache: true
+
+      - name: Decode keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          KEY_PROPERTIES: ${{ secrets.ANDROID_KEY_PROPERTIES }}
+        run: |
+          echo "$KEYSTORE_BASE64" | base64 --decode > android/app/upload-keystore.jks
+          echo "$KEY_PROPERTIES" > android/key.properties
+
+      - name: Build AAB
+        run: flutter build appbundle --release --dart-define=ENVIRONMENT=prod
+
+      - name: Upload to Google Play
+        if: inputs.track || startsWith(github.ref, 'refs/tags/v')
+        env:
+          SUPPLY_JSON_KEY_DATA: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          cd fastlane
+          bundle exec fastlane upload_android track:${{ inputs.track || 'internal' }}
+
+      - name: Upload AAB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-aab
+          path: co-talk-flutter/build/app/outputs/bundle/release/app-release.aab
+          retention-days: 14
+```
+
+Android는 Linux runner에서 돌릴 수 있어서 iOS보다 훨씬 저렴하다. 같은 30분짜리 빌드가 $0.24다.
+
+**Keystore 관리**: Android 서명 키(`upload-keystore.jks`)도 바이너리 파일이라 base64가 필요하다. `key.properties` 파일에는 비밀번호가 들어가는데, 이건 텍스트라 시크릿에 바로 저장하면 된다. 런타임에 파일로 써내는 방식을 쓴다.
+
+```bash
+# keystore base64 인코딩
+base64 -i android/app/upload-keystore.jks | pbcopy
+```
+
+**`key.properties` 내용 예시:**
+```
+storePassword=mypassword
+keyPassword=mypassword
+keyAlias=upload
+storeFile=upload-keystore.jks
+```
+
+이 내용 전체를 `ANDROID_KEY_PROPERTIES` 시크릿에 저장한다. 여러 줄 텍스트도 GitHub Secrets에 저장 가능하다.
+
+**track 선택**: `workflow_dispatch` 에 `choice` 타입 입력을 달면 GitHub Actions UI에서 드롭다운으로 track을 선택할 수 있다. `internal` → `alpha` → `beta` → `production` 순서로 단계적 배포가 가능하다. 태그로 트리거할 때는 기본값 `internal` 로 고정.
+
+**`SUPPLY_JSON_KEY_DATA`**: Fastlane의 `supply` 플러그인은 환경변수로 서비스 계정 JSON을 받을 수 있다. 파일로 저장할 필요 없이 환경변수로 바로 넘기면 된다.
+
+---
+
+## 5. macOS 빌드 워크플로우
+
+macOS 빌드가 가장 복잡하다. 앱 서명 인증서(Apple Distribution)와 패키지 서명 인증서(Mac Installer Distribution) 두 개가 필요하고, CI 환경에는 키체인이 없어서 직접 만들어줘야 한다.
+
+```yaml
+# .github/workflows/flutter-build-macos.yml
+name: Flutter macOS Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      upload_to_testflight:
+        type: boolean
+        default: false
+  push:
+    tags:
+      - 'v*'
+
+defaults:
+  run:
+    working-directory: co-talk-flutter
+
+jobs:
+  build-macos:
+    runs-on: macos-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.8.0'
+          cache: true
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+          working-directory: co-talk-flutter
+
+      - name: Decode certificates and API key
+        env:
+          DIST_CERT_BASE64: ${{ secrets.APPLE_DISTRIBUTION_CERT_BASE64 }}
+          DIST_CERT_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_CERT_PASSWORD }}
+          INSTALLER_CERT_BASE64: ${{ secrets.MAC_INSTALLER_CERT_BASE64 }}
+          INSTALLER_CERT_PASSWORD: ${{ secrets.MAC_INSTALLER_CERT_PASSWORD }}
+          API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
+        run: |
+          # 임시 키체인 생성
+          security create-keychain -p "" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "" build.keychain
+
+          # 앱 서명 인증서 임포트
+          echo "$DIST_CERT_BASE64" | base64 --decode > dist_cert.p12
+          security import dist_cert.p12 -k build.keychain -P "$DIST_CERT_PASSWORD" -T /usr/bin/codesign
+
+          # pkg 서명 인증서 임포트
+          echo "$INSTALLER_CERT_BASE64" | base64 --decode > installer_cert.p12
+          security import installer_cert.p12 -k build.keychain -P "$INSTALLER_CERT_PASSWORD" -T /usr/bin/codesign
+
+          # codesign이 키체인에 접근할 수 있도록 권한 설정
+          security set-key-partition-list -S apple-tool:,apple: -s -k "" build.keychain
+
+          # API Key 복원
+          mkdir -p fastlane/keys
+          echo "$API_KEY_BASE64" | base64 --decode > fastlane/keys/AuthKey.p8
+
+      - name: Build and sign macOS
+        env:
+          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_KEY_FILEPATH: ./fastlane/keys/AuthKey.p8
+        run: |
+          cd fastlane
+          bundle exec fastlane deploy_macos skip_bump:true
+
+      - name: Cleanup keychain
+        if: always()
+        run: security delete-keychain build.keychain
+```
+
+**임시 키체인 생성 흐름**:
+1. `create-keychain`: `build.keychain` 이라는 이름으로 새 키체인 생성 (빈 비밀번호)
+2. `default-keychain`: 이걸 기본 키체인으로 설정
+3. `unlock-keychain`: CI에서는 키체인이 잠겨 있으므로 잠금 해제
+4. `import`: `.p12` 인증서 파일을 키체인에 등록
+5. `set-key-partition-list`: `/usr/bin/codesign` 이 비밀번호 없이 키체인에 접근할 수 있도록 허용
+
+이 단계에서 `set-key-partition-list` 를 빠뜨리면 codesign이 "keychain password" 팝업을 띄우려다 CI 환경에서 멈춰버린다. 한참 삽질했던 부분이다.
+
+**`if: always()` 키체인 정리**: 빌드가 성공하든 실패하든 임시 키체인을 반드시 지운다. 안 지우면 다음 빌드에서 "keychain already exists" 에러가 난다.
+
+---
+
+## 6. 시크릿 관리 전략
+
+워크플로우에서 사용하는 시크릿을 한 번에 정리하면 이렇다.
+
+| Secret Name | 용도 | 생성 방법 |
+|---|---|---|
+| `APP_STORE_CONNECT_API_KEY_BASE64` | ASC API Key | `base64 -i AuthKey_XXX.p8` |
+| `ASC_KEY_ID` | API Key ID | App Store Connect → Users and Access → Keys |
+| `ASC_ISSUER_ID` | Issuer ID | App Store Connect → Users and Access → Keys |
+| `APPLE_DISTRIBUTION_CERT_BASE64` | iOS/macOS 앱 서명 인증서 | Keychain에서 .p12 내보내기 후 base64 |
+| `APPLE_DISTRIBUTION_CERT_PASSWORD` | .p12 비밀번호 | 내보내기 시 직접 설정 |
+| `MAC_INSTALLER_CERT_BASE64` | macOS pkg 서명 인증서 | 위와 동일 |
+| `MAC_INSTALLER_CERT_PASSWORD` | .p12 비밀번호 | 위와 동일 |
+| `ANDROID_KEYSTORE_BASE64` | Android 업로드 키 | `base64 -i upload-keystore.jks` |
+| `ANDROID_KEY_PROPERTIES` | keystore 비밀번호 등 | key.properties 파일 내용 전체 |
+| `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | Play Store 업로드 권한 | GCP Console → IAM → Service Account → JSON 키 |
+
+**왜 base64인가?**
+
+GitHub Secrets는 텍스트만 저장할 수 있다. `.p8`, `.p12`, `.jks` 같은 바이너리 파일을 직접 저장하면 데이터가 깨진다. base64는 바이너리를 ASCII 텍스트로 변환하는 인코딩이라 Secrets에 안전하게 저장할 수 있고, 런타임에 `base64 --decode` 로 원본 파일을 복원할 수 있다.
+
+**.p12 인증서 내보내기 (macOS Keychain Access):**
+1. Keychain Access 앱 열기
+2. "Apple Distribution: ..." 인증서 우클릭 → "Export"
+3. `.p12` 형식으로 저장, 비밀번호 설정
+4. `base64 -i exported.p12 | pbcopy` 로 클립보드에 복사
+5. GitHub Secrets에 붙여넣기
+
+---
+
+## 7. 빌드 캐시 전략
+
+캐시 없이 돌리면 Gradle 다운로드, CocoaPods 설치, Flutter SDK 설치가 매번 반복된다. 이게 빌드 시간의 절반을 잡아먹는다.
+
+```yaml
+# Flutter SDK 캐시 (subosito/flutter-action에 내장)
+- uses: subosito/flutter-action@v2
+  with:
+    cache: true  # pub-cache + Flutter SDK 자동 캐싱
+
+# Gradle 캐시 (Android 빌드)
+- uses: actions/cache@v4
+  with:
+    path: |
+      ~/.gradle/caches
+      ~/.gradle/wrapper
+    key: gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+    restore-keys: |
+      gradle-
+
+# CocoaPods 캐시 (iOS/macOS 빌드)
+- uses: actions/cache@v4
+  with:
+    path: co-talk-flutter/ios/Pods
+    key: pods-${{ hashFiles('**/Podfile.lock') }}
+    restore-keys: |
+      pods-
+```
+
+캐시 적용 전후 시간 비교:
+
+| 캐시 대상 | 캐시 없음 | 캐시 있음 | 절약 |
+|---|---|---|---|
+| Flutter SDK | 약 2분 | 약 10초 | 110초 |
+| pub packages | 약 30초 | 약 5초 | 25초 |
+| Gradle | 약 3분 | 약 30초 | 150초 |
+| CocoaPods | 약 2분 | 약 15초 | 105초 |
+| **합계** | **약 8분** | **약 1분** | **약 7분** |
+
+iOS 빌드 기준으로 7분이 절약되면, 분당 $0.08 환산으로 빌드 1회당 $0.56 절감이다. 월 10회 빌드하면 $5.60. 티끌도 모아야 태산이다.
+
+**캐시 키 설계**:
+- `hashFiles('**/*.gradle*')`: Gradle 관련 파일이 바뀌면 캐시 무효화
+- `hashFiles('**/Podfile.lock')`: Podfile.lock이 바뀌면 (의존성 변경) CocoaPods 재설치
+- `restore-keys`: 정확한 키 매치가 없을 때 prefix로 가장 최근 캐시를 사용
+
+---
+
+## 8. 비용 현실
+
+GitHub Actions 비용은 생각보다 빠르게 쌓인다. 특히 macOS runner.
+
+| Runner | 분당 비용 | iOS 빌드 (~40분) | Android 빌드 (~15분) | macOS 빌드 (~40분) |
+|---|---|---|---|---|
+| macOS (GitHub) | $0.08 | $3.20 | - | $3.20 |
+| Ubuntu (GitHub) | $0.008 | - | $0.12 | - |
+| self-hosted Mac Mini | $0 (초기 투자) | $0 | - | $0 |
+
+태그 릴리스 1회 기준: iOS ($3.20) + macOS ($3.20) + Android ($0.12) = **$6.52**
+
+월 10회 릴리스: **$65.20**
+
+GitHub Free 플랜은 월 2,000 분을 제공하는데, macOS runner는 10배 비율로 차감된다. 즉 실제 macOS 빌드 가능 시간은 200분. iOS + macOS 빌드가 각 40분이면, 10회 릴리스면 이미 800분이라 무료 한도를 훌쩍 넘는다.
+
+**self-hosted runner 고려 시점**: 월 배포 횟수 × (iOS 빌드 시간 + macOS 빌드 시간) × $0.08이 월 $30을 넘으면, 중고 Mac Mini(M1, 약 $400) 투자를 고려할 만하다. 초기 비용 회수가 13개월 정도면 충분히 합리적이다.
+
+self-hosted runner 설정 자체는 간단하다:
+
+```bash
+# GitHub Repo → Settings → Actions → Runners → New self-hosted runner
+# macOS 선택 후 안내 스크립트 실행
+./config.sh --url https://github.com/org/repo --token XXXXX
+./run.sh
+```
+
+워크플로우에서는 `runs-on: [self-hosted, macos]` 로 라우팅하면 된다.
+
+---
+
+## 9. 교훈
+
+직접 설계하고 삽질하면서 얻은 것들.
+
+**1. macOS runner 비용을 과소평가하지 마라**
+
+"GitHub Actions 무료잖아" 라고 생각했다가 나중에 청구서 보고 놀란다. iOS/macOS 빌드는 macOS runner가 필수고 비용이 Linux의 10배다. 월 배포 빈도에 따라 self-hosted runner를 처음부터 고려하는 게 낫다.
+
+**2. 시크릿은 base64 인코딩이 정답**
+
+`.p8`, `.p12`, `.jks` 같은 바이너리 파일을 GitHub Secrets에 저장하는 방법은 base64 인코딩이 유일하다. 다른 방법 찾지 말고 이 패턴으로 통일하면 된다. 디코딩 스크립트도 `echo "$SECRET" | base64 --decode > file` 이 한 줄이 전부다.
+
+**3. 임시 키체인은 반드시 정리하라**
+
+CI macOS 환경에서 `security create-keychain` 으로 임시 키체인을 만들었으면, 빌드 성공/실패와 관계없이 삭제해야 한다. `if: always()` 블록에 `security delete-keychain build.keychain` 을 넣지 않으면 다음 빌드에서 "A keychain with the same name already exists" 에러로 실패한다.
+
+**4. 캐시가 빌드 시간의 50%를 결정한다**
+
+Flutter SDK, Gradle, CocoaPods 캐시만 제대로 설정해도 총 7분 이상이 절약된다. 캐시 없이 계속 돌리는 건 돈 낭비이자 시간 낭비다. 워크플로우 처음 짤 때 캐시부터 설계하자.
+
+**5. `workflow_dispatch` + `tags` 조합이 가장 유연하다**
+
+긴급 핫픽스는 Actions UI에서 수동으로 트리거하고, 계획된 릴리스는 태그로 자동화한다. 이 두 가지 트리거를 모두 지원하면 어떤 상황에도 대응할 수 있다.
+
+**6. `paths` 필터는 모노레포의 필수 설정이다**
+
+백엔드와 Flutter가 같은 레포에 있으면, 백엔드 변경 때마다 Flutter CI가 돌면 안 된다. `paths` 필터로 각 워크플로우가 관련 파일 변경에만 반응하도록 설정하면 불필요한 CI 실행과 비용을 막을 수 있다.
+
+---
+
+## 마무리
+
+Co-Talk 시리즈 19편을 통해 백엔드 아키텍처부터 Flutter 프론트엔드, 배포 자동화까지 전 과정을 다뤘다. 처음 레이어드 아키텍처로 시작해서 헥사고날로 리팩토링하고, WebSocket 실시간 채팅을 구현하고, NAS에 자동 배포하고, 모니터링을 붙이고, Flutter 앱을 설계하고, Fastlane으로 3플랫폼을 배포하기까지 — 사이드 프로젝트 하나가 이렇게 깊어질 줄은 몰랐다.
+
+GitHub Actions는 결국 "어디서 어떤 명령을 실행할 것인가"의 문제다. Fastlane으로 로컬 배포 스크립트를 잘 만들어두면, CI에서는 그걸 호출하기만 하면 된다. 핵심은 시크릿 관리(바이너리 파일은 base64)와 비용 관리(macOS runner는 아껴서 쓰기)다.
+
+모든 코드는 [GitHub 저장소](https://github.com/with-co-talk/co-talk)에서 확인할 수 있다.
+
+---
+
+*[Co-Talk 시리즈 전체 목차](blog-index.md)*
+
+다음 편: [카나리아 3인스턴스에서 Blue-Green 단일 운영으로 — NAS CPU가 항복했다](blog-19-nas-bluegreen-rollback.md)

--- a/docs/blog-19-nas-bluegreen-rollback.md
+++ b/docs/blog-19-nas-bluegreen-rollback.md
@@ -1,0 +1,458 @@
+# 카나리아 3인스턴스에서 Blue-Green 단일 운영으로 — NAS CPU가 항복했다
+
+> "배포 전략은 고정이 아니다. 하드웨어 앞에서는 교과서도 접어야 할 때가 있다."
+
+[이전 글](blog-07-nas-auto-deployment.md)에서 카나리아 롤링 배포를 자랑스럽게 소개했다. app-1, app-2, app-3 세 인스턴스가 동시에 돌아가고, 배포 시엔 한 대씩 교체하며 에러율을 검증하는 구조. 그런데 얼마 지나지 않아 Grafana에서 불편한 숫자를 보게 됐다.
+
+CPU 사용률이 배포 중에 100%에 닿았다.
+
+이 글은 그 숫자를 보고 카나리아를 포기한 이야기다.
+
+---
+
+## CPU가 항복한 순간
+
+### 하드웨어 환경
+
+지금 Co-Talk이 돌아가는 곳은 Synology DS923+다. CPU는 **Celeron J4125, 4코어**. RAM은 **20GB**로 업그레이드했다. 클라우드 관점에서 보면 t3.small보다 조금 나은 수준이다. 서버라기보다 NAS에 가깝다.
+
+이 위에 올라간 스택을 나열하면 이렇다.
+
+| 서비스 | 메모리 제한 | 비고 |
+|--------|------------|------|
+| app-1 | 768M | JVM, Spring Boot |
+| app-2 | 768M | JVM, Spring Boot |
+| app-3 | 768M | JVM, Spring Boot |
+| PostgreSQL 16 | 512M | |
+| Redis 7 | 192M | |
+| MinIO | 512M | |
+| Prometheus | 256M | |
+| Grafana | 256M | |
+| Loki | 256M | |
+| Promtail | 128M | |
+| Zipkin | 256M | |
+| Alertmanager | 128M | |
+| nginx | - | |
+| **합계** | **~4.7GB** | 20GB 대비 메모리는 여유 |
+
+메모리는 충분했다. 문제는 CPU였다.
+
+### 증상
+
+평시에는 괜찮았다. CPU 사용률이 20~30% 수준으로 유지됐다. 그런데 배포가 시작되는 순간 그래프가 솟았다.
+
+배포 스크립트가 하는 일을 떠올리면 당연한 결과였다.
+
+1. GHCR에서 새 이미지를 pull한다 — 네트워크 I/O + 디스크 쓰기
+2. app-1을 중지하고 새 이미지로 다시 띄운다 — JVM 콜드 스타트
+3. Spring Boot가 뜨면서 Flyway 마이그레이션, DB 커넥션 풀 초기화, 빈 초기화가 한꺼번에 일어난다
+4. 헬스체크가 통과하면 app-2도 같은 과정을 거친다
+5. app-3도 마찬가지
+
+JVM 콜드 스타트는 CPU를 집중적으로 쓴다. 특히 Java 25 + Virtual Threads 조합에서 초기 컴파일(JIT) 부하가 적지 않다. 인스턴스 하나가 뜨는 동안 나머지 두 인스턴스가 실제 트래픽을 처리하고 있으니, 콜드 스타트 부하와 서비스 부하가 Celeron J4125 4코어 위에서 경쟁했다.
+
+결과적으로 배포 중 응답 지연이 눈에 띄었다. Grafana 대시보드에서 배포 타임라인과 레이턴시 급등 구간이 정확히 겹쳤다.
+
+---
+
+## Blue-Green 단일 운영으로 전환
+
+전략을 바꿨다. **평소에는 app-1 하나만 운영**하고, **배포 시에만 app-2를 잠깐 기동**한다. 트래픽을 app-2로 전환하고, app-1을 중지한 뒤, 다음 배포까지 app-1은 멈춰 있는다.
+
+카나리아와 비교하면 이렇다.
+
+| 항목 | 카나리아 3인스턴스 | Blue-Green 단일 |
+|------|-----------------|----------------|
+| 평시 인스턴스 수 | 3 | 1 |
+| 배포 시 인스턴스 수 | 3 (순차 교체) | 2 (일시적) |
+| JVM 콜드 스타트 횟수/배포 | 3회 | 1회 |
+| 평시 CPU 점유 | ~3코어 | ~1코어 |
+| 배포 중 서비스 영향 | 콜드 스타트 중 CPU 경쟁 | 없음 (트래픽 전환 후 중지) |
+| 점진적 롤아웃 | 가능 | 불가 |
+| 평시 메모리 | 3 × 768M = 2.3GB | 1 × 1024M = 1GB |
+
+사이드 프로젝트 규모에서 점진적 롤아웃을 포기하는 건 크게 아프지 않았다. 대신 배포 중 CPU 경쟁이 사라지고, 평시 메모리도 오히려 줄었다.
+
+---
+
+## 변경 내용
+
+### docker-compose.nas.yml: profiles로 app-2 비활성화
+
+가장 핵심적인 변경이다. **app-3은 완전히 제거**하고, **app-2에 `profiles: ["deploy"]`를 추가**했다.
+
+`profiles`는 Docker Compose의 조건부 서비스 기동 기능이다. `--profile deploy` 플래그 없이 `docker compose up`을 하면 해당 서비스가 아예 기동되지 않는다.
+
+**변경 전 (카나리아 3인스턴스):**
+
+```yaml
+# docker-compose.nas.yml (카나리아 시절)
+  app-1:
+    image: ghcr.io/${GITHUB_REPO}:latest
+    deploy:
+      resources:
+        limits:
+          memory: 768M
+
+  app-2:
+    image: ghcr.io/${GITHUB_REPO}:latest
+    deploy:
+      resources:
+        limits:
+          memory: 768M
+
+  app-3:
+    image: ghcr.io/${GITHUB_REPO}:latest
+    deploy:
+      resources:
+        limits:
+          memory: 768M
+```
+
+**변경 후 (Blue-Green 단일):**
+
+```yaml
+# docker-compose.nas.yml (현재)
+
+  # ===========================================
+  # 애플리케이션 (Instance 1) - 상시 활성
+  # ===========================================
+  app-1:
+    image: ghcr.io/${GITHUB_REPO}:latest
+    restart: unless-stopped
+    stop_grace_period: 35s
+    # ... 환경변수 생략 ...
+    deploy:
+      resources:
+        limits:
+          memory: 1024M  # 단일 인스턴스이므로 768M → 1024M으로 증가
+
+  # ===========================================
+  # 애플리케이션 (Instance 2 - Blue-Green Standby)
+  # ===========================================
+  # 평소에는 뜨지 않음. 배포 시 deploy.sh가 --profile deploy로 시작.
+  # 맥미니 이전 후 3인스턴스 복구 시 profiles 제거하면 됨.
+  app-2:
+    image: ghcr.io/${GITHUB_REPO}:latest
+    profiles: ["deploy"]          # <-- 핵심 변경
+    restart: unless-stopped
+    stop_grace_period: 35s
+    # ... 환경변수 생략 ...
+    deploy:
+      resources:
+        limits:
+          memory: 1024M
+```
+
+app-3은 파일에서 완전히 사라졌다. app-2는 `profiles: ["deploy"]` 한 줄로 평시에는 존재하지 않는 서비스가 됐다.
+
+메모리 제한도 768M에서 1024M으로 올렸다. 혼자 트래픽을 받는 인스턴스인데 이전과 같은 제한을 두면 메모리 압박이 커질 수 있다. 3인스턴스 합산(2.3GB)보다도 오히려 적다(1GB).
+
+### deploy.sh: 카나리아 → Blue-Green 재작성
+
+스크립트 헤더부터 달라졌다.
+
+```bash
+# ===========================================
+# Co-Talk Blue-Green Deployment Script
+# ===========================================
+# Zero-downtime blue-green deployment for 1-instance NAS setup
+# (Synology NAS Celeron J4125 4코어, 20GB RAM — CPU 경합 방지를 위해 단일 인스턴스 운영)
+#
+# 3인스턴스 복구:
+#   맥미니 이전 후 docker-compose.nas.yml에서 app-2 profiles 제거,
+#   upstream.conf에 3개 서버 복원, 이 스크립트를 canary 버전으로 원복
+# ===========================================
+```
+
+주석에 복구 경로까지 남겨뒀다. 나중에 맥 미니로 이전하면 이 주석을 보고 원복하면 된다.
+
+인스턴스 변수도 명시했다.
+
+```bash
+# Blue-Green instances
+BLUE_INSTANCE="app-1"
+GREEN_INSTANCE="app-2"
+STATE_FILE="${PROJECT_ROOT}/.deploy-active"
+UPSTREAM_CONF="${PROJECT_ROOT}/docker/nginx/upstream.conf"
+```
+
+배포 흐름은 이렇다.
+
+```bash
+# Phase 1: 현재 :latest → :previous 백업 + 새 이미지 pull/build
+backup_current_image
+dc pull "$active"   # 또는 dc build "$active"
+
+# Phase 2: standby(GREEN) 기동 — --profile deploy 필수
+dc_deploy stop -t 35 "$standby" 2>/dev/null || true
+dc_deploy up -d --no-deps "$standby"
+health_check "$standby"   # 최대 120초 대기
+
+# Phase 3: upstream 전환 → nginx reload
+switch_upstream "$standby"
+
+# Phase 4: 기존 active(BLUE) 드레인 후 중지
+sleep 3
+dc stop -t 35 "$active"
+
+# Phase 5: 상태 파일 업데이트, nginx 확인
+echo "$standby" > "$STATE_FILE"
+```
+
+`switch_upstream()` 함수는 `upstream.conf`를 동적으로 덮어쓴다.
+
+```bash
+switch_upstream() {
+    local target=$1
+    cat > "$UPSTREAM_CONF" << EOF
+# Auto-generated by deploy.sh - do not edit manually
+# Active instance: ${target}
+
+upstream cotalk-backend {
+    server ${target}:8080 max_fails=10 fail_timeout=10s;
+    keepalive 16;
+}
+EOF
+    dc exec -T nginx nginx -s reload
+    log_success "Upstream switched to ${target}"
+}
+```
+
+매 배포마다 파일 내용이 완전히 교체된다. 수동으로 편집해봤자 다음 배포 때 덮어쓰인다. 주석에도 "do not edit manually"를 써뒀다.
+
+`dc_deploy`는 `--profile deploy` 플래그를 포함한 래퍼 함수다.
+
+```bash
+# Docker compose with deploy profile (for starting standby instance)
+dc_deploy() {
+    docker compose -f "$COMPOSE_FILE" --profile deploy "$@"
+}
+```
+
+이 함수를 통해 standby 인스턴스만 선택적으로 기동하고 헬스체크할 수 있다.
+
+### upstream.conf: 평소에는 app-1 단독
+
+```nginx
+# docker/nginx/upstream.conf
+
+# Blue-Green Deployment Upstream
+# 평소: app-1만 활성 / 배포 시: deploy.sh가 동적으로 전환
+# 3인스턴스 복구 시 이 파일과 deploy.sh를 원복하면 됨
+
+upstream cotalk-backend {
+    server app-1:8080 max_fails=10 fail_timeout=10s;
+    keepalive 16;
+}
+```
+
+파일 자체는 단순하다. 하지만 배포 중에는 `deploy.sh`의 `switch_upstream()` 함수가 이 파일을 덮어써서 app-2를 가리키게 된다.
+
+```
+배포 전:  upstream → app-1
+배포 중:  upstream → app-2  (nginx reload)
+배포 완료: 다음 배포까지 app-2가 활성
+```
+
+다음 배포가 돌면 상황이 반전된다. app-1이 standby로 새 이미지를 받고, upstream이 app-1으로 전환되고, app-2가 중지된다. 그래서 배포가 끝난 상태를 기준으로 active 인스턴스가 app-1과 app-2 사이를 번갈아 가리킨다.
+
+---
+
+## Blue-Green 배포 시퀀스
+
+```plantuml
+@startuml
+skinparam monochrome true
+skinparam shadowing false
+skinparam defaultFontSize 13
+
+title Blue-Green 배포 흐름 (NAS 단일 인스턴스)
+
+actor "GitHub Actions" as GA
+participant "deploy.sh" as DS
+participant "app-1\n(BLUE, 현재 active)" as A1
+participant "app-2\n(GREEN, standby)" as A2
+participant "upstream.conf\n+ nginx" as NG
+participant "GHCR" as REG
+
+GA -> DS : ./scripts/deploy.sh -f docker-compose.nas.yml --pull
+DS -> REG : docker pull :latest
+REG --> DS : 새 이미지 준비 완료
+DS -> DS : docker tag :latest :previous\n(롤백 백업)
+
+note over A2 : profiles: ["deploy"]\n평소에는 미기동
+
+DS -> A2 : dc_deploy up -d --no-deps app-2\n(--profile deploy)
+A2 -> A2 : JVM 콜드 스타트\nSpring Boot 초기화
+A2 --> DS : /actuator/health/liveness → 200 OK
+
+note over A1 : 여전히 트래픽 처리 중\n배포 영향 없음
+
+DS -> NG : upstream.conf 덮어쓰기\nserver app-2:8080
+DS -> NG : nginx -s reload
+NG --> A2 : 트래픽 전환 완료
+
+DS -> DS : sleep 3s (진행 중 요청 드레인)
+DS -> A1 : dc stop -t 35 app-1\n(Graceful Shutdown 30s)
+A1 --> DS : 중지 완료
+
+DS -> DS : echo "app-2" > .deploy-active
+DS --> GA : 배포 완료. active=app-2
+
+@enduml
+```
+
+<!-- IMAGE: deploy.sh 실행 로그 — Phase 1~5 순서대로 INFO/SUCCESS 메시지가 출력되고, 마지막에 "Blue-Green Deployment Completed Successfully / Active instance: app-2" 가 찍힌 터미널 캡처 -->
+
+---
+
+## 리소스 비교
+
+```plantuml
+@startuml
+skinparam monochrome true
+skinparam shadowing false
+skinparam defaultFontSize 13
+
+title 카나리아 vs Blue-Green 리소스 비교
+
+rectangle "카나리아 3인스턴스 (이전)" as OLD {
+    rectangle "app-1\n768M" as O1
+    rectangle "app-2\n768M" as O2
+    rectangle "app-3\n768M" as O3
+    rectangle "공통 인프라\n(PG 512M + Redis 192M\n+ MinIO 512M + 모니터링 1.3GB)" as OINF
+
+    note bottom of O3
+    App 합계: 2.3GB
+    CPU 점유: ~3코어 (평시)
+    배포 중 콜드 스타트: 3회
+    end note
+}
+
+rectangle "Blue-Green 단일 (현재)" as NEW {
+    rectangle "app-1\n1024M\n(상시 active)" as N1
+    rectangle "app-2\n1024M\n(배포 시에만)" as N2 #grey
+    rectangle "공통 인프라\n(동일)" as NINF
+
+    note bottom of N2
+    App 합계: 1GB (평시)
+    일시적 2GB (배포 중)
+    CPU 점유: ~1코어 (평시)
+    배포 중 콜드 스타트: 1회
+    end note
+}
+
+@enduml
+```
+
+<!-- IMAGE: Grafana CPU 사용률 대시보드 — 카나리아 시절 배포 중 CPU 100% 급등 구간과, Blue-Green 전환 후 배포 중 CPU 사용률이 50~60% 수준으로 유지되는 두 구간이 한 화면에 비교되는 스크린샷 -->
+
+실제로 전환 후 배포 중 CPU 그래프가 눈에 띄게 낮아졌다. JVM이 동시에 콜드 스타트를 3번 하지 않고 1번만 하니까 당연한 결과다.
+
+---
+
+## 아직 정리 못 한 것들
+
+솔직히 말하면, 전략을 바꾸면서 연관 설정 파일들을 전부 업데이트하지는 못했다.
+
+### prometheus.yml — app-2, app-3 스크래핑 실패 중
+
+```yaml
+# docker/prometheus/prometheus.yml (현재 — 불일치 상태)
+- job_name: 'cotalk-app'
+  metrics_path: '/actuator/prometheus'
+  scrape_interval: 5s
+  static_configs:
+    - targets: ['app-1:8080', 'app-2:8080', 'app-3:8080']  # <-- 3개가 아직 남아있음
+```
+
+app-2와 app-3은 평시에 기동되지 않으니 Prometheus가 15초마다 스크래핑 실패를 기록한다. 지금 Grafana에서 `up{job="cotalk-app"}` 그래프를 보면 app-1만 1이고 app-2, app-3은 0이다.
+
+동작에는 무해하다. 스크래핑 타임아웃이 나도 기존 메트릭이 사라지는 건 아니고, app-1 메트릭은 정상 수집된다. 다만 불필요한 에러 로그가 쌓이고 있다.
+
+### alert-rules.yml — 3인스턴스 기준 알림 규칙
+
+```yaml
+# docker/prometheus/alert-rules.yml (현재 — 오경보 가능)
+
+# 인스턴스 다운 알림 (3인스턴스 티어)
+- alert: InstanceDown
+  expr: up{job="cotalk-app"} == 0
+  for: 30s
+  annotations:
+    description: "인스턴스 {{ $labels.instance }}가 30초 이상 응답하지 않습니다. 나머지 인스턴스가 트래픽을 처리 중입니다."
+
+- alert: MultipleInstancesDown
+  expr: count(up{job="cotalk-app"} == 0) >= 2
+  for: 30s
+  annotations:
+    description: "3개 인스턴스 중 2개 이상이 다운되었습니다. 즉시 확인이 필요합니다."
+```
+
+`InstanceDown`은 app-2, app-3이 항상 0이니까 항상 발화하는 알림이다. 배포 직후부터 오경보가 계속 나오고 있다. `MultipleInstancesDown`은 더하다 — 2개 이상이 0이면 critical인데, 평시에 app-2와 app-3이 항상 0이니 조건이 상시 충족된다.
+
+### promtail-config.yml — regex 불일치
+
+```yaml
+# docker/promtail/promtail-config.yml
+# 파이프라인 필터에 app-(1|2|3) 패턴이 있지만 app-3은 이제 없음
+```
+
+이건 동작에 무해하다. app-3에 매칭되는 컨테이너가 없으면 해당 패턴은 그냥 아무것도 수집 안 할 뿐이다.
+
+### 왜 아직 안 고쳤는가
+
+두 가지 이유다.
+
+첫째, **prometheus.yml과 alert-rules.yml 수정이 생각보다 신중하게 해야 한다.** 지금 app-1이 내려가도 알람이 오긴 한다(`ApplicationDown`이 발화한다). 알람 체계 전체를 다시 설계하는 건 별도 작업이다.
+
+둘째, **어차피 맥 미니 이전 후 3인스턴스로 복구할 예정이다.** 그때 다시 원복하면 되는데 지금 Blue-Green 기준으로 맞춰봤자 다시 바꿔야 한다. 결국 부채를 감수하고 TODO 주석으로 남겨뒀다.
+
+---
+
+## 복구 계획
+
+deploy.sh 상단에 주석으로 남겨뒀다.
+
+```bash
+# 3인스턴스 복구:
+#   맥미니 이전 후 docker-compose.nas.yml에서 app-2 profiles 제거,
+#   upstream.conf에 3개 서버 복원, 이 스크립트를 canary 버전으로 원복
+```
+
+세 가지 파일만 수정하면 원래대로 돌아간다.
+
+1. `docker-compose.nas.yml` — app-2 `profiles` 제거, app-3 추가, 메모리 768M으로 변경
+2. `docker/nginx/upstream.conf` — `server app-1:8080; server app-2:8080; server app-3:8080;` 복원
+3. `scripts/deploy.sh` — 카나리아 버전으로 교체 (git history에 있다)
+
+그때 prometheus.yml, alert-rules.yml, promtail-config.yml도 함께 정리할 예정이다.
+
+---
+
+## 교훈
+
+**1. 인프라는 하드웨어 스펙에 맞춰야 한다.**
+
+카나리아 롤링은 좋은 전략이다. 하지만 Celeron J4125 4코어 위에서 JVM 3개를 동시에 콜드 스타트시키면 CPU 경쟁이 생긴다. 교과서가 옳아도 하드웨어가 감당 못하면 소용없다. 사이드 프로젝트 인프라는 항상 실제 스펙 기준으로 설계해야 한다.
+
+**2. Docker Compose `profiles`는 조건부 서비스 기동에 딱 맞는 도구다.**
+
+`profiles: ["deploy"]` 한 줄로 서비스를 평시에 완전히 비활성화할 수 있다. 별도 compose 파일을 만들거나 수동으로 컨테이너를 관리할 필요 없다. 배포 스크립트에서 `--profile deploy`로 선택적으로 기동하는 패턴은 NAS 같은 제한된 환경에서 특히 유용하다.
+
+**3. 배포 전략은 되돌릴 수 있다.**
+
+카나리아에서 Blue-Green으로 내려갔다. 부끄럽지 않다. 하드웨어가 바뀌면 다시 카나리아로 올라갈 것이다. 배포 전략을 "진화"로 보면 한 방향만 있는 것 같지만, 실제로는 환경에 따라 앞뒤로 움직인다.
+
+**4. 남긴 부채는 코드 주석으로 명시해라.**
+
+prometheus.yml, alert-rules.yml의 불일치를 당장 못 고쳤다. 대신 deploy.sh에 복구 경로 주석을 남겼고, upstream.conf에도 "3인스턴스 복구 시 원복" 안내를 박아뒀다. 6개월 뒤에 이 코드를 다시 볼 때 주석이 없었다면 어디서부터 손대야 할지 막막했을 것이다.
+
+**5. 카나리아가 항상 정답은 아니다.**
+
+분산 시스템 교과서는 카나리아를 권장한다. 하지만 트래픽이 거의 없는 사이드 프로젝트에서 점진적 롤아웃은 필수가 아니다. 반면 배포 중 CPU 경쟁은 실제 사용자에게 영향을 준다. 무엇이 "더 나은 전략"인지는 이론이 아니라 지금 실행되는 하드웨어 위에서 판단해야 한다.
+
+---
+
+*[Co-Talk 시리즈 전체 목차](blog-index.md)*

--- a/docs/blog-index.md
+++ b/docs/blog-index.md
@@ -1,0 +1,120 @@
+# Co-Talk 개발기 — 전체 시리즈 목차
+
+> 사이드 프로젝트 하나로 백엔드 아키텍처, Flutter 앱, 배포 자동화, 모니터링까지 — 실시간 채팅 앱을 처음부터 끝까지 만들어본 기록.
+
+---
+
+## 시리즈 소개
+
+Co-Talk은 Java/Spring Boot 백엔드 + Flutter 프론트엔드로 구성된 실시간 채팅 애플리케이션이다. 이 시리즈는 프로젝트를 처음 시작한 시점부터 프로덕션 배포, Flutter 앱 개발, CI/CD 자동화까지의 전 과정을 **실제 개발 순서대로** 기록한 20편의 글이다.
+
+각 글은 독립적으로 읽을 수 있지만, 순서대로 읽으면 프로젝트가 성장하는 흐름을 따라갈 수 있다.
+
+---
+
+## 프로젝트 소개
+
+| # | 제목 | 핵심 키워드 |
+|---|------|------------|
+| 00 | [Co-Talk: 실시간 채팅 백엔드를 처음부터 만들어보며 배운 것들](blog-00-project-introduction.md) | 프로젝트 소개, 기술 스택, Java 25, Spring Boot 3.5 |
+
+> 전체 시리즈의 진입점. 왜 이 프로젝트를 시작했는지, 어떤 기술 스택을 선택했는지, 전체 아키텍처 개요를 다룬다.
+
+---
+
+## 백엔드 — 아키텍처와 핵심 기능 구현
+
+| 순서 | # | 제목 | 핵심 키워드 | 이슈/PR |
+|------|---|------|------------|---------|
+| 1 | 01 | [실시간 채팅 아키텍처를 밑바닥부터 쌓아올리기](blog-01-realtime-chat-architecture.md) | WebSocket, STOMP, Redis Pub/Sub, Snowflake ID, AES 암호화 | #1~#17 |
+| 2 | 02 | [헥사고날 아키텍처로 리팩토링하기](blog-02-hexagonal-architecture.md) | Ports & Adapters, ArchUnit, 도메인 독립성, 패키지 구조 | #19, #22, #24 |
+| 3 | 03 | [CI만 터지는 이유 — MinIO 설정 한 줄의 차이](blog-03-ci-minio-connection.md) | CI 트러블슈팅, MinIO, @ConditionalOnProperty | #30 |
+| 4 | 05 | [DTO에서 userId를 제거한 이유 — 보안 리팩토링](blog-05-dto-userid-security.md) | SecurityContext, 인증 정보 신뢰, DTO 설계 | #46 |
+| 5 | 06 | [Redis 캐시 직렬화 삽질기](blog-06-redis-cache-serialization.md) | LocalDateTime 직렬화, 다형성, ObjectMapper 설정 | #48 |
+
+---
+
+## 백엔드 — 인프라와 운영
+
+| 순서 | # | 제목 | 핵심 키워드 | 이슈/PR |
+|------|---|------|------------|---------|
+| 6 | 04 | [사이드 프로젝트를 프로덕션에 올리기까지](blog-04-production-readiness.md) | 시크릿 관리, Flyway, Redis 캐시, Actuator 보안, 백업 | — |
+| 7 | 07 | [사이드 프로젝트를 NAS에 자동 배포하기](blog-07-nas-auto-deployment.md) | GitHub Actions, GHCR, SSH, 카나리아 롤링 | PR #61, #95, #97 |
+| 8 | 08 | [WebSocket 브로드캐스트가 실패해도 메시지는 살려야 한다](blog-08-websocket-broadcast-resilience.md) | TransactionTemplate, 실패 격리, 부분 성공 | PR #62 |
+| 9 | 09 | [사이드 프로젝트에 모니터링 스택을 붙인 이유](blog-09-monitoring-stack.md) | Prometheus, Grafana, Loki, Zipkin, Alertmanager | PR #63~#67 |
+| 10 | 10 | [k6로 채팅 앱 부하 테스트하기 — 그리고 성능 최적화](blog-10-k6-load-testing.md) | k6, WebSocket 부하, 커넥션 풀, 성능 튜닝 | PR #99, #100 |
+
+---
+
+## 백엔드 — 업그레이드와 CI 수정
+
+| 순서 | # | 제목 | 핵심 키워드 | 이슈/PR |
+|------|---|------|------------|---------|
+| 11 | 11 | [Java 25를 쓰려면 Gradle 9가 필수다](blog-11-gradle-9-java25-upgrade.md) | Java 25, Gradle 9, Virtual Threads, JaCoCo, ArchUnit | #126, PR #125 |
+| 12 | 12 | [로컬 올 그린, CI 올 레드 — 통합 테스트 20건 수정기](blog-12-ci-integration-test-fix.md) | Flyway+H2, SecurityFilterChain, TestConfiguration, Redis 레이스 컨디션 | PR #127, #130, #132 |
+| 13 | 13 | [로컬 올 그린, CI 올 레드 — WebSocket 통합 테스트 수정기 2탄](blog-13-ci-integration-test-fix-2.md) | Testcontainers Redis, WebSocket 테스트, 최종 해결 | PR #137 |
+
+---
+
+## Flutter 프론트엔드
+
+| 순서 | # | 제목 | 핵심 키워드 |
+|------|---|------|------------|
+| 14 | 14 | [Flutter에서도 Clean Architecture가 필요할까](blog-14-flutter-clean-architecture.md) | 4레이어, GetIt+Injectable DI, GoRouter 인증 가드, Cubit vs BLoC |
+| 15 | 15 | [Flutter 실시간 채팅 — WebSocket Facade 패턴과 Optimistic UI](blog-15-flutter-realtime-websocket.md) | STOMP, Facade + 4 Manager, Exponential Backoff, Event Dedup, Optimistic UI |
+| 16 | 16 | [Flutter UX 깊이 파기 — 테마, 생체인증, 오프라인 캐시](blog-16-flutter-ux-features.md) | Material 3 테마, 생체인증 Grace Period, Drift FTS5, copyWith 버그 |
+
+---
+
+## 배포 자동화
+
+| 순서 | # | 제목 | 핵심 키워드 |
+|------|---|------|------------|
+| 17 | 17 | [Fastlane으로 iOS·macOS·Android 한 번에 배포하기](blog-17-fastlane-multiplatform.md) | 통합 Fastfile, ASC API Key, macOS 재서명, Google Play 트랙 |
+| 18 | 18 | [Flutter CI/CD 설계하기 — GitHub Actions로 테스트부터 스토어 배포까지](blog-18-flutter-cicd-github-actions.md) | 재사용 워크플로우, 병렬 빌드, 시크릿 관리, 빌드 캐시, 비용 |
+
+---
+
+## 인프라 회고
+
+| 순서 | # | 제목 | 핵심 키워드 |
+|------|---|------|------------|
+| 19 | 19 | [카나리아 3인스턴스에서 Blue-Green 단일 운영으로 — NAS CPU가 항복했다](blog-19-nas-bluegreen-rollback.md) | Celeron J4125, CPU 경합, profiles 조건부 기동, Blue-Green 회귀 |
+
+---
+
+## 읽기 가이드
+
+### 처음부터 끝까지 따라가고 싶다면
+
+위 순서(00 → 01 → 02 → ... → 18)대로 읽으면 된다. 실제 개발 순서 그대로다.
+
+### 관심 분야만 골라 읽고 싶다면
+
+| 관심사 | 추천 글 |
+|--------|---------|
+| **아키텍처 설계** | 01 → 02 → 14 |
+| **실시간 채팅 구현** | 01 → 08 → 15 |
+| **보안** | 04 → 05 |
+| **캐시와 성능** | 06 → 10 |
+| **인프라와 배포** | 04 → 07 → 09 → 17 → 18 → 19 |
+| **Flutter 앱 개발** | 14 → 15 → 16 |
+| **CI/CD 전체** | 07 → 17 → 18 |
+| **트러블슈팅** | 03 → 11 → 12 → 13 |
+
+---
+
+## 기술 스택 요약
+
+| 영역 | 기술 |
+|------|------|
+| **백엔드** | Java 25, Spring Boot 3.5.6, PostgreSQL 16, Redis 7, MinIO |
+| **프론트엔드** | Flutter 3.8+, BLoC/Cubit, Drift(SQLite), STOMP WebSocket |
+| **인프라** | Docker Compose, Nginx, Blue-Green 배포 (NAS), 카나리아 롤링 (확장 시) |
+| **모니터링** | Prometheus, Grafana, Loki, Zipkin, Alertmanager |
+| **CI/CD** | GitHub Actions, Fastlane, GHCR |
+| **배포 대상** | NAS(백엔드), App Store(iOS/macOS), Google Play(Android) |
+
+---
+
+모든 코드는 [GitHub 저장소](https://github.com/with-co-talk/co-talk)에서 확인할 수 있다.


### PR DESCRIPTION
## 개요
삭제됐던 NAS/배포/모니터링 및 Flutter 클라이언트 관련 블로그 문서를 리포지토리 내에 다시 복원합니다.

## 변경 사항
- NAS Blue-Green 단일 인스턴스 운영, 롤백 전략, 배포 스크립트 구조를 다루는 블로그() 추가
- 실시간 채팅 아키텍처, Redis/모니터링/테스트 전략 등 서버 사이드 글(, ) 중 일부를 선별 복원 (현재 브랜치 기준 01 + 14~19)
- Flutter 클린 아키텍처/실시간 WebSocket/UX 기능/CI-CD 파이프라인 관련 문서() 추가
- 를 통해 전체 시리즈 목차 및 문서 링크를 한 곳에서 관리

## 통계
- 브랜치: docs/nas-bluegreen-prometheus-from-canary
- 변경 파일 수: 8
- 추가/삭제: +4189 / -0
- 관련 이슈: Closes #148

## 체크리스트
- [ ] 문서 내 코드/명령 예제가 최신 인프라 구성(Tailscale, Blue-Green, Prometheus 등)과 일치하는지 검토
- [ ] 외부에 공개되면 안 되는 민감 정보(호스트명, 비밀번호, 토큰 등)가 포함되어 있지 않은지 재확인
- [ ] README나 기타 문서에서 이 블로그 인덱스를 참조할지 여부 검토

## 테스트 방법
- [ ] 로컬에서 Markdown 렌더링 확인 (VSCode/IDE/뷰어 등)
- [ ] PlantUML/다이어그램 블록이 깨지지 않는지 확인


Made with [Cursor](https://cursor.com)