### PR TITLE
[BUG/FEAT] 비밀번호 재설정 코드 검증 수정 및 브루트포스 방어

### DIFF
--- a/src/main/java/com/cotalk/adapter/outbound/persistence/auth/PasswordResetTokenJpaRepository.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/auth/PasswordResetTokenJpaRepository.java
@@ -1,9 +1,11 @@
 package com.cotalk.adapter.outbound.persistence.auth;
 
 import com.cotalk.domain.entity.PasswordResetToken;
+import com.cotalk.domain.model.Email;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -31,7 +33,8 @@ public interface PasswordResetTokenJpaRepository extends JpaRepository<PasswordR
      * @param verificationCode 6자리 인증 코드
      * @return 비밀번호 재설정 토큰 (Optional)
      */
-    Optional<PasswordResetToken> findByEmailAndVerificationCode(String email, String verificationCode);
+    @Query("SELECT t FROM PasswordResetToken t WHERE t.email = :email AND t.verificationCode = :code")
+    Optional<PasswordResetToken> findByEmailAndVerificationCode(@Param("email") Email email, @Param("code") String code);
 
     /**
      * 사용자 ID로 비밀번호 재설정 토큰을 삭제한다.

--- a/src/main/java/com/cotalk/adapter/outbound/persistence/auth/PasswordResetTokenRepositoryAdapter.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/auth/PasswordResetTokenRepositoryAdapter.java
@@ -1,6 +1,7 @@
 package com.cotalk.adapter.outbound.persistence.auth;
 
 import com.cotalk.domain.entity.PasswordResetToken;
+import com.cotalk.domain.model.Email;
 import com.cotalk.domain.port.outbound.PasswordResetTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -51,7 +52,7 @@ public class PasswordResetTokenRepositoryAdapter implements PasswordResetTokenRe
      */
     @Override
     public Optional<PasswordResetToken> findByEmailAndVerificationCode(String email, String verificationCode) {
-        return jpaRepository.findByEmailAndVerificationCode(email, verificationCode);
+        return jpaRepository.findByEmailAndVerificationCode(new Email(email), verificationCode);
     }
 
     /**


### PR DESCRIPTION
## 개요
비밀번호 재설정 인증 코드 검증 시 서버 오류(500) 수정 및 브루트포스 방어 추가.

## 변경사항

### 버그 수정
- `findByEmailAndVerificationCode`: `Email` 값 객체 타입 불일치 → JPQL 명시 쿼리로 전환

### 브루트포스 방어
- `PasswordResetToken`에 `failedAttempts` 필드 추가 (5회 초과 시 토큰 무효화)
- `verifyCode`: boolean → void 반환, 실패 시 사유별 예외 발생
  - `invalidCode`: 코드 불일치
  - `expired`: 만료
  - `alreadyUsed`: 이미 사용됨
  - `maxAttemptsExceeded`: 입력 횟수 초과
- `application.yml`: 3개 엔드포인트 Rate Limit 추가

### 이메일 발송 개선
- `MailProperties`: `@ConfigurationProperties`로 메일 설정 타입 안전 바인딩
- `SmtpEmailSender`: `setFrom` 명시적 설정, `@ConditionalOnExpression`으로 빈 문자열 host 필터링

## 통계
- 변경 파일: 13개
- 추가: 569줄 / 삭제: 16줄
- 커밋: 4개
- 테스트: 19개 추가

Closes #151
Closes #153

## 체크리스트
- [x] 코드 변경 완료
- [x] 테스트 추가 (19개)
- [x] 빌드 통과 (`./gradlew build`)
- [ ] 배포 후 실기기 테스트

## 테스트 방법
1. 비밀번호 찾기 > 이메일 입력 > 인증 코드 발송
2. 잘못된 코드 입력 → "인증 코드가 일치하지 않습니다" 에러
3. 5회 실패 → "인증 코드 입력 횟수를 초과했습니다" 에러
4. 정상 코드 입력 → 비밀번호 변경 화면 전환
5. 비밀번호 변경 완료 확인