### PR TITLE
[CHORE] /actuator/prometheus 공개 허용

### DIFF
--- a/src/main/java/com/cotalk/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/cotalk/infrastructure/security/SecurityConfig.java
@@ -128,7 +128,7 @@ public class SecurityConfig {
                         ).permitAll()
                         .requestMatchers("/ws/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
-                        .requestMatchers("/actuator/health", "/actuator/health/**", "/actuator/info").permitAll()
+                        .requestMatchers("/actuator/health", "/actuator/health/**", "/actuator/info", "/actuator/prometheus").permitAll()
                         // 관리자 전용 엔드포인트
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                         .requestMatchers("/actuator/**").hasRole("ADMIN")


### PR DESCRIPTION
## 개요
Prometheus가 애플리케이션 메트릭을 수집할 수 있도록 Spring Security에서 `/actuator/prometheus` 엔드포인트 접근을 공개로 허용합니다.

## 변경 사항
- `SecurityConfig`에서 `/actuator/prometheus`를 `permitAll()`에 추가
- 그 외 `/actuator/**`는 기존대로 `ADMIN` 권한 필요

## 통계
- 변경 파일 수: 1
- 관련 파일: `SecurityConfig.java`

## 체크리스트
- [ ] Prometheus scrape가 200으로 성공하는지 확인
- [ ] `/actuator/**` 다른 엔드포인트는 여전히 관리자만 접근 가능한지 확인

Made with [Cursor](https://cursor.com)