### PR TITLE
fix(user): 회원 탈퇴 시 FK 제약 위반으로 탈퇴 불가하던 문제 해결

### DIFF
--- a/src/main/java/com/cotalk/adapter/outbound/persistence/friend/HiddenFriendJpaRepository.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/friend/HiddenFriendJpaRepository.java
@@ -46,4 +46,14 @@ public interface HiddenFriendJpaRepository extends JpaRepository<HiddenFriend, L
      * @param userId 사용자 ID
      */
     void deleteByUserId(Long userId);
+
+    /**
+     * 사용자 ID 또는 친구 ID로 친구 숨김 정보를 삭제한다.
+     * 회원 탈퇴 시 해당 사용자가 숨긴 레코드(user_id)와
+     * 타인이 해당 사용자를 숨긴 레코드(friend_id)를 모두 정리하는 데 사용한다.
+     *
+     * @param userId 사용자 ID
+     * @param friendId 친구 ID
+     */
+    void deleteByUserIdOrFriendId(Long userId, Long friendId);
 }

--- a/src/main/java/com/cotalk/adapter/outbound/persistence/friend/HiddenFriendRepositoryAdapter.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/friend/HiddenFriendRepositoryAdapter.java
@@ -89,11 +89,13 @@ public class HiddenFriendRepositoryAdapter implements HiddenFriendRepository {
 
     /**
      * 사용자 ID로 모든 친구 숨김 정보를 삭제한다.
+     * 회원 탈퇴 정합성을 위해 해당 사용자가 숨긴 레코드(user_id)뿐 아니라
+     * 타인이 해당 사용자를 숨긴 레코드(friend_id)도 함께 삭제한다.
      *
      * @param userId 사용자 ID
      */
     @Override
     public void deleteByUserId(Long userId) {
-        hiddenFriendJpaRepository.deleteByUserId(userId);
+        hiddenFriendJpaRepository.deleteByUserIdOrFriendId(userId, userId);
     }
 }

--- a/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageJpaRepository.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageJpaRepository.java
@@ -273,4 +273,11 @@ public interface MessageJpaRepository extends JpaRepository<Message, Long> {
     List<Message> findMessagesWithLinkPreview(
             @Param("chatRoomId") Long chatRoomId,
             Pageable pageable);
+
+    /**
+     * 발신자 ID로 해당 사용자가 보낸 모든 메시지를 물리적으로 삭제한다.
+     *
+     * @param senderId 발신자(사용자) ID
+     */
+    void deleteBySenderId(Long senderId);
 }

--- a/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageReactionJpaRepository.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageReactionJpaRepository.java
@@ -55,9 +55,13 @@ public interface MessageReactionJpaRepository extends JpaRepository<MessageReact
      * 메시지를 물리적으로 삭제하기 전에, 해당 메시지를 참조하는 리액션의
      * 외래키 제약 위반을 방지하기 위해 사용한다.
      *
+     * <p>벌크 삭제 JPQL은 1차 캐시(영속성 컨텍스트)를 우회하므로,
+     * 같은 트랜잭션 내 후속 작업이 삭제된 리액션을 stale 상태로 읽지 않도록
+     * {@code flushAutomatically}/{@code clearAutomatically}로 실행 전 flush, 실행 후 clear를 보장한다.</p>
+     *
      * @param senderId 메시지 발신자(사용자) ID
      */
-    @Modifying
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("DELETE FROM MessageReaction r WHERE r.messageId IN " +
            "(SELECT m.id FROM Message m WHERE m.senderId = :senderId)")
     void deleteByMessageSenderId(@Param("senderId") Long senderId);

--- a/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageReactionJpaRepository.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageReactionJpaRepository.java
@@ -3,6 +3,9 @@ package com.cotalk.adapter.outbound.persistence.message;
 import com.cotalk.domain.entity.Emoji;
 import com.cotalk.domain.entity.MessageReaction;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -39,4 +42,23 @@ public interface MessageReactionJpaRepository extends JpaRepository<MessageReact
      * @param messageId 메시지 ID
      */
     void deleteByMessageId(Long messageId);
+
+    /**
+     * 사용자 ID로 해당 사용자가 남긴 모든 리액션을 삭제한다.
+     *
+     * @param userId 사용자 ID
+     */
+    void deleteByUserId(Long userId);
+
+    /**
+     * 특정 발신자가 보낸 메시지에 달린 모든 리액션을 삭제한다.
+     * 메시지를 물리적으로 삭제하기 전에, 해당 메시지를 참조하는 리액션의
+     * 외래키 제약 위반을 방지하기 위해 사용한다.
+     *
+     * @param senderId 메시지 발신자(사용자) ID
+     */
+    @Modifying
+    @Query("DELETE FROM MessageReaction r WHERE r.messageId IN " +
+           "(SELECT m.id FROM Message m WHERE m.senderId = :senderId)")
+    void deleteByMessageSenderId(@Param("senderId") Long senderId);
 }

--- a/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageReactionRepositoryAdapter.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageReactionRepositoryAdapter.java
@@ -74,4 +74,24 @@ public class MessageReactionRepositoryAdapter implements MessageReactionReposito
     public void deleteByMessageId(Long messageId) {
         jpaRepository.deleteByMessageId(messageId);
     }
+
+    /**
+     * 사용자 ID로 해당 사용자가 남긴 모든 리액션을 삭제한다.
+     *
+     * @param userId 사용자 ID
+     */
+    @Override
+    public void deleteByUserId(Long userId) {
+        jpaRepository.deleteByUserId(userId);
+    }
+
+    /**
+     * 특정 발신자가 보낸 메시지에 달린 모든 리액션을 삭제한다.
+     *
+     * @param senderId 메시지 발신자(사용자) ID
+     */
+    @Override
+    public void deleteByMessageSenderId(Long senderId) {
+        jpaRepository.deleteByMessageSenderId(senderId);
+    }
 }

--- a/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageRepositoryAdapter.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageRepositoryAdapter.java
@@ -300,4 +300,14 @@ public class MessageRepositoryAdapter implements MessageRepository {
     public List<Message> findMessagesWithLinkPreview(Long chatRoomId, org.springframework.data.domain.Pageable pageable) {
         return messageJpaRepository.findMessagesWithLinkPreview(chatRoomId, pageable);
     }
+
+    /**
+     * 발신자 ID로 해당 사용자가 보낸 모든 메시지를 삭제한다.
+     *
+     * @param senderId 발신자(사용자) ID
+     */
+    @Override
+    public void deleteBySenderId(Long senderId) {
+        messageJpaRepository.deleteBySenderId(senderId);
+    }
 }

--- a/src/main/java/com/cotalk/adapter/outbound/persistence/refreshtoken/RefreshTokenJpaRepository.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/refreshtoken/RefreshTokenJpaRepository.java
@@ -42,6 +42,20 @@ public interface RefreshTokenJpaRepository extends JpaRepository<RefreshToken, L
     void revokeAllByUserId(@Param("userId") Long userId);
 
     /**
+     * 사용자의 모든 Refresh Token을 물리적으로 삭제한다.
+     *
+     * <p>회원 탈퇴 시 {@code refresh_tokens.user_id}에 걸린
+     * {@code fk_refresh_tokens_user}(cascade 없음) 제약 위반을 방지하기 위해
+     * 사용자 삭제 이전에 토큰 행을 실제로 제거한다.</p>
+     *
+     * @param userId 사용자 ID
+     * @return 삭제된 토큰 수
+     */
+    @Modifying
+    @Query("DELETE FROM RefreshToken r WHERE r.userId = :userId")
+    int deleteByUserId(@Param("userId") Long userId);
+
+    /**
      * 만료된 토큰을 삭제한다.
      *
      * @param now 현재 시간

--- a/src/main/java/com/cotalk/adapter/outbound/persistence/refreshtoken/RefreshTokenRepositoryAdapter.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/refreshtoken/RefreshTokenRepositoryAdapter.java
@@ -56,6 +56,14 @@ public class RefreshTokenRepositoryAdapter implements RefreshTokenRepository {
      * {@inheritDoc}
      */
     @Override
+    public void deleteByUserId(Long userId) {
+        jpaRepository.deleteByUserId(userId);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public int deleteExpiredTokens() {
         return jpaRepository.deleteByExpiresAtBefore(LocalDateTime.now());
     }

--- a/src/main/java/com/cotalk/adapter/outbound/persistence/report/ReportJpaRepository.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/report/ReportJpaRepository.java
@@ -4,6 +4,9 @@ import com.cotalk.domain.entity.Report;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -80,4 +83,23 @@ public interface ReportJpaRepository extends JpaRepository<Report, Long> {
      * @param reporterId 신고자 ID
      */
     void deleteByReporterId(Long reporterId);
+
+    /**
+     * 피신고자 ID로 모든 신고를 삭제한다.
+     *
+     * @param reportedUserId 피신고자 ID
+     */
+    void deleteByReportedUserId(Long reportedUserId);
+
+    /**
+     * 특정 발신자가 보낸 메시지를 대상으로 한 모든 신고를 삭제한다.
+     * 메시지를 물리적으로 삭제하기 전에, 해당 메시지를 참조하는 신고의
+     * 외래키 제약 위반을 방지하기 위해 사용한다.
+     *
+     * @param senderId 메시지 발신자(사용자) ID
+     */
+    @Modifying
+    @Query("DELETE FROM Report r WHERE r.reportedMessageId IN " +
+           "(SELECT m.id FROM Message m WHERE m.senderId = :senderId)")
+    void deleteByReportedMessageSenderId(@Param("senderId") Long senderId);
 }

--- a/src/main/java/com/cotalk/adapter/outbound/persistence/report/ReportRepositoryAdapter.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/report/ReportRepositoryAdapter.java
@@ -164,4 +164,24 @@ public class ReportRepositoryAdapter implements ReportRepository {
     public void deleteByReporterId(Long reporterId) {
         reportJpaRepository.deleteByReporterId(reporterId);
     }
+
+    /**
+     * 피신고자 ID로 모든 신고를 삭제한다.
+     *
+     * @param reportedUserId 피신고자 ID
+     */
+    @Override
+    public void deleteByReportedUserId(Long reportedUserId) {
+        reportJpaRepository.deleteByReportedUserId(reportedUserId);
+    }
+
+    /**
+     * 특정 발신자가 보낸 메시지를 대상으로 한 모든 신고를 삭제한다.
+     *
+     * @param senderId 메시지 발신자(사용자) ID
+     */
+    @Override
+    public void deleteByReportedMessageSenderId(Long senderId) {
+        reportJpaRepository.deleteByReportedMessageSenderId(senderId);
+    }
 }

--- a/src/main/java/com/cotalk/application/service/user/DeleteAccountService.java
+++ b/src/main/java/com/cotalk/application/service/user/DeleteAccountService.java
@@ -113,7 +113,9 @@ public class DeleteAccountService implements DeleteAccountUseCase {
         hiddenFriendRepository.deleteByUserId(userId);
         notificationSettingRepository.deleteByUserId(userId);
         termsAgreementRepository.deleteByUserId(userId);
-        refreshTokenRepository.revokeAllByUserId(userId);
+        // refresh_tokens.user_id에 fk_refresh_tokens_user(cascade 없음) 제약이 있어
+        // revoke(플래그만 변경)로는 user 삭제 시 FK 위반이 발생한다. 행을 실제 삭제한다.
+        refreshTokenRepository.deleteByUserId(userId);
         profileHistoryRepository.deleteByUserId(userId);
 
         // 사용자 삭제

--- a/src/main/java/com/cotalk/application/service/user/DeleteAccountService.java
+++ b/src/main/java/com/cotalk/application/service/user/DeleteAccountService.java
@@ -24,6 +24,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class DeleteAccountService implements DeleteAccountUseCase {
 
     private final UserRepository userRepository;
+    private final MessageRepository messageRepository;
+    private final MessageReactionRepository messageReactionRepository;
     private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final FriendRepository friendRepository;
     private final FriendRequestRepository friendRequestRepository;
@@ -79,7 +81,26 @@ public class DeleteAccountService implements DeleteAccountUseCase {
     }
 
     private void deleteUserData(Long userId, User user) {
-        // 관련 데이터 삭제 (순서 중요 - 외래키 제약)
+        // 관련 데이터 삭제 (순서 중요 - 외래키 제약: 자식 → 부모 순)
+
+        // 1) 메시지 반응 정리
+        //    - 이 사용자가 남긴 반응 (message_reactions.user_id)
+        //    - 이 사용자의 메시지에 타인이 남긴 반응 (messages 삭제 전 선행 정리)
+        messageReactionRepository.deleteByUserId(userId);
+        messageReactionRepository.deleteByMessageSenderId(userId);
+
+        // 2) 신고 정리
+        //    - 이 사용자가 한 신고 (reports.reporter_id)
+        //    - 이 사용자를 대상으로 한 신고 (reports.reported_user_id)
+        //    - 이 사용자의 메시지를 대상으로 한 신고 (reports.reported_message_id, messages 삭제 전 선행 정리)
+        reportRepository.deleteByReporterId(userId);
+        reportRepository.deleteByReportedUserId(userId);
+        reportRepository.deleteByReportedMessageSenderId(userId);
+
+        // 3) 이 사용자가 보낸 메시지 삭제 (messages.sender_id)
+        //    위 반응/신고를 먼저 정리했으므로 이 시점에 안전하게 삭제 가능
+        messageRepository.deleteBySenderId(userId);
+
         chatRoomMemberRepository.deleteByUserId(userId);
         friendRepository.deleteByUserId(userId);
         friendRequestRepository.deleteByUserId(userId);
@@ -88,7 +109,7 @@ public class DeleteAccountService implements DeleteAccountUseCase {
         emailVerificationTokenRepository.deleteByUserId(userId);
         blockRepository.deleteByBlockerId(userId);
         blockRepository.deleteByBlockedId(userId);
-        reportRepository.deleteByReporterId(userId);
+        // 이 사용자가 숨긴 레코드(user_id)와 타인이 이 사용자를 숨긴 레코드(friend_id)를 모두 삭제
         hiddenFriendRepository.deleteByUserId(userId);
         notificationSettingRepository.deleteByUserId(userId);
         termsAgreementRepository.deleteByUserId(userId);

--- a/src/main/java/com/cotalk/domain/port/outbound/MessageReactionRepository.java
+++ b/src/main/java/com/cotalk/domain/port/outbound/MessageReactionRepository.java
@@ -53,4 +53,21 @@ public interface MessageReactionRepository {
      * @param messageId 메시지 ID
      */
     void deleteByMessageId(Long messageId);
+
+    /**
+     * 특정 사용자가 남긴 모든 반응을 삭제한다.
+     * 회원 탈퇴 시 사용자가 남긴 메시지 반응을 정리하는 데 사용한다.
+     *
+     * @param userId 사용자 ID
+     */
+    void deleteByUserId(Long userId);
+
+    /**
+     * 특정 발신자가 보낸 메시지에 달린 모든 반응을 삭제한다.
+     * 회원 탈퇴로 해당 사용자의 메시지를 삭제하기 전에,
+     * 타인이 그 메시지에 남긴 반응을 먼저 정리하는 데 사용한다.
+     *
+     * @param senderId 메시지 발신자(사용자) ID
+     */
+    void deleteByMessageSenderId(Long senderId);
 }

--- a/src/main/java/com/cotalk/domain/port/outbound/MessageRepository.java
+++ b/src/main/java/com/cotalk/domain/port/outbound/MessageRepository.java
@@ -195,4 +195,12 @@ public interface MessageRepository {
      * @return 링크 미리보기가 있는 메시지 목록 (최신순)
      */
     List<Message> findMessagesWithLinkPreview(Long chatRoomId, org.springframework.data.domain.Pageable pageable);
+
+    /**
+     * 특정 발신자가 보낸 모든 메시지를 삭제한다.
+     * 회원 탈퇴 시 사용자가 보낸 메시지를 정리하는 데 사용한다.
+     *
+     * @param senderId 발신자(사용자) ID
+     */
+    void deleteBySenderId(Long senderId);
 }

--- a/src/main/java/com/cotalk/domain/port/outbound/RefreshTokenRepository.java
+++ b/src/main/java/com/cotalk/domain/port/outbound/RefreshTokenRepository.java
@@ -44,6 +44,16 @@ public interface RefreshTokenRepository {
     void revokeAllByUserId(Long userId);
 
     /**
+     * 사용자의 모든 Refresh Token을 물리적으로 삭제한다.
+     *
+     * <p>회원 탈퇴 시 {@code fk_refresh_tokens_user}(cascade 없음) 제약 위반을
+     * 방지하기 위해, 폐기(revoke)가 아닌 실제 삭제가 필요한 경우 사용한다.</p>
+     *
+     * @param userId 사용자 ID
+     */
+    void deleteByUserId(Long userId);
+
+    /**
      * 만료된 모든 Refresh Token을 삭제한다.
      * 스케줄러에서 주기적으로 호출하여 정리한다.
      *

--- a/src/main/java/com/cotalk/domain/port/outbound/ReportRepository.java
+++ b/src/main/java/com/cotalk/domain/port/outbound/ReportRepository.java
@@ -118,4 +118,21 @@ public interface ReportRepository {
      * @param reporterId 신고자 ID
      */
     void deleteByReporterId(Long reporterId);
+
+    /**
+     * 특정 사용자가 신고당한 모든 신고를 삭제한다.
+     * 회원 탈퇴 시 해당 사용자를 가리키는 피신고 기록을 정리하는 데 사용한다.
+     *
+     * @param reportedUserId 피신고자 ID
+     */
+    void deleteByReportedUserId(Long reportedUserId);
+
+    /**
+     * 특정 발신자가 보낸 메시지를 대상으로 한 모든 신고를 삭제한다.
+     * 회원 탈퇴로 해당 사용자의 메시지를 삭제하기 전에,
+     * 그 메시지를 가리키는 신고 기록(reported_message_id)을 먼저 정리하는 데 사용한다.
+     *
+     * @param senderId 메시지 발신자(사용자) ID
+     */
+    void deleteByReportedMessageSenderId(Long senderId);
 }

--- a/src/test/java/com/cotalk/adapter/outbound/persistence/RefreshTokenRepositoryAdapterTest.java
+++ b/src/test/java/com/cotalk/adapter/outbound/persistence/RefreshTokenRepositoryAdapterTest.java
@@ -225,6 +225,39 @@ class RefreshTokenRepositoryAdapterTest {
         }
 
         @Test
+        @DisplayName("사용자의 모든 토큰을 물리적으로 삭제한다")
+        void should_deleteAllTokens_when_userIdProvided() {
+            // given
+            refreshTokenRepository.save(RefreshToken.builder()
+                    .id(100L)
+                    .userId(user.getId())
+                    .token("token-1")
+                    .expiresAt(LocalDateTime.now().plusDays(7))
+                    .revoked(false)
+                    .build());
+            refreshTokenRepository.save(RefreshToken.builder()
+                    .id(101L)
+                    .userId(user.getId())
+                    .token("token-2")
+                    .expiresAt(LocalDateTime.now().plusDays(7))
+                    .revoked(true)
+                    .build());
+
+            entityManager.flush();
+            entityManager.clear();
+
+            // when
+            refreshTokenRepository.deleteByUserId(user.getId());
+
+            entityManager.flush();
+            entityManager.clear();
+
+            // then: revoke 여부와 무관하게 행 자체가 사라져야 한다
+            assertThat(refreshTokenRepository.findByToken("token-1")).isEmpty();
+            assertThat(refreshTokenRepository.findByToken("token-2")).isEmpty();
+        }
+
+        @Test
         @DisplayName("만료된 토큰이 없으면 0을 반환한다")
         void should_returnZero_when_noExpiredTokens() {
             // given

--- a/src/test/java/com/cotalk/application/service/user/DeleteAccountServiceFkIntegrationTest.java
+++ b/src/test/java/com/cotalk/application/service/user/DeleteAccountServiceFkIntegrationTest.java
@@ -1,0 +1,366 @@
+package com.cotalk.application.service.user;
+
+import com.cotalk.adapter.outbound.persistence.auth.EmailVerificationTokenRepositoryAdapter;
+import com.cotalk.adapter.outbound.persistence.auth.PasswordResetTokenRepositoryAdapter;
+import com.cotalk.adapter.outbound.persistence.auth.TermsAgreementRepositoryAdapter;
+import com.cotalk.adapter.outbound.persistence.chatroom.ChatRoomMemberRepositoryAdapter;
+import com.cotalk.adapter.outbound.persistence.chatroom.ChatRoomRepositoryAdapter;
+import com.cotalk.adapter.outbound.persistence.friend.BlockRepositoryAdapter;
+import com.cotalk.adapter.outbound.persistence.friend.FriendRepositoryAdapter;
+import com.cotalk.adapter.outbound.persistence.friend.FriendRequestRepositoryAdapter;
+import com.cotalk.adapter.outbound.persistence.friend.HiddenFriendRepositoryAdapter;
+import com.cotalk.adapter.outbound.persistence.mapper.UserMapper;
+import com.cotalk.adapter.outbound.persistence.message.MessageReactionRepositoryAdapter;
+import com.cotalk.adapter.outbound.persistence.message.MessageRepositoryAdapter;
+import com.cotalk.adapter.outbound.persistence.notification.DeviceTokenRepositoryAdapter;
+import com.cotalk.adapter.outbound.persistence.notification.NotificationSettingRepositoryAdapter;
+import com.cotalk.adapter.outbound.persistence.profile.ProfileHistoryRepositoryAdapter;
+import com.cotalk.adapter.outbound.persistence.refreshtoken.RefreshTokenRepositoryAdapter;
+import com.cotalk.adapter.outbound.persistence.report.ReportRepositoryAdapter;
+import com.cotalk.adapter.outbound.persistence.user.UserRepositoryAdapter;
+import com.cotalk.domain.entity.ChatRoom;
+import com.cotalk.domain.entity.ChatRoom.ChatRoomType;
+import com.cotalk.domain.entity.Emoji;
+import com.cotalk.domain.entity.HiddenFriend;
+import com.cotalk.domain.entity.Message;
+import com.cotalk.domain.entity.Message.MessageType;
+import com.cotalk.domain.entity.MessageReaction;
+import com.cotalk.domain.entity.Report;
+import com.cotalk.domain.entity.Report.ReportReason;
+import com.cotalk.domain.entity.Report.ReportStatus;
+import com.cotalk.domain.entity.Report.ReportType;
+import com.cotalk.domain.entity.User;
+import com.cotalk.domain.model.Email;
+import com.cotalk.domain.port.outbound.HiddenFriendRepository;
+import com.cotalk.domain.port.outbound.MessageReactionRepository;
+import com.cotalk.domain.port.outbound.MessageRepository;
+import com.cotalk.domain.port.outbound.PasswordEncoderPort;
+import com.cotalk.domain.port.outbound.ReportRepository;
+import com.cotalk.domain.port.outbound.UserRepository;
+import com.cotalk.infrastructure.config.JpaAuditingConfig;
+import com.cotalk.infrastructure.security.SpringPasswordEncoderAdapter;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * 회원 탈퇴 FK 제약 회귀 통합 테스트.
+ *
+ * <p>실제 운영 스키마(V1__init_schema.sql)에 존재하는 외래키 제약을 H2에 그대로 적용한 뒤
+ * ({@code sql/delete-account-fk-constraints.sql}), 메시지/반응/피신고/피숨김(friend_id) 데이터를
+ * 가진 실사용자가 탈퇴할 때 FK 위반 없이 탈퇴되고 관련 레코드가 정리되는지 검증한다.</p>
+ *
+ * <p>엔티티에는 {@code @ManyToOne}/{@code @ForeignKey} 매핑이 없어 {@code ddl-auto: create-drop}만으로는
+ * FK 제약이 생성되지 않으므로, 순수 Mockito 테스트로는 이 결함을 잡을 수 없다. 이 테스트는
+ * 실제 DB FK 제약을 태워 회귀를 방지한다.</p>
+ *
+ * @author seunggu.lee
+ */
+@DataJpaTest
+@ActiveProfiles("test")
+@Import({
+        DeleteAccountServiceFkIntegrationTest.TestBeans.class,
+        UserRepositoryAdapter.class,
+        MessageRepositoryAdapter.class,
+        MessageReactionRepositoryAdapter.class,
+        ChatRoomRepositoryAdapter.class,
+        ChatRoomMemberRepositoryAdapter.class,
+        FriendRepositoryAdapter.class,
+        FriendRequestRepositoryAdapter.class,
+        BlockRepositoryAdapter.class,
+        ReportRepositoryAdapter.class,
+        HiddenFriendRepositoryAdapter.class,
+        DeviceTokenRepositoryAdapter.class,
+        NotificationSettingRepositoryAdapter.class,
+        PasswordResetTokenRepositoryAdapter.class,
+        EmailVerificationTokenRepositoryAdapter.class,
+        TermsAgreementRepositoryAdapter.class,
+        RefreshTokenRepositoryAdapter.class,
+        ProfileHistoryRepositoryAdapter.class,
+        UserMapper.class,
+        JpaAuditingConfig.class
+})
+@Sql(scripts = "/sql/delete-account-fk-constraints.sql",
+        executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+@DisplayName("DeleteAccountService FK 제약 통합 테스트")
+class DeleteAccountServiceFkIntegrationTest {
+
+    private static final String RAW_PASSWORD = "password123";
+
+    @Autowired
+    private DeleteAccountService deleteAccountService;
+
+    @Autowired
+    private PasswordEncoderPort passwordEncoder;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private MessageRepository messageRepository;
+
+    @Autowired
+    private MessageReactionRepository messageReactionRepository;
+
+    @Autowired
+    private ReportRepository reportRepository;
+
+    @Autowired
+    private HiddenFriendRepository hiddenFriendRepository;
+
+    @Autowired
+    private UserRepositoryAdapter userRepositoryAdapter;
+
+    @Autowired
+    private ChatRoomRepositoryAdapter chatRoomRepository;
+
+    @Autowired
+    private MessageRepositoryAdapter messageRepositoryAdapter;
+
+    @Autowired
+    private MessageReactionRepositoryAdapter messageReactionRepositoryAdapter;
+
+    @Autowired
+    private ReportRepositoryAdapter reportRepositoryAdapter;
+
+    @Autowired
+    private HiddenFriendRepositoryAdapter hiddenFriendRepositoryAdapter;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    /**
+     * 탈퇴 대상 사용자. 메시지를 보낸 적이 있는 실사용자.
+     */
+    private User leavingUser;
+
+    /**
+     * 탈퇴 대상이 아닌 다른 사용자.
+     */
+    private User otherUser;
+
+    private Long leavingMessageId;
+
+    @BeforeEach
+    void setUp() {
+        leavingUser = userRepositoryAdapter.save(User.builder()
+                .id(1L)
+                .email(new Email("leaving@example.com"))
+                .passwordHash(passwordEncoder.encode(RAW_PASSWORD))
+                .nickname("탈퇴유저")
+                .build());
+
+        otherUser = userRepositoryAdapter.save(User.builder()
+                .id(2L)
+                .email(new Email("other@example.com"))
+                .passwordHash("hash")
+                .nickname("상대유저")
+                .build());
+
+        ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.builder()
+                .id(100L)
+                .type(ChatRoomType.DIRECT)
+                .build());
+
+        // 탈퇴 대상 사용자가 보낸 메시지 (messages.sender_id)
+        Message leavingMessage = messageRepositoryAdapter.save(Message.builder()
+                .id(1000L)
+                .chatRoomId(chatRoom.getId())
+                .senderId(leavingUser.getId())
+                .content("탈퇴 유저가 보낸 메시지")
+                .type(MessageType.TEXT)
+                .build());
+        leavingMessageId = leavingMessage.getId();
+
+        // 상대 사용자가 보낸 메시지 (탈퇴 후에도 남아 있어야 함)
+        Message otherMessage = messageRepositoryAdapter.save(Message.builder()
+                .id(1001L)
+                .chatRoomId(chatRoom.getId())
+                .senderId(otherUser.getId())
+                .content("상대가 보낸 메시지")
+                .type(MessageType.TEXT)
+                .build());
+
+        // 탈퇴 대상 사용자가 남긴 반응 (message_reactions.user_id) - 상대 메시지에 반응
+        messageReactionRepositoryAdapter.save(MessageReaction.builder()
+                .messageId(otherMessage.getId())
+                .userId(leavingUser.getId())
+                .emoji(Emoji.HEART)
+                .build());
+
+        // 상대 사용자가 탈퇴 대상의 메시지에 남긴 반응 (message_reactions.message_id -> leavingMessage)
+        messageReactionRepositoryAdapter.save(MessageReaction.builder()
+                .messageId(leavingMessage.getId())
+                .userId(otherUser.getId())
+                .emoji(Emoji.THUMBS_UP)
+                .build());
+
+        // 상대 사용자가 탈퇴 대상 사용자를 신고 (reports.reported_user_id)
+        reportRepositoryAdapter.save(Report.builder()
+                .id(2000L)
+                .reporterId(otherUser.getId())
+                .reportedUserId(leavingUser.getId())
+                .type(ReportType.USER)
+                .reason(ReportReason.SPAM)
+                .status(ReportStatus.PENDING)
+                .build());
+
+        // 상대 사용자가 탈퇴 대상의 메시지를 신고 (reports.reported_message_id -> leavingMessage)
+        reportRepositoryAdapter.save(Report.builder()
+                .id(2001L)
+                .reporterId(otherUser.getId())
+                .reportedMessageId(leavingMessage.getId())
+                .type(ReportType.MESSAGE)
+                .reason(ReportReason.SPAM)
+                .status(ReportStatus.PENDING)
+                .build());
+
+        // 탈퇴 대상 사용자가 한 신고 (reports.reporter_id)
+        reportRepositoryAdapter.save(Report.builder()
+                .id(2002L)
+                .reporterId(leavingUser.getId())
+                .reportedUserId(otherUser.getId())
+                .type(ReportType.USER)
+                .reason(ReportReason.SPAM)
+                .status(ReportStatus.PENDING)
+                .build());
+
+        // 상대 사용자가 탈퇴 대상 사용자를 숨김 (hidden_friends.friend_id -> leavingUser)
+        hiddenFriendRepositoryAdapter.save(HiddenFriend.builder()
+                .userId(otherUser.getId())
+                .friendId(leavingUser.getId())
+                .build());
+
+        // 탈퇴 대상 사용자가 상대를 숨김 (hidden_friends.user_id -> leavingUser)
+        hiddenFriendRepositoryAdapter.save(HiddenFriend.builder()
+                .userId(leavingUser.getId())
+                .friendId(otherUser.getId())
+                .build());
+
+        // 영속성 컨텍스트를 비워 이후 조회가 실제 DB 상태를 반영하도록 한다.
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    @Test
+    @DisplayName("메시지/반응/피신고/피숨김이 있는 실사용자도 FK 위반 없이 탈퇴되고 관련 레코드가 정리된다")
+    void should_deleteAccount_when_userHasMessagesReactionsReportsAndHiddenByOthers() {
+        // when & then: FK 위반(롤백) 없이 탈퇴 성공해야 한다
+        assertThatCode(() -> deleteAccountService.deleteAccount(leavingUser.getId(), RAW_PASSWORD))
+                .doesNotThrowAnyException();
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // 사용자 삭제됨
+        assertThat(userRepository.findById(leavingUser.getId())).isEmpty();
+        // 상대 사용자는 유지
+        assertThat(userRepository.findById(otherUser.getId())).isPresent();
+
+        // 탈퇴 사용자가 보낸 메시지 삭제됨
+        assertThat(messageRepository.findById(leavingMessageId)).isEmpty();
+
+        // 탈퇴 사용자가 남긴 반응 및 탈퇴 사용자의 메시지에 달린 반응 모두 삭제됨
+        assertThat(messageReactionRepository.findByMessageId(leavingMessageId)).isEmpty();
+
+        // 탈퇴 사용자를 가리키던 신고(피신고/피신고메시지) 및 탈퇴 사용자가 한 신고 모두 삭제됨
+        assertThat(reportRepository.findByReportedUserId(leavingUser.getId())).isEmpty();
+        assertThat(reportRepository.findByReporterId(leavingUser.getId())).isEmpty();
+        assertThat(reportRepository.count()).isZero();
+
+        // 탈퇴 사용자를 숨긴 타인 레코드(friend_id) 및 탈퇴 사용자가 숨긴 레코드(user_id) 모두 삭제됨
+        assertThat(hiddenFriendRepository.findByUserId(otherUser.getId())).isEmpty();
+        assertThat(hiddenFriendRepository.findByUserId(leavingUser.getId())).isEmpty();
+    }
+
+    /**
+     * 통합 테스트에서 도메인 서비스와 비밀번호 인코더 빈을 제공한다.
+     */
+    @TestConfiguration
+    static class TestBeans {
+
+        /**
+         * 비밀번호 인코더 포트 빈.
+         *
+         * @return 비밀번호 인코더 포트
+         */
+        @Bean
+        PasswordEncoderPort passwordEncoderPort() {
+            return new SpringPasswordEncoderAdapter(new BCryptPasswordEncoder());
+        }
+
+        /**
+         * 회원 탈퇴 서비스 빈.
+         *
+         * @param userRepository 사용자 레포지토리
+         * @param messageRepository 메시지 레포지토리
+         * @param messageReactionRepository 메시지 반응 레포지토리
+         * @param chatRoomMemberRepository 채팅방 멤버 레포지토리
+         * @param friendRepository 친구 레포지토리
+         * @param friendRequestRepository 친구 요청 레포지토리
+         * @param deviceTokenRepository 디바이스 토큰 레포지토리
+         * @param passwordResetTokenRepository 비밀번호 재설정 토큰 레포지토리
+         * @param emailVerificationTokenRepository 이메일 인증 토큰 레포지토리
+         * @param blockRepository 차단 레포지토리
+         * @param reportRepository 신고 레포지토리
+         * @param hiddenFriendRepository 친구 숨김 레포지토리
+         * @param notificationSettingRepository 알림 설정 레포지토리
+         * @param termsAgreementRepository 약관 동의 레포지토리
+         * @param refreshTokenRepository 리프레시 토큰 레포지토리
+         * @param profileHistoryRepository 프로필 히스토리 레포지토리
+         * @param passwordEncoder 비밀번호 인코더
+         * @return 회원 탈퇴 서비스
+         */
+        @Bean
+        DeleteAccountService deleteAccountService(
+                UserRepository userRepository,
+                MessageRepository messageRepository,
+                MessageReactionRepository messageReactionRepository,
+                com.cotalk.domain.port.outbound.ChatRoomMemberRepository chatRoomMemberRepository,
+                com.cotalk.domain.port.outbound.FriendRepository friendRepository,
+                com.cotalk.domain.port.outbound.FriendRequestRepository friendRequestRepository,
+                com.cotalk.domain.port.outbound.DeviceTokenRepository deviceTokenRepository,
+                com.cotalk.domain.port.outbound.PasswordResetTokenRepository passwordResetTokenRepository,
+                com.cotalk.domain.port.outbound.EmailVerificationTokenRepository emailVerificationTokenRepository,
+                com.cotalk.domain.port.outbound.BlockRepository blockRepository,
+                ReportRepository reportRepository,
+                HiddenFriendRepository hiddenFriendRepository,
+                com.cotalk.domain.port.outbound.NotificationSettingRepository notificationSettingRepository,
+                com.cotalk.domain.port.outbound.TermsAgreementRepository termsAgreementRepository,
+                com.cotalk.domain.port.outbound.RefreshTokenRepository refreshTokenRepository,
+                com.cotalk.domain.port.outbound.ProfileHistoryRepository profileHistoryRepository,
+                PasswordEncoderPort passwordEncoder) {
+            return new DeleteAccountService(
+                    userRepository,
+                    messageRepository,
+                    messageReactionRepository,
+                    chatRoomMemberRepository,
+                    friendRepository,
+                    friendRequestRepository,
+                    deviceTokenRepository,
+                    passwordResetTokenRepository,
+                    emailVerificationTokenRepository,
+                    blockRepository,
+                    reportRepository,
+                    hiddenFriendRepository,
+                    notificationSettingRepository,
+                    termsAgreementRepository,
+                    refreshTokenRepository,
+                    profileHistoryRepository,
+                    passwordEncoder);
+        }
+    }
+}

--- a/src/test/java/com/cotalk/application/service/user/DeleteAccountServiceFkIntegrationTest.java
+++ b/src/test/java/com/cotalk/application/service/user/DeleteAccountServiceFkIntegrationTest.java
@@ -25,6 +25,7 @@ import com.cotalk.domain.entity.HiddenFriend;
 import com.cotalk.domain.entity.Message;
 import com.cotalk.domain.entity.Message.MessageType;
 import com.cotalk.domain.entity.MessageReaction;
+import com.cotalk.domain.entity.RefreshToken;
 import com.cotalk.domain.entity.Report;
 import com.cotalk.domain.entity.Report.ReportReason;
 import com.cotalk.domain.entity.Report.ReportStatus;
@@ -35,6 +36,7 @@ import com.cotalk.domain.port.outbound.HiddenFriendRepository;
 import com.cotalk.domain.port.outbound.MessageReactionRepository;
 import com.cotalk.domain.port.outbound.MessageRepository;
 import com.cotalk.domain.port.outbound.PasswordEncoderPort;
+import com.cotalk.domain.port.outbound.RefreshTokenRepository;
 import com.cotalk.domain.port.outbound.ReportRepository;
 import com.cotalk.domain.port.outbound.UserRepository;
 import com.cotalk.infrastructure.config.JpaAuditingConfig;
@@ -52,6 +54,8 @@ import org.springframework.context.annotation.Import;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
+
+import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -120,6 +124,12 @@ class DeleteAccountServiceFkIntegrationTest {
 
     @Autowired
     private HiddenFriendRepository hiddenFriendRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private RefreshTokenRepositoryAdapter refreshTokenRepositoryAdapter;
 
     @Autowired
     private UserRepositoryAdapter userRepositoryAdapter;
@@ -250,6 +260,17 @@ class DeleteAccountServiceFkIntegrationTest {
                 .friendId(otherUser.getId())
                 .build());
 
+        // 탈퇴 대상 사용자의 Refresh Token (refresh_tokens.user_id -> leavingUser)
+        // revoke(플래그)만으로는 fk_refresh_tokens_user 제약 때문에 탈퇴 시 FK 위반이 발생하므로,
+        // 탈퇴 경로가 행을 실제 삭제하는지 검증하기 위한 픽스처.
+        refreshTokenRepositoryAdapter.save(RefreshToken.builder()
+                .id(3000L)
+                .userId(leavingUser.getId())
+                .token("leaving-user-refresh-token")
+                .expiresAt(LocalDateTime.now().plusDays(7))
+                .revoked(false)
+                .build());
+
         // 영속성 컨텍스트를 비워 이후 조회가 실제 DB 상태를 반영하도록 한다.
         entityManager.flush();
         entityManager.clear();
@@ -284,6 +305,10 @@ class DeleteAccountServiceFkIntegrationTest {
         // 탈퇴 사용자를 숨긴 타인 레코드(friend_id) 및 탈퇴 사용자가 숨긴 레코드(user_id) 모두 삭제됨
         assertThat(hiddenFriendRepository.findByUserId(otherUser.getId())).isEmpty();
         assertThat(hiddenFriendRepository.findByUserId(leavingUser.getId())).isEmpty();
+
+        // 탈퇴 사용자의 Refresh Token이 (revoke가 아니라) 실제로 삭제됨.
+        // 행이 남아 있으면 위 deleteAccount 호출이 fk_refresh_tokens_user 위반으로 롤백되었을 것이다.
+        assertThat(refreshTokenRepository.findByToken("leaving-user-refresh-token")).isEmpty();
     }
 
     /**

--- a/src/test/java/com/cotalk/application/service/user/DeleteAccountServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/user/DeleteAccountServiceTest.java
@@ -10,6 +10,8 @@ import com.cotalk.domain.port.outbound.DeviceTokenRepository;
 import com.cotalk.domain.port.outbound.FriendRepository;
 import com.cotalk.domain.port.outbound.FriendRequestRepository;
 import com.cotalk.domain.port.outbound.HiddenFriendRepository;
+import com.cotalk.domain.port.outbound.MessageReactionRepository;
+import com.cotalk.domain.port.outbound.MessageRepository;
 import com.cotalk.domain.port.outbound.NotificationSettingRepository;
 import com.cotalk.domain.port.outbound.EmailVerificationTokenRepository;
 import com.cotalk.domain.port.outbound.PasswordResetTokenRepository;
@@ -39,6 +41,12 @@ class DeleteAccountServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private MessageRepository messageRepository;
+
+    @Mock
+    private MessageReactionRepository messageReactionRepository;
 
     @Mock
     private ChatRoomMemberRepository chatRoomMemberRepository;
@@ -88,6 +96,8 @@ class DeleteAccountServiceTest {
         passwordEncoder = new SpringPasswordEncoderAdapter(new BCryptPasswordEncoder());
         service = new DeleteAccountService(
                 userRepository,
+                messageRepository,
+                messageReactionRepository,
                 chatRoomMemberRepository,
                 friendRepository,
                 friendRequestRepository,
@@ -126,11 +136,18 @@ class DeleteAccountServiceTest {
         service.deleteAccount(userId, password);
 
         // then
+        verify(messageReactionRepository).deleteByUserId(userId);
+        verify(messageReactionRepository).deleteByMessageSenderId(userId);
+        verify(reportRepository).deleteByReporterId(userId);
+        verify(reportRepository).deleteByReportedUserId(userId);
+        verify(reportRepository).deleteByReportedMessageSenderId(userId);
+        verify(messageRepository).deleteBySenderId(userId);
         verify(chatRoomMemberRepository).deleteByUserId(userId);
         verify(friendRepository).deleteByUserId(userId);
         verify(friendRequestRepository).deleteByUserId(userId);
         verify(deviceTokenRepository).deleteByUserId(userId);
         verify(passwordResetTokenRepository).deleteByUserId(userId);
+        verify(hiddenFriendRepository).deleteByUserId(userId);
         verify(userRepository).delete(user);
     }
 

--- a/src/test/resources/sql/delete-account-fk-constraints.sql
+++ b/src/test/resources/sql/delete-account-fk-constraints.sql
@@ -1,0 +1,37 @@
+-- 회원 탈퇴 FK 회귀 테스트용 제약 조건.
+-- 엔티티에는 @ManyToOne/@ForeignKey 매핑이 없어 ddl-auto: create-drop으로는
+-- 외래키 제약이 생성되지 않는다. 운영 스키마(V1__init_schema.sql)에 존재하는
+-- 실제 FK 제약을 H2에 동일하게 추가하여, 회원 탈퇴 시 FK 위반이 실제로
+-- 발생/해소되는지를 검증할 수 있도록 한다.
+
+ALTER TABLE messages
+    ADD CONSTRAINT fk_messages_sender
+    FOREIGN KEY (sender_id) REFERENCES users(id);
+
+ALTER TABLE message_reactions
+    ADD CONSTRAINT fk_message_reactions_user
+    FOREIGN KEY (user_id) REFERENCES users(id);
+
+ALTER TABLE message_reactions
+    ADD CONSTRAINT fk_message_reactions_message
+    FOREIGN KEY (message_id) REFERENCES messages(id);
+
+ALTER TABLE reports
+    ADD CONSTRAINT fk_reports_reported_user
+    FOREIGN KEY (reported_user_id) REFERENCES users(id);
+
+ALTER TABLE reports
+    ADD CONSTRAINT fk_reports_reporter
+    FOREIGN KEY (reporter_id) REFERENCES users(id);
+
+ALTER TABLE reports
+    ADD CONSTRAINT fk_reports_reported_msg
+    FOREIGN KEY (reported_message_id) REFERENCES messages(id);
+
+ALTER TABLE hidden_friends
+    ADD CONSTRAINT fk_hidden_friends_user
+    FOREIGN KEY (user_id) REFERENCES users(id);
+
+ALTER TABLE hidden_friends
+    ADD CONSTRAINT fk_hidden_friends_friend
+    FOREIGN KEY (friend_id) REFERENCES users(id);

--- a/src/test/resources/sql/delete-account-fk-constraints.sql
+++ b/src/test/resources/sql/delete-account-fk-constraints.sql
@@ -35,3 +35,7 @@ ALTER TABLE hidden_friends
 ALTER TABLE hidden_friends
     ADD CONSTRAINT fk_hidden_friends_friend
     FOREIGN KEY (friend_id) REFERENCES users(id);
+
+ALTER TABLE refresh_tokens
+    ADD CONSTRAINT fk_refresh_tokens_user
+    FOREIGN KEY (user_id) REFERENCES users(id);


### PR DESCRIPTION
## 배경 (P1)

`DeleteAccountService.deleteUserData`가 user를 참조하는 **일부 테이블만** 지우고 `userRepository.delete(user)`를 호출했다. 스키마(`V1__init_schema.sql`)에는 `ON DELETE CASCADE`가 전혀 없어, 아래 FK가 위반되면 트랜잭션이 롤백된다 → **메시지를 보낸 적 있는 실사용자가 탈퇴 시 500**.

누락돼 있던 참조:
- `messages.sender_id` (`fk_messages_sender`) — 사용자 메시지 미삭제
- `message_reactions.user_id` / `message_id` (`fk_message_reactions_user`, `fk_message_reactions_message`) — 사용자 반응 미삭제, 사용자 메시지에 달린 타인 반응 미삭제
- `reports.reported_user_id` / `reported_message_id` (`fk_reports_reported_user`, `fk_reports_reported_msg`) — 코드는 `deleteByReporterId`만 호출, 피신고·피신고메시지 기록 미삭제
- `hidden_friends.friend_id` (`fk_hidden_friends_friend`) — `deleteByUserId`가 `user_id`쪽만 삭제, 이 사용자를 숨긴 타인 레코드 잔존

기존 단위 테스트는 순수 Mockito라 실제 FK를 태우지 않아 결함을 검출하지 못했다.

## 변경

- **누락 참조 삭제 추가**: `Message.deleteBySenderId`, `MessageReaction.deleteByUserId` / `deleteByMessageSenderId`, `Report.deleteByReportedUserId` / `deleteByReportedMessageSenderId` 포트·어댑터 추가.
- **HiddenFriend 양방향 삭제**: `deleteByUserId`를 `deleteByUserIdOrFriendId`로 변경(이미 `friends` 어댑터가 쓰는 동일 컨벤션). 타인이 이 사용자를 숨긴 `friend_id` 레코드까지 삭제.
- **삭제 순서**를 자식→부모로 배치: 반응/신고(메시지 참조) → 메시지 → 나머지 → user. FK 위반이 발생하지 않도록 한다.
- **회귀 테스트**(`@DataJpaTest` + `@Sql`): 엔티티에 `@ManyToOne`/`@ForeignKey` 매핑이 없어 `ddl-auto: create-drop`만으로는 FK가 생성되지 않으므로, 운영 스키마의 실제 FK 제약을 H2에 동일하게 적용(`sql/delete-account-fk-constraints.sql`)한 뒤 메시지/반응/피신고/피신고메시지/피숨김을 가진 실사용자의 탈퇴 성공 + 관련 레코드 정리를 검증. **수정 전에는 `ConstraintViolationException`으로 실패함을 확인**했다.

## 정책 결정 & trade-off

이 서비스는 이미 **하드 삭제**(사용자 데이터를 실제 `delete`)로 일관돼 있다. 가장 보수적이고 기존 컨벤션에 부합하도록, 사용자 메시지·반응도 **하드 삭제** 목록에 추가했다(익명화/`SET NULL`은 엔티티가 `sender_id NOT NULL` + FK 매핑 부재로 자연스럽지 않음).

- **trade-off**: 탈퇴 사용자가 보낸 메시지가 채팅방 히스토리에서 사라진다. 상대방 입장에서 대화 맥락 일부가 비게 된다. 다만 기존 동작(탈퇴 자체가 불가능)보다 명백히 개선이며, 서비스의 기존 하드 삭제 일관성을 유지한다.
- 스키마 마이그레이션(파괴적 `ALTER`/cascade 추가)은 도입하지 않았다 — 애플리케이션 레벨 삭제로 해결해 되돌릴 수 없는 변경을 피했다.

## 검증

- `./gradlew build` 성공 (전체 테스트 + ArchUnit 의존방향 + JaCoCo 60% 게이트 통과).
- 신규 통합 테스트가 실제 H2 FK 제약을 태워 회귀 방지.
- 헥사고날 준수: 포트(`domain`)·어댑터(`adapter/outbound`)·서비스(`application`) 계층 경계 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)