### PR TITLE
fix(push): FCM 전송 트랜잭션 분리 및 디바이스 토큰 이전 UNIQUE 충돌 방지

### DIFF
--- a/src/main/java/com/cotalk/adapter/outbound/persistence/notification/DeviceTokenRepositoryAdapter.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/notification/DeviceTokenRepositoryAdapter.java
@@ -32,6 +32,17 @@ public class DeviceTokenRepositoryAdapter implements DeviceTokenRepository {
     }
 
     /**
+     * 디바이스 토큰을 저장하고 즉시 flush한다.
+     *
+     * @param deviceToken 저장할 디바이스 토큰 엔티티
+     * @return 저장된 디바이스 토큰 엔티티
+     */
+    @Override
+    public DeviceToken saveAndFlush(DeviceToken deviceToken) {
+        return deviceTokenJpaRepository.saveAndFlush(deviceToken);
+    }
+
+    /**
      * ID로 디바이스 토큰을 조회한다.
      *
      * @param id 디바이스 토큰 ID

--- a/src/main/java/com/cotalk/application/service/notification/DeviceTokenInserter.java
+++ b/src/main/java/com/cotalk/application/service/notification/DeviceTokenInserter.java
@@ -1,0 +1,79 @@
+package com.cotalk.application.service.notification;
+
+import com.cotalk.domain.entity.DeviceToken;
+import com.cotalk.domain.port.outbound.DeviceTokenRepository;
+import com.cotalk.domain.port.outbound.IdGenerator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 신규 디바이스 토큰을 독립 트랜잭션(REQUIRES_NEW) 안에서 INSERT하는 컴포넌트.
+ *
+ * <p><b>왜 별도 빈 + REQUIRES_NEW인가:</b> {@link DeviceToken}은 {@code @Id}를 수동
+ * 할당(Snowflake)하며 {@code @GeneratedValue}/{@code Persistable}/{@code @Version}가
+ * 없다. 따라서 Spring Data {@code save()}는 {@code isNew()==false}로 판단해
+ * {@code persist()}가 아닌 {@code merge()}를 타고, 기본 AUTO flush에서 INSERT(및
+ * {@code token} UNIQUE 위반)가 커밋 시점까지 지연된다. 만약 이 INSERT를
+ * {@link RegisterDeviceTokenService#register}의 클래스 레벨 {@code @Transactional}이
+ * 만든 동일 트랜잭션 안에서 수행하면, 동시 등록 경합 시:
+ * <ul>
+ *   <li>flush가 커밋까지 지연되어 UNIQUE 위반이 {@code register}의 {@code try/catch}
+ *       <b>바깥</b>(트랜잭션 프록시 경계)에서 터져 폴백이 동작하지 않을 수 있고,</li>
+ *   <li>flush가 동기로 일어나 catch가 잡히더라도 그 트랜잭션은 이미 rollback-only로
+ *       마킹되어, 그 위에서 폴백 UPDATE를 쓰면 커밋 시 {@code UnexpectedRollbackException}이
+ *       발생한다.</li>
+ * </ul>
+ *
+ * <p>이를 해결하기 위해 신규 INSERT를 이 빈의 {@code REQUIRES_NEW} 메서드로 분리한다.
+ * UNIQUE 위반은 이 <b>독립된 내부 트랜잭션</b> 경계에서 surface·롤백되며, 호출자의
+ * 바깥 트랜잭션은 오염되지 않은 깨끗한 상태로 유지된다. 호출자는 위반을 감지하면
+ * 깨끗한 상태에서 재조회→UPDATE(소유자 이전/활성화)를 수행한다.</p>
+ *
+ * <p>self-invocation 프록시 함정(같은 클래스 내부에서 {@code @Transactional} 메서드를
+ * 호출하면 AOP 프록시를 거치지 않아 전파 속성이 무시됨)을 피하기 위해 반드시 외부
+ * 빈으로 분리한다.</p>
+ *
+ * @author seunggu.lee
+ * @see RegisterDeviceTokenService
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DeviceTokenInserter {
+
+    private final DeviceTokenRepository deviceTokenRepository;
+    private final IdGenerator idGenerator;
+
+    /**
+     * 신규 디바이스 토큰을 독립 트랜잭션 안에서 INSERT한다.
+     *
+     * <p>{@code saveAndFlush}로 즉시 flush하여, 동시 등록 경합 시 {@code token} UNIQUE
+     * 위반이 이 메서드 안에서 동기적으로 발생하도록 한다. 위반이 발생하면 이 독립
+     * 트랜잭션만 롤백되고 예외가 호출자에게 전파된다. (호출자의 바깥 트랜잭션은
+     * 오염되지 않는다.)</p>
+     *
+     * @param userId     사용자 ID
+     * @param token      디바이스 토큰
+     * @param deviceType 디바이스 타입
+     * @return 저장된 디바이스 토큰
+     * @throws DataIntegrityViolationException 동시 등록 경합으로 {@code token} UNIQUE
+     *                                         제약을 위반한 경우
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public DeviceToken insertNew(Long userId, String token, DeviceToken.DeviceType deviceType) {
+        DeviceToken newToken = DeviceToken.builder()
+                .id(idGenerator.nextId())
+                .userId(userId)
+                .token(token)
+                .deviceType(deviceType)
+                .build();
+
+        DeviceToken saved = deviceTokenRepository.saveAndFlush(newToken);
+        log.info("New device token registered for user: {}, type: {}", userId, deviceType);
+        return saved;
+    }
+}

--- a/src/main/java/com/cotalk/application/service/notification/RegisterDeviceTokenService.java
+++ b/src/main/java/com/cotalk/application/service/notification/RegisterDeviceTokenService.java
@@ -3,7 +3,6 @@ package com.cotalk.application.service.notification;
 import com.cotalk.domain.entity.DeviceToken;
 import com.cotalk.domain.port.inbound.notification.RegisterDeviceTokenUseCase;
 import com.cotalk.domain.port.outbound.DeviceTokenRepository;
-import com.cotalk.domain.port.outbound.IdGenerator;
 import com.cotalk.domain.util.TokenMasker;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,7 +25,7 @@ import java.util.Optional;
 public class RegisterDeviceTokenService implements RegisterDeviceTokenUseCase {
 
     private final DeviceTokenRepository deviceTokenRepository;
-    private final IdGenerator idGenerator;
+    private final DeviceTokenInserter deviceTokenInserter;
 
     /**
      * 디바이스 토큰을 등록한다.
@@ -40,10 +39,19 @@ public class RegisterDeviceTokenService implements RegisterDeviceTokenUseCase {
      *
      * <p>동시성 처리: 두 요청이 거의 동시에 동일한 신규 토큰을 등록하면 양쪽 모두
      * {@code findByToken}에서 empty를 읽고 각자 새 레코드를 INSERT하여 한쪽이
-     * {@code token} UNIQUE 제약을 위반한다. 이때 발생하는
-     * {@link DataIntegrityViolationException}을 잡아 동일 트랜잭션을 롤백시키지 않고
-     * 재조회 후 UPDATE 경로로 폴백하여, 경쟁에서 진 요청도 정상적으로 등록 결과를
-     * 반환한다. ({@code AddMessageReactionService}의 UNIQUE + 예외 폴백 패턴과 동일)</p>
+     * {@code token} UNIQUE 제약을 위반한다. 신규 INSERT는
+     * {@link DeviceTokenInserter#insertNew}({@code REQUIRES_NEW})로 분리되어 있어,
+     * 위반 시 그 <b>독립 트랜잭션만 롤백</b>되고 이 {@code register}의 바깥 트랜잭션은
+     * 오염되지 않는다. 발생한 {@link DataIntegrityViolationException}을 잡아 깨끗한
+     * 상태에서 재조회 후 UPDATE 경로(소유자 이전/활성화)로 폴백하여, 경쟁에서 진
+     * 요청도 정상적으로 등록 결과를 반환한다.</p>
+     *
+     * <p>{@code DeviceToken}은 {@code @Id} 수동 할당(Snowflake)이라 {@code save()}가
+     * {@code merge()}를 타고 INSERT/UNIQUE 위반이 커밋까지 지연되는 특성이 있어,
+     * {@code @GeneratedValue(IDENTITY)} + read-only 폴백인
+     * {@code AddMessageReactionService} 패턴을 그대로 쓸 수 없다. 이 차이 때문에
+     * 신규 INSERT를 별도 트랜잭션 경계로 분리하고 즉시 flush한다.
+     * 자세한 근거는 {@link DeviceTokenInserter} JavaDoc 참고.</p>
      *
      * @param userId     사용자 ID
      * @param token      디바이스 토큰
@@ -88,6 +96,12 @@ public class RegisterDeviceTokenService implements RegisterDeviceTokenUseCase {
     /**
      * 신규 토큰을 등록하되, 동시 INSERT로 인한 UNIQUE 위반 시 재조회 후 UPDATE로 폴백한다.
      *
+     * <p>실제 INSERT는 {@link DeviceTokenInserter#insertNew}의 {@code REQUIRES_NEW}
+     * 트랜잭션에서 수행되고 즉시 flush된다. 동시 경합으로 {@code token} UNIQUE 위반이
+     * 발생하면 그 독립 트랜잭션만 롤백되고 {@link DataIntegrityViolationException}이
+     * 전파되며, 이 메서드(및 바깥 {@code register} 트랜잭션)는 rollback-only로
+     * 오염되지 않으므로 안전하게 재조회→UPDATE 폴백을 수행할 수 있다.</p>
+     *
      * @param userId     사용자 ID
      * @param token      디바이스 토큰
      * @param deviceType 디바이스 타입
@@ -95,17 +109,11 @@ public class RegisterDeviceTokenService implements RegisterDeviceTokenUseCase {
      */
     private DeviceToken registerNewTokenSafely(Long userId, String token, DeviceToken.DeviceType deviceType) {
         try {
-            DeviceToken newToken = DeviceToken.builder()
-                    .id(idGenerator.nextId())
-                    .userId(userId)
-                    .token(token)
-                    .deviceType(deviceType)
-                    .build();
-
-            log.info("New device token registered for user: {}, type: {}", userId, deviceType);
-            return deviceTokenRepository.save(newToken);
+            return deviceTokenInserter.insertNew(userId, token, deviceType);
         } catch (DataIntegrityViolationException e) {
-            // 동시 등록 경합: 다른 요청이 같은 토큰을 먼저 INSERT함 → 재조회 후 UPDATE로 폴백
+            // 동시 등록 경합: 다른 요청이 같은 토큰을 먼저 INSERT함.
+            // 신규 INSERT는 REQUIRES_NEW 경계에서 롤백되었으므로 바깥 트랜잭션은 깨끗하다.
+            // 깨끗한 상태에서 재조회 후 UPDATE(소유자 이전/활성화)로 폴백한다.
             log.debug("Concurrent device token registration detected, falling back to update for user: {}", userId);
             DeviceToken existing = deviceTokenRepository.findByToken(token)
                     .orElseThrow(() -> new IllegalStateException(

--- a/src/main/java/com/cotalk/application/service/notification/RegisterDeviceTokenService.java
+++ b/src/main/java/com/cotalk/application/service/notification/RegisterDeviceTokenService.java
@@ -31,7 +31,11 @@ public class RegisterDeviceTokenService implements RegisterDeviceTokenUseCase {
      * 디바이스 토큰을 등록한다.
      * 동일한 토큰이 이미 존재하는 경우:
      * - 같은 사용자: 토큰을 재활성화
-     * - 다른 사용자: 기존 토큰 삭제 후 새로 등록
+     * - 다른 사용자: 기존 레코드의 소유자를 새 사용자로 이전(UPDATE)하여 재활성화
+     *
+     * <p>토큰 컬럼은 UNIQUE 제약을 가지므로, 소유자 이전 시 기존 레코드를 삭제 후
+     * 동일 토큰으로 새 레코드를 INSERT하면 Hibernate flush 순서에 따라 UNIQUE 위반이
+     * 발생할 수 있다. 이를 회피하기 위해 기존 레코드를 그대로 UPDATE한다.</p>
      *
      * @param userId     사용자 ID
      * @param token      디바이스 토큰
@@ -44,17 +48,19 @@ public class RegisterDeviceTokenService implements RegisterDeviceTokenUseCase {
 
         if (existingToken.isPresent()) {
             DeviceToken existing = existingToken.get();
-            
+
             // 같은 사용자면 활성화만
             if (existing.getUserId().equals(userId)) {
                 existing.updateToken(token);
                 log.info("Device token reactivated for user: {}", userId);
                 return deviceTokenRepository.save(existing);
             }
-            
-            // 다른 사용자면 기존 토큰 삭제 후 새로 생성
-            deviceTokenRepository.deleteByToken(token);
-            log.info("Device token transferred from user {} to user {}", existing.getUserId(), userId);
+
+            // 다른 사용자면 기존 레코드의 소유자를 이전(UPDATE) — delete+insert UNIQUE 충돌 회피
+            Long previousUserId = existing.getUserId();
+            existing.transferTo(userId, deviceType);
+            log.info("Device token transferred from user {} to user {}", previousUserId, userId);
+            return deviceTokenRepository.save(existing);
         }
 
         DeviceToken newToken = DeviceToken.builder()

--- a/src/main/java/com/cotalk/application/service/notification/RegisterDeviceTokenService.java
+++ b/src/main/java/com/cotalk/application/service/notification/RegisterDeviceTokenService.java
@@ -7,6 +7,7 @@ import com.cotalk.domain.port.outbound.IdGenerator;
 import com.cotalk.domain.util.TokenMasker;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,6 +38,13 @@ public class RegisterDeviceTokenService implements RegisterDeviceTokenUseCase {
      * 동일 토큰으로 새 레코드를 INSERT하면 Hibernate flush 순서에 따라 UNIQUE 위반이
      * 발생할 수 있다. 이를 회피하기 위해 기존 레코드를 그대로 UPDATE한다.</p>
      *
+     * <p>동시성 처리: 두 요청이 거의 동시에 동일한 신규 토큰을 등록하면 양쪽 모두
+     * {@code findByToken}에서 empty를 읽고 각자 새 레코드를 INSERT하여 한쪽이
+     * {@code token} UNIQUE 제약을 위반한다. 이때 발생하는
+     * {@link DataIntegrityViolationException}을 잡아 동일 트랜잭션을 롤백시키지 않고
+     * 재조회 후 UPDATE 경로로 폴백하여, 경쟁에서 진 요청도 정상적으로 등록 결과를
+     * 반환한다. ({@code AddMessageReactionService}의 UNIQUE + 예외 폴백 패턴과 동일)</p>
+     *
      * @param userId     사용자 ID
      * @param token      디바이스 토큰
      * @param deviceType 디바이스 타입 (iOS, Android 등)
@@ -47,31 +55,63 @@ public class RegisterDeviceTokenService implements RegisterDeviceTokenUseCase {
         Optional<DeviceToken> existingToken = deviceTokenRepository.findByToken(token);
 
         if (existingToken.isPresent()) {
-            DeviceToken existing = existingToken.get();
+            return reuseExistingToken(existingToken.get(), userId, token, deviceType);
+        }
 
-            // 같은 사용자면 활성화만
-            if (existing.getUserId().equals(userId)) {
-                existing.updateToken(token);
-                log.info("Device token reactivated for user: {}", userId);
-                return deviceTokenRepository.save(existing);
-            }
+        return registerNewTokenSafely(userId, token, deviceType);
+    }
 
-            // 다른 사용자면 기존 레코드의 소유자를 이전(UPDATE) — delete+insert UNIQUE 충돌 회피
-            Long previousUserId = existing.getUserId();
-            existing.transferTo(userId, deviceType);
-            log.info("Device token transferred from user {} to user {}", previousUserId, userId);
+    /**
+     * 기존 레코드를 재사용하여 토큰을 재활성화하거나 소유자를 이전한다.
+     *
+     * @param existing   기존 디바이스 토큰 레코드
+     * @param userId     요청 사용자 ID
+     * @param token      디바이스 토큰
+     * @param deviceType 디바이스 타입
+     * @return 갱신된 디바이스 토큰 정보
+     */
+    private DeviceToken reuseExistingToken(DeviceToken existing, Long userId, String token, DeviceToken.DeviceType deviceType) {
+        // 같은 사용자면 활성화만
+        if (existing.getUserId().equals(userId)) {
+            existing.updateToken(token);
+            log.info("Device token reactivated for user: {}", userId);
             return deviceTokenRepository.save(existing);
         }
 
-        DeviceToken newToken = DeviceToken.builder()
-                .id(idGenerator.nextId())
-                .userId(userId)
-                .token(token)
-                .deviceType(deviceType)
-                .build();
+        // 다른 사용자면 기존 레코드의 소유자를 이전(UPDATE) — delete+insert UNIQUE 충돌 회피
+        Long previousUserId = existing.getUserId();
+        existing.transferTo(userId, deviceType);
+        log.info("Device token transferred from user {} to user {}", previousUserId, userId);
+        return deviceTokenRepository.save(existing);
+    }
 
-        log.info("New device token registered for user: {}, type: {}", userId, deviceType);
-        return deviceTokenRepository.save(newToken);
+    /**
+     * 신규 토큰을 등록하되, 동시 INSERT로 인한 UNIQUE 위반 시 재조회 후 UPDATE로 폴백한다.
+     *
+     * @param userId     사용자 ID
+     * @param token      디바이스 토큰
+     * @param deviceType 디바이스 타입
+     * @return 등록되거나 폴백으로 갱신된 디바이스 토큰 정보
+     */
+    private DeviceToken registerNewTokenSafely(Long userId, String token, DeviceToken.DeviceType deviceType) {
+        try {
+            DeviceToken newToken = DeviceToken.builder()
+                    .id(idGenerator.nextId())
+                    .userId(userId)
+                    .token(token)
+                    .deviceType(deviceType)
+                    .build();
+
+            log.info("New device token registered for user: {}, type: {}", userId, deviceType);
+            return deviceTokenRepository.save(newToken);
+        } catch (DataIntegrityViolationException e) {
+            // 동시 등록 경합: 다른 요청이 같은 토큰을 먼저 INSERT함 → 재조회 후 UPDATE로 폴백
+            log.debug("Concurrent device token registration detected, falling back to update for user: {}", userId);
+            DeviceToken existing = deviceTokenRepository.findByToken(token)
+                    .orElseThrow(() -> new IllegalStateException(
+                            "Device token should exist after DataIntegrityViolationException"));
+            return reuseExistingToken(existing, userId, token, deviceType);
+        }
     }
 
     /**

--- a/src/main/java/com/cotalk/domain/entity/DeviceToken.java
+++ b/src/main/java/com/cotalk/domain/entity/DeviceToken.java
@@ -63,6 +63,20 @@ public class DeviceToken extends BaseEntity {
     }
 
     /**
+     * 토큰의 소유자를 이전하고 활성화한다.
+     * 동일 토큰을 다른 사용자가 등록할 때, 기존 레코드를 삭제 후 재생성하는 대신
+     * 소유자(userId)와 디바이스 타입을 갱신하여 UNIQUE 제약 충돌을 회피한다.
+     *
+     * @param newUserId    새 소유자 사용자 ID
+     * @param newDeviceType 새 디바이스 타입
+     */
+    public void transferTo(Long newUserId, DeviceType newDeviceType) {
+        this.userId = newUserId;
+        this.deviceType = newDeviceType;
+        this.active = true;
+    }
+
+    /**
      * 디바이스 유형을 나타내는 열거형.
      *
      * @author seunggu.lee

--- a/src/main/java/com/cotalk/domain/port/outbound/DeviceTokenRepository.java
+++ b/src/main/java/com/cotalk/domain/port/outbound/DeviceTokenRepository.java
@@ -22,6 +22,20 @@ public interface DeviceTokenRepository {
     DeviceToken save(DeviceToken deviceToken);
 
     /**
+     * 디바이스 토큰을 저장하고 즉시 영속성 컨텍스트를 flush한다.
+     *
+     * <p>{@code DeviceToken}은 {@code @Id}를 수동 할당(Snowflake)하므로 Spring Data
+     * {@code save()}가 {@code persist()}가 아닌 {@code merge()}를 타게 되어, 기본 AUTO
+     * flush 모드에서는 INSERT(및 {@code token} UNIQUE 위반)가 트랜잭션 커밋 시점까지
+     * 지연된다. 동시 등록 경합 시 위반 예외를 호출자의 {@code try/catch} 경계 안에서
+     * 동기적으로 surface시키려면 이 메서드로 즉시 flush해야 한다.</p>
+     *
+     * @param deviceToken 저장할 디바이스 토큰
+     * @return 저장된 디바이스 토큰
+     */
+    DeviceToken saveAndFlush(DeviceToken deviceToken);
+
+    /**
      * ID로 디바이스 토큰을 조회한다.
      *
      * @param id 디바이스 토큰 ID

--- a/src/main/java/com/cotalk/infrastructure/push/FcmPushNotificationSender.java
+++ b/src/main/java/com/cotalk/infrastructure/push/FcmPushNotificationSender.java
@@ -1,6 +1,5 @@
 package com.cotalk.infrastructure.push;
 
-import com.cotalk.domain.port.outbound.DeviceTokenRepository;
 import com.cotalk.domain.port.outbound.PushNotificationSender;
 import com.cotalk.domain.port.outbound.PushNotificationSender.PushTarget;
 import com.cotalk.domain.util.TokenMasker;
@@ -8,7 +7,6 @@ import com.google.firebase.messaging.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,9 +21,14 @@ import java.util.Map;
  *
  * <p>대량 전송 시 FCM의 제한(500개/요청)에 맞춰 자동으로 배치 처리된다.
  *
+ * <p>성능: FCM 원격 호출(네트워크, 수백ms~수초)은 트랜잭션 밖에서 수행하고,
+ * 전송 실패로 무효화된 토큰의 비활성화(DB 쓰기)만 {@link InvalidTokenDeactivator}의
+ * 짧은 별도 트랜잭션으로 위임하여 DB 커넥션 점유 시간을 최소화한다.
+ *
  * @author seunggu.lee
  * @see PushNotificationSender
  * @see FcmConfig
+ * @see InvalidTokenDeactivator
  */
 @Slf4j
 @Component
@@ -34,19 +37,19 @@ public class FcmPushNotificationSender implements PushNotificationSender {
     private static final int FCM_BATCH_SIZE = 500;
 
     private final FirebaseMessaging firebaseMessaging;
-    private final DeviceTokenRepository deviceTokenRepository;
+    private final InvalidTokenDeactivator invalidTokenDeactivator;
 
     /**
      * FcmPushNotificationSender를 생성한다.
      *
-     * @param firebaseMessaging     FirebaseMessaging 인스턴스, Firebase가 비활성화된 경우 {@code null}일 수 있음
-     * @param deviceTokenRepository 디바이스 토큰 레포지토리
+     * @param firebaseMessaging      FirebaseMessaging 인스턴스, Firebase가 비활성화된 경우 {@code null}일 수 있음
+     * @param invalidTokenDeactivator 무효 토큰 비활성화 컴포넌트(별도 트랜잭션)
      */
     public FcmPushNotificationSender(
             @Nullable FirebaseMessaging firebaseMessaging,
-            DeviceTokenRepository deviceTokenRepository) {
+            InvalidTokenDeactivator invalidTokenDeactivator) {
         this.firebaseMessaging = firebaseMessaging;
-        this.deviceTokenRepository = deviceTokenRepository;
+        this.invalidTokenDeactivator = invalidTokenDeactivator;
     }
 
     /**
@@ -62,7 +65,6 @@ public class FcmPushNotificationSender implements PushNotificationSender {
      * @return 전송 성공 시 {@code true}, 실패 시 {@code false}
      */
     @Override
-    @Transactional
     public boolean send(String token, String title, String body, Map<String, String> data, String imageUrl) {
         if (firebaseMessaging == null) {
             log.debug("Firebase is not configured. Skipping push notification.");
@@ -101,7 +103,6 @@ public class FcmPushNotificationSender implements PushNotificationSender {
      * @return 성공적으로 전송된 알림 수
      */
     @Override
-    @Transactional
     public int sendMultiple(List<String> tokens, String title, String body, Map<String, String> data, String imageUrl) {
         if (firebaseMessaging == null) {
             log.debug("Firebase is not configured. Skipping push notifications.");
@@ -178,7 +179,7 @@ public class FcmPushNotificationSender implements PushNotificationSender {
         }
 
         if (!invalidTokens.isEmpty()) {
-            deactivateTokens(invalidTokens);
+            invalidTokenDeactivator.deactivateTokens(invalidTokens);
         }
     }
 
@@ -195,7 +196,7 @@ public class FcmPushNotificationSender implements PushNotificationSender {
 
         if (isInvalidTokenError(errorCode)) {
             log.warn("FCM token is invalid or unregistered: {}", TokenMasker.mask(token));
-            deactivateToken(token);
+            invalidTokenDeactivator.deactivateToken(token);
         } else {
             log.error("FCM send failed for token {}: {}", TokenMasker.mask(token), e.getMessage());
         }
@@ -210,32 +211,6 @@ public class FcmPushNotificationSender implements PushNotificationSender {
     private boolean isInvalidTokenError(MessagingErrorCode errorCode) {
         return errorCode == MessagingErrorCode.UNREGISTERED ||
                errorCode == MessagingErrorCode.INVALID_ARGUMENT;
-    }
-
-    /**
-     * 단일 토큰을 비활성화한다.
-     *
-     * @param token 비활성화할 토큰
-     */
-    private void deactivateToken(String token) {
-        deviceTokenRepository.findByToken(token)
-                .ifPresent(deviceToken -> {
-                    deviceToken.deactivate();
-                    deviceTokenRepository.save(deviceToken);
-                    log.info("Deactivated invalid FCM token: {}", TokenMasker.mask(token));
-                });
-    }
-
-    /**
-     * 여러 토큰을 비활성화한다.
-     *
-     * @param tokens 비활성화할 토큰 목록
-     */
-    private void deactivateTokens(List<String> tokens) {
-        for (String token : tokens) {
-            deactivateToken(token);
-        }
-        log.info("Deactivated {} invalid FCM tokens", tokens.size());
     }
 
     /**
@@ -325,7 +300,6 @@ public class FcmPushNotificationSender implements PushNotificationSender {
      * @return 성공적으로 전송된 알림 수
      */
     @Override
-    @Transactional
     public int sendEachWithBadge(List<PushTarget> targets, String title, String body, Map<String, String> data, String imageUrl) {
         if (firebaseMessaging == null) {
             log.debug("Firebase is not configured. Skipping push notifications.");
@@ -405,7 +379,7 @@ public class FcmPushNotificationSender implements PushNotificationSender {
         }
 
         if (!invalidTokens.isEmpty()) {
-            deactivateTokens(invalidTokens);
+            invalidTokenDeactivator.deactivateTokens(invalidTokens);
         }
     }
 }

--- a/src/main/java/com/cotalk/infrastructure/push/InvalidTokenDeactivator.java
+++ b/src/main/java/com/cotalk/infrastructure/push/InvalidTokenDeactivator.java
@@ -1,0 +1,69 @@
+package com.cotalk.infrastructure.push;
+
+import com.cotalk.domain.entity.DeviceToken;
+import com.cotalk.domain.port.outbound.DeviceTokenRepository;
+import com.cotalk.domain.util.TokenMasker;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * FCM 전송 실패로 무효화된 디바이스 토큰을 비활성화하는 컴포넌트.
+ *
+ * <p>FCM 네트워크 호출(수백ms~수초)과 토큰 비활성화 DB 쓰기를 분리하기 위해
+ * 별도 빈으로 추출되었다. {@link FcmPushNotificationSender}는 트랜잭션 밖에서
+ * FCM 원격 호출을 수행한 뒤, 비활성화가 필요한 토큰만 이 컴포넌트의
+ * {@code @Transactional} 메서드로 위임한다. 이렇게 하면 DB 커넥션 점유 시간이
+ * FCM 왕복 시간이 아닌 짧은 UPDATE 시간으로 제한된다.
+ *
+ * <p>별도 빈으로 분리한 이유: 동일 클래스 내부에서 {@code @Transactional} 메서드를
+ * 호출하면 Spring AOP 프록시를 거치지 않아 트랜잭션이 적용되지 않는
+ * self-invocation 함정에 빠진다. 외부 빈으로 호출하면 프록시를 거쳐 트랜잭션이
+ * 정상 적용된다.
+ *
+ * @author seunggu.lee
+ * @see FcmPushNotificationSender
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class InvalidTokenDeactivator {
+
+    private final DeviceTokenRepository deviceTokenRepository;
+
+    /**
+     * 단일 토큰을 짧은 독립 트랜잭션 안에서 비활성화한다.
+     *
+     * @param token 비활성화할 토큰
+     */
+    @Transactional
+    public void deactivateToken(String token) {
+        Optional<DeviceToken> found = deviceTokenRepository.findByToken(token);
+        found.ifPresent(deviceToken -> {
+            deviceToken.deactivate();
+            deviceTokenRepository.save(deviceToken);
+            log.info("Deactivated invalid FCM token: {}", TokenMasker.mask(token));
+        });
+    }
+
+    /**
+     * 여러 토큰을 짧은 독립 트랜잭션 안에서 비활성화한다.
+     *
+     * @param tokens 비활성화할 토큰 목록
+     */
+    @Transactional
+    public void deactivateTokens(List<String> tokens) {
+        for (String token : tokens) {
+            deviceTokenRepository.findByToken(token).ifPresent(deviceToken -> {
+                deviceToken.deactivate();
+                deviceTokenRepository.save(deviceToken);
+                log.info("Deactivated invalid FCM token: {}", TokenMasker.mask(token));
+            });
+        }
+        log.info("Deactivated {} invalid FCM tokens", tokens.size());
+    }
+}

--- a/src/main/java/com/cotalk/infrastructure/push/InvalidTokenDeactivator.java
+++ b/src/main/java/com/cotalk/infrastructure/push/InvalidTokenDeactivator.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 /**
  * FCM 전송 실패로 무효화된 디바이스 토큰을 비활성화하는 컴포넌트.
@@ -24,6 +23,20 @@ import java.util.Optional;
  * 호출하면 Spring AOP 프록시를 거치지 않아 트랜잭션이 적용되지 않는
  * self-invocation 함정에 빠진다. 외부 빈으로 호출하면 프록시를 거쳐 트랜잭션이
  * 정상 적용된다.
+ *
+ * <p><b>트랜잭션 전제</b>: 이 컴포넌트의 {@code @Transactional} 메서드는 기본 전파
+ * 속성({@code REQUIRED})을 사용한다. 즉, 호출 시점에 활성 트랜잭션이 없어야 새 트랜잭션을
+ * 시작하여 "짧은 독립 트랜잭션"이라는 의도가 성립한다. 현재 호출 체인은 이 전제를 만족한다:
+ * {@link com.cotalk.application.service.notification.SendPushNotificationService}는
+ * {@code @Async}이며 {@code @Transactional}이 없고(별도 스레드 + 트랜잭션 없음),
+ * {@link FcmPushNotificationSender} 또한 트랜잭션이 없어 FCM 원격 호출은 트랜잭션 밖에서
+ * 수행된다. 따라서 이 메서드 진입 시점에 활성 트랜잭션이 없다.
+ *
+ * <p>만약 향후 이 컴포넌트를 이미 트랜잭션이 열린 컨텍스트(예: {@code @Transactional}
+ * 서비스 내부)에서 호출하도록 호출 체인이 바뀌면, 기본 {@code REQUIRED} 전파로는 기존
+ * 트랜잭션에 합류하여 "짧은 독립 트랜잭션"이라는 성능 의도가 깨진다. 그 경우
+ * {@code @Transactional(propagation = REQUIRES_NEW)}로 변경하여 항상 독립 트랜잭션을
+ * 보장해야 한다.
  *
  * @author seunggu.lee
  * @see FcmPushNotificationSender
@@ -42,12 +55,7 @@ public class InvalidTokenDeactivator {
      */
     @Transactional
     public void deactivateToken(String token) {
-        Optional<DeviceToken> found = deviceTokenRepository.findByToken(token);
-        found.ifPresent(deviceToken -> {
-            deviceToken.deactivate();
-            deviceTokenRepository.save(deviceToken);
-            log.info("Deactivated invalid FCM token: {}", TokenMasker.mask(token));
-        });
+        deactivateSingle(token);
     }
 
     /**
@@ -58,12 +66,27 @@ public class InvalidTokenDeactivator {
     @Transactional
     public void deactivateTokens(List<String> tokens) {
         for (String token : tokens) {
-            deviceTokenRepository.findByToken(token).ifPresent(deviceToken -> {
-                deviceToken.deactivate();
-                deviceTokenRepository.save(deviceToken);
-                log.info("Deactivated invalid FCM token: {}", TokenMasker.mask(token));
-            });
+            deactivateSingle(token);
         }
         log.info("Deactivated {} invalid FCM tokens", tokens.size());
+    }
+
+    /**
+     * 단일 토큰의 비활성화 로직(조회→비활성화→저장→로그)을 수행한다.
+     *
+     * <p>{@code private} 메서드이므로 호출자({@code deactivateToken} /
+     * {@code deactivateTokens})가 이미 진입한 트랜잭션 컨텍스트 안에서 실행된다.
+     * 공개 {@code @Transactional} 메서드를 self-invocation으로 호출하면 프록시를
+     * 거치지 않아 트랜잭션 경계가 무시되므로, 트랜잭션 경계는 공개 메서드에 두고
+     * 공통 로직만 이 헬퍼로 추출하여 중복을 제거한다.
+     *
+     * @param token 비활성화할 토큰
+     */
+    private void deactivateSingle(String token) {
+        deviceTokenRepository.findByToken(token).ifPresent(deviceToken -> {
+            deviceToken.deactivate();
+            deviceTokenRepository.save(deviceToken);
+            log.info("Deactivated invalid FCM token: {}", TokenMasker.mask(token));
+        });
     }
 }

--- a/src/test/java/com/cotalk/adapter/outbound/persistence/DeviceTokenRepositoryAdapterTest.java
+++ b/src/test/java/com/cotalk/adapter/outbound/persistence/DeviceTokenRepositoryAdapterTest.java
@@ -3,11 +3,13 @@ package com.cotalk.adapter.outbound.persistence;
 import com.cotalk.adapter.outbound.persistence.notification.DeviceTokenRepositoryAdapter;
 import com.cotalk.adapter.outbound.persistence.mapper.UserMapper;
 import com.cotalk.adapter.outbound.persistence.user.UserRepositoryAdapter;
+import com.cotalk.application.service.notification.RegisterDeviceTokenService;
 import com.cotalk.domain.entity.DeviceToken;
 import com.cotalk.domain.entity.DeviceToken.DeviceType;
 import com.cotalk.domain.entity.User;
 import com.cotalk.domain.model.Email;
 import com.cotalk.infrastructure.config.JpaAuditingConfig;
+import com.cotalk.infrastructure.id.SnowflakeIdGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -202,6 +204,45 @@ class DeviceTokenRepositoryAdapterTest {
 
             // then
             assertThat(tokens).hasSize(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 소유자 이전 시 (RegisterDeviceTokenService 통합)")
+    class TransferOwnership {
+
+        @Test
+        @DisplayName("다른 사용자가 같은 토큰을 등록해도 UNIQUE 충돌 없이 소유자가 이전되고 활성화된다")
+        void should_transferOwnershipWithoutUniqueViolation_when_sameTokenRegisteredByAnotherUser() {
+            // given: user1이 토큰을 비활성 상태로 보유
+            RegisterDeviceTokenService service = new RegisterDeviceTokenService(
+                    deviceTokenRepository, new SnowflakeIdGenerator(0, 0));
+            String token = "shared-fcm-token";
+
+            DeviceToken existing = DeviceToken.builder()
+                    .id(500L)
+                    .userId(user1.getId())
+                    .token(token)
+                    .deviceType(DeviceType.ANDROID)
+                    .build();
+            existing.deactivate();
+            deviceTokenRepository.save(existing);
+
+            // when: user2가 동일 토큰을 등록 (이전 케이스)
+            // delete+insert 였다면 flush 순서에 따라 UNIQUE 제약 위반이 발생할 수 있음
+            DeviceToken result = service.register(user2.getId(), token, DeviceType.IOS);
+
+            // then: 예외 없이 소유자/타입/활성 상태가 갱신되고, 동일 토큰의 레코드는 1개만 존재
+            assertThat(result.getUserId()).isEqualTo(user2.getId());
+            assertThat(result.getDeviceType()).isEqualTo(DeviceType.IOS);
+            assertThat(result.isActive()).isTrue();
+
+            Optional<DeviceToken> found = deviceTokenRepository.findByToken(token);
+            assertThat(found).isPresent();
+            assertThat(found.get().getUserId()).isEqualTo(user2.getId());
+            assertThat(found.get().isActive()).isTrue();
+            assertThat(deviceTokenRepository.findByUserId(user1.getId())).isEmpty();
+            assertThat(deviceTokenRepository.findByUserId(user2.getId())).hasSize(1);
         }
     }
 

--- a/src/test/java/com/cotalk/adapter/outbound/persistence/DeviceTokenRepositoryAdapterTest.java
+++ b/src/test/java/com/cotalk/adapter/outbound/persistence/DeviceTokenRepositoryAdapterTest.java
@@ -3,6 +3,7 @@ package com.cotalk.adapter.outbound.persistence;
 import com.cotalk.adapter.outbound.persistence.notification.DeviceTokenRepositoryAdapter;
 import com.cotalk.adapter.outbound.persistence.mapper.UserMapper;
 import com.cotalk.adapter.outbound.persistence.user.UserRepositoryAdapter;
+import com.cotalk.application.service.notification.DeviceTokenInserter;
 import com.cotalk.application.service.notification.RegisterDeviceTokenService;
 import com.cotalk.domain.entity.DeviceToken;
 import com.cotalk.domain.entity.DeviceToken.DeviceType;
@@ -216,7 +217,8 @@ class DeviceTokenRepositoryAdapterTest {
         void should_transferOwnershipWithoutUniqueViolation_when_sameTokenRegisteredByAnotherUser() {
             // given: user1이 토큰을 비활성 상태로 보유
             RegisterDeviceTokenService service = new RegisterDeviceTokenService(
-                    deviceTokenRepository, new SnowflakeIdGenerator(0, 0));
+                    deviceTokenRepository,
+                    new DeviceTokenInserter(deviceTokenRepository, new SnowflakeIdGenerator(0, 0)));
             String token = "shared-fcm-token";
 
             DeviceToken existing = DeviceToken.builder()

--- a/src/test/java/com/cotalk/adapter/outbound/persistence/RegisterDeviceTokenServiceConcurrencyTest.java
+++ b/src/test/java/com/cotalk/adapter/outbound/persistence/RegisterDeviceTokenServiceConcurrencyTest.java
@@ -1,0 +1,273 @@
+package com.cotalk.adapter.outbound.persistence;
+
+import com.cotalk.adapter.outbound.persistence.mapper.UserMapper;
+import com.cotalk.adapter.outbound.persistence.notification.DeviceTokenRepositoryAdapter;
+import com.cotalk.adapter.outbound.persistence.user.UserRepositoryAdapter;
+import com.cotalk.application.service.notification.DeviceTokenInserter;
+import com.cotalk.application.service.notification.RegisterDeviceTokenService;
+import com.cotalk.domain.entity.DeviceToken;
+import com.cotalk.domain.entity.DeviceToken.DeviceType;
+import com.cotalk.domain.entity.User;
+import com.cotalk.domain.model.Email;
+import com.cotalk.infrastructure.config.JpaAuditingConfig;
+import com.cotalk.infrastructure.id.SnowflakeIdGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * {@link RegisterDeviceTokenService}의 동시 등록 경합 처리를 <b>실제 H2 UNIQUE 제약과
+ * 실제 트랜잭션 거동</b>으로 검증하는 통합 테스트.
+ *
+ * <p>mock-throw 단위 테스트는 INSERT 실패를 인위적으로 던질 뿐이라 "지연 flush로 위반이
+ * 트랜잭션 경계 밖에서 터지는지", "REQUIRES_NEW 롤백 후 바깥 트랜잭션이 깨끗한지"를
+ * 검증하지 못한다(항진적). 이 테스트는:
+ * <ul>
+ *   <li>{@link DeviceTokenInserter#insertNew}가 {@code saveAndFlush}로 실제 UNIQUE
+ *       위반을 <b>동기적으로</b> surface시키는지,</li>
+ *   <li>{@code register}가 위반을 잡아 폴백 UPDATE를 <b>커밋까지 성공</b>시키는지
+ *       (rollback-only 오염으로 인한 {@code UnexpectedRollbackException}이 없는지)</li>
+ * </ul>
+ * 를 실제 DB 상태로 확인한다.</p>
+ *
+ * <p>각 테스트 메서드는 트랜잭션 밖에서 실행되어({@code @Transactional(propagation=NEVER)}
+ * 효과를 위해 {@code @DataJpaTest}의 기본 테스트 트랜잭션을 비활성화), 서비스의
+ * {@code @Transactional}/{@code REQUIRES_NEW} 경계가 실제로 동작하도록 한다.</p>
+ *
+ * @author seunggu.lee
+ */
+@DataJpaTest(properties = "spring.test.database.replace=none")
+@ActiveProfiles("test")
+@Import({
+        DeviceTokenRepositoryAdapter.class,
+        UserRepositoryAdapter.class,
+        UserMapper.class,
+        JpaAuditingConfig.class,
+        DeviceTokenInserter.class,
+        RegisterDeviceTokenService.class,
+        RegisterDeviceTokenServiceConcurrencyTest.IdGeneratorTestConfig.class
+})
+@org.springframework.transaction.annotation.Transactional(propagation = org.springframework.transaction.annotation.Propagation.NEVER)
+@DisplayName("RegisterDeviceTokenService 동시 등록 경합 (실제 H2 UNIQUE)")
+class RegisterDeviceTokenServiceConcurrencyTest {
+
+    /**
+     * 테스트용 Snowflake ID 생성기 빈 설정.
+     */
+    @TestConfiguration
+    static class IdGeneratorTestConfig {
+        /**
+         * Snowflake ID 생성기 빈.
+         *
+         * @return ID 생성기
+         */
+        @Bean
+        SnowflakeIdGenerator idGenerator() {
+            return new SnowflakeIdGenerator(0, 0);
+        }
+    }
+
+    @Autowired
+    private RegisterDeviceTokenService service;
+
+    @Autowired
+    private DeviceTokenInserter inserter;
+
+    @Autowired
+    private DeviceTokenRepositoryAdapter deviceTokenRepository;
+
+    @Autowired
+    private UserRepositoryAdapter userRepository;
+
+    @Autowired
+    private org.springframework.transaction.PlatformTransactionManager transactionManager;
+
+    private User user1;
+    private User user2;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트 트랜잭션이 비활성(NEVER)이므로 서비스의 @Transactional/REQUIRES_NEW 경계가
+        // 실제로 동작한다. 단, 셋업/정리의 DB 쓰기는 트랜잭션이 필요하므로 명시적으로
+        // TransactionTemplate으로 감싸 즉시 커밋한다. (컨텍스트 재사용 대비 직전 데이터 정리)
+        org.springframework.transaction.support.TransactionTemplate tx =
+                new org.springframework.transaction.support.TransactionTemplate(transactionManager);
+        tx.executeWithoutResult(status -> {
+            deviceTokenRepository.deleteByUserId(1L);
+            deviceTokenRepository.deleteByUserId(2L);
+            userRepository.findById(1L).ifPresent(userRepository::delete);
+            userRepository.findById(2L).ifPresent(userRepository::delete);
+        });
+
+        user1 = tx.execute(status -> userRepository.save(User.builder()
+                .id(1L)
+                .email(new Email("user1@example.com"))
+                .passwordHash("hash")
+                .nickname("user1")
+                .build()));
+        user2 = tx.execute(status -> userRepository.save(User.builder()
+                .id(2L)
+                .email(new Email("user2@example.com"))
+                .passwordHash("hash")
+                .nickname("user2")
+                .build()));
+    }
+
+    /**
+     * 주어진 토큰을 짧은 트랜잭션 안에서 비활성화 상태로 갱신한다.
+     * ({@code @Transactional(NEVER)} 환경에서 bare save를 직접 호출하면 트랜잭션이 없어
+     * 실패하므로 명시적으로 트랜잭션으로 감싼다.)
+     *
+     * @param token 비활성화할 토큰
+     */
+    private void deactivateInTx(String token) {
+        org.springframework.transaction.support.TransactionTemplate tx =
+                new org.springframework.transaction.support.TransactionTemplate(transactionManager);
+        tx.executeWithoutResult(status ->
+                deviceTokenRepository.findByToken(token).ifPresent(t -> {
+                    t.deactivate();
+                    deviceTokenRepository.save(t);
+                }));
+    }
+
+    @Test
+    @DisplayName("DeviceTokenInserter.insertNew는 이미 같은 토큰이 존재하면 실제 UNIQUE 위반을 동기적으로 던진다")
+    void should_throwDataIntegrityViolation_synchronously_when_tokenAlreadyExists() {
+        // given: 경쟁 요청이 먼저 같은 토큰을 INSERT(커밋)한 상태
+        String token = "racing-token";
+        inserter.insertNew(user1.getId(), token, DeviceType.ANDROID);
+
+        // when / then: 동일 토큰 신규 INSERT는 saveAndFlush로 즉시 UNIQUE 위반을 surface시킨다.
+        // (지연 flush였다면 이 호출은 통과하고 커밋 시점에야 터졌을 것)
+        assertThatThrownBy(() -> inserter.insertNew(user2.getId(), token, DeviceType.IOS))
+                .isInstanceOf(DataIntegrityViolationException.class);
+
+        // 첫 레코드만 남아있어야 한다 (실패한 INSERT는 REQUIRES_NEW 경계에서 롤백)
+        List<DeviceToken> all = deviceTokenRepository.findByToken(token).map(List::of).orElse(List.of());
+        assertThat(all).hasSize(1);
+        assertThat(all.get(0).getUserId()).isEqualTo(user1.getId());
+    }
+
+    @Test
+    @DisplayName("동시 신규 경합: 경쟁 레코드 선존재 시 같은 사용자 register는 위반→폴백 UPDATE로 커밋 성공한다")
+    void should_fallbackAndCommit_when_sameUserRacesNewToken() {
+        // given: 경쟁 요청이 먼저 같은 토큰을 비활성으로 INSERT(커밋)
+        String token = "shared-token";
+        inserter.insertNew(user1.getId(), token, DeviceType.ANDROID);
+        // 비활성 상태로 만들어 폴백/재사용 UPDATE가 활성화까지 수행함을 확인
+        deactivateInTx(token);
+
+        // when: 같은 사용자가 register → 내부 findByToken이 이미 존재를 보면 재사용,
+        // 만약 경합으로 miss했다면 insertNew가 위반→폴백. 어느 경로든 최종 상태는 활성 1건.
+        DeviceToken result = service.register(user1.getId(), token, DeviceType.ANDROID);
+
+        // then: 예외 없이 커밋 성공, 활성 레코드 1건
+        assertThat(result.getUserId()).isEqualTo(user1.getId());
+        assertThat(result.isActive()).isTrue();
+        Optional<DeviceToken> found = deviceTokenRepository.findByToken(token);
+        assertThat(found).isPresent();
+        assertThat(found.get().isActive()).isTrue();
+        assertThat(deviceTokenRepository.findByUserId(user1.getId())).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("실제 동시 등록: 두 스레드가 같은 신규 토큰을 register해도 둘 다 예외 없이 활성 레코드 1건으로 수렴한다")
+    void should_bothSucceedWithSingleRecord_when_twoThreadsRaceSameNewToken() throws Exception {
+        // given: 같은 신규 토큰을 두 스레드가 동시에 register 시도.
+        // 한쪽은 신규 INSERT 성공, 다른 한쪽은 findByToken miss → insertNew UNIQUE 위반
+        // → REQUIRES_NEW 롤백 → 깨끗한 바깥 트랜잭션에서 재조회→UPDATE 폴백으로 커밋 성공.
+        String token = "true-race-token";
+        int threads = 2;
+        java.util.concurrent.ExecutorService pool = java.util.concurrent.Executors.newFixedThreadPool(threads);
+        java.util.concurrent.CyclicBarrier barrier = new java.util.concurrent.CyclicBarrier(threads);
+        java.util.List<java.util.concurrent.Future<Throwable>> futures = new java.util.ArrayList<>();
+
+        for (int i = 0; i < threads; i++) {
+            final Long uid = user1.getId();
+            futures.add(pool.submit(() -> {
+                try {
+                    barrier.await(); // 동시 출발
+                    service.register(uid, token, DeviceType.ANDROID);
+                    return null;
+                } catch (Throwable t) {
+                    return t;
+                }
+            }));
+        }
+
+        // then: 어떤 스레드도 UnexpectedRollbackException/500 없이 완료되어야 한다
+        for (java.util.concurrent.Future<Throwable> f : futures) {
+            Throwable t = f.get(10, java.util.concurrent.TimeUnit.SECONDS);
+            assertThat(t).as("동시 register는 예외 없이 완료되어야 한다").isNull();
+        }
+        pool.shutdownNow();
+
+        // 최종 상태: 동일 토큰 레코드 1건, 활성
+        Optional<DeviceToken> found = deviceTokenRepository.findByToken(token);
+        assertThat(found).isPresent();
+        assertThat(found.get().isActive()).isTrue();
+        assertThat(deviceTokenRepository.findByUserId(user1.getId())).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("신규 정상 경로: 토큰이 없으면 INSERT되어 커밋된다")
+    void should_insertAndCommit_when_brandNewToken() {
+        // when
+        DeviceToken result = service.register(user1.getId(), "brand-new-token", DeviceType.ANDROID);
+
+        // then
+        assertThat(result.getUserId()).isEqualTo(user1.getId());
+        assertThat(result.isActive()).isTrue();
+        Optional<DeviceToken> found = deviceTokenRepository.findByToken("brand-new-token");
+        assertThat(found).isPresent();
+        assertThat(found.get().getId()).isEqualTo(result.getId());
+    }
+
+    @Test
+    @DisplayName("재등록 경로: 같은 사용자의 비활성 토큰을 다시 등록하면 활성화된다")
+    void should_reactivate_when_sameUserReregisters() {
+        // given
+        String token = "reactivate-token";
+        inserter.insertNew(user1.getId(), token, DeviceType.ANDROID);
+        deactivateInTx(token);
+
+        // when
+        DeviceToken result = service.register(user1.getId(), token, DeviceType.ANDROID);
+
+        // then
+        assertThat(result.isActive()).isTrue();
+        assertThat(deviceTokenRepository.findByUserId(user1.getId())).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("소유자 이전 경로: 다른 사용자가 같은 토큰을 등록하면 UNIQUE 충돌 없이 이전된다")
+    void should_transferOwnership_when_anotherUserRegisters() {
+        // given: user1이 토큰 보유
+        String token = "transfer-token";
+        inserter.insertNew(user1.getId(), token, DeviceType.ANDROID);
+        deactivateInTx(token);
+
+        // when: user2가 동일 토큰 등록
+        DeviceToken result = service.register(user2.getId(), token, DeviceType.IOS);
+
+        // then: 소유자/타입/활성 갱신, 레코드 1건
+        assertThat(result.getUserId()).isEqualTo(user2.getId());
+        assertThat(result.getDeviceType()).isEqualTo(DeviceType.IOS);
+        assertThat(result.isActive()).isTrue();
+        assertThat(deviceTokenRepository.findByUserId(user1.getId())).isEmpty();
+        assertThat(deviceTokenRepository.findByUserId(user2.getId())).hasSize(1);
+    }
+}

--- a/src/test/java/com/cotalk/application/service/notification/RegisterDeviceTokenServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/notification/RegisterDeviceTokenServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.util.Optional;
 
@@ -119,6 +120,78 @@ class RegisterDeviceTokenServiceTest {
             assertThat(result.getDeviceType()).isEqualTo(newDeviceType);
             assertThat(result.isActive()).isTrue();
             verify(deviceTokenRepository).save(existingToken);
+        }
+
+        @Test
+        @DisplayName("동시 등록 경합 - 신규 INSERT가 UNIQUE 위반 시 재조회 후 같은 사용자로 UPDATE 폴백")
+        void should_fallbackToUpdate_when_concurrentInsertViolatesUniqueForSameUser() {
+            // given: findByToken은 처음엔 empty(신규로 판단) → INSERT 시도가 UNIQUE 위반 →
+            //        재조회 시 다른 요청이 먼저 INSERT한 동일 사용자 레코드가 존재
+            Long userId = 1L;
+            String token = "racing-fcm-token";
+            DeviceToken.DeviceType deviceType = DeviceToken.DeviceType.ANDROID;
+
+            DeviceToken concurrentlyInserted = DeviceToken.builder()
+                    .id(200L)
+                    .userId(userId)
+                    .token(token)
+                    .deviceType(deviceType)
+                    .build();
+            concurrentlyInserted.deactivate();
+
+            given(deviceTokenRepository.findByToken(token))
+                    .willReturn(Optional.empty())          // 최초 조회: 신규로 판단
+                    .willReturn(Optional.of(concurrentlyInserted)); // 폴백 재조회: 경쟁 레코드 발견
+            given(idGenerator.nextId()).willReturn(100L);
+            given(deviceTokenRepository.save(any(DeviceToken.class)))
+                    .willThrow(new DataIntegrityViolationException("duplicate token")) // 신규 INSERT 실패
+                    .willAnswer(invocation -> invocation.getArgument(0));              // 폴백 UPDATE 성공
+
+            // when
+            DeviceToken result = registerDeviceTokenService.register(userId, token, deviceType);
+
+            // then: 새 ID(100L)로 INSERT가 아닌, 기존 경쟁 레코드(200L)를 UPDATE하여 반환
+            assertThat(result.getId()).isEqualTo(200L);
+            assertThat(result.getUserId()).isEqualTo(userId);
+            assertThat(result.getToken()).isEqualTo(token);
+            assertThat(result.isActive()).isTrue();
+            verify(deviceTokenRepository, org.mockito.Mockito.times(2)).findByToken(token);
+            verify(deviceTokenRepository).save(concurrentlyInserted);
+        }
+
+        @Test
+        @DisplayName("동시 등록 경합 - 신규 INSERT가 UNIQUE 위반 시 재조회 후 다른 사용자 레코드를 소유자 이전 UPDATE 폴백")
+        void should_fallbackToTransfer_when_concurrentInsertViolatesUniqueForAnotherUser() {
+            // given: 다른 사용자가 먼저 같은 토큰을 INSERT한 상태에서 우리 INSERT가 UNIQUE 위반
+            Long newUserId = 2L;
+            String token = "racing-fcm-token";
+            DeviceToken.DeviceType newDeviceType = DeviceToken.DeviceType.IOS;
+
+            DeviceToken concurrentlyInserted = DeviceToken.builder()
+                    .id(300L)
+                    .userId(1L) // 다른 사용자
+                    .token(token)
+                    .deviceType(DeviceToken.DeviceType.ANDROID)
+                    .build();
+
+            given(deviceTokenRepository.findByToken(token))
+                    .willReturn(Optional.empty())
+                    .willReturn(Optional.of(concurrentlyInserted));
+            given(idGenerator.nextId()).willReturn(101L);
+            given(deviceTokenRepository.save(any(DeviceToken.class)))
+                    .willThrow(new DataIntegrityViolationException("duplicate token"))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            DeviceToken result = registerDeviceTokenService.register(newUserId, token, newDeviceType);
+
+            // then: 경쟁 레코드의 소유자를 우리 사용자로 이전(UPDATE)
+            assertThat(result.getId()).isEqualTo(300L);
+            assertThat(result.getUserId()).isEqualTo(newUserId);
+            assertThat(result.getDeviceType()).isEqualTo(newDeviceType);
+            assertThat(result.isActive()).isTrue();
+            verify(deviceTokenRepository, org.mockito.Mockito.never()).deleteByToken(token);
+            verify(deviceTokenRepository).save(concurrentlyInserted);
         }
     }
 

--- a/src/test/java/com/cotalk/application/service/notification/RegisterDeviceTokenServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/notification/RegisterDeviceTokenServiceTest.java
@@ -2,7 +2,6 @@ package com.cotalk.application.service.notification;
 
 import com.cotalk.domain.entity.DeviceToken;
 import com.cotalk.domain.port.outbound.DeviceTokenRepository;
-import com.cotalk.infrastructure.id.SnowflakeIdGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -19,6 +18,16 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+/**
+ * {@link RegisterDeviceTokenService} 단위 테스트.
+ *
+ * <p>이 단위 테스트는 mock 기반으로 <b>라우팅/위임 로직</b>(기존 토큰 분기, 신규 INSERT
+ * 위임, UNIQUE 위반 시 폴백 경로 선택)만 검증한다. 신규 INSERT는 별도 빈
+ * {@link DeviceTokenInserter}({@code REQUIRES_NEW})에 위임되므로, 실제 트랜잭션 거동
+ * (REQUIRES_NEW 경계에서의 위반 롤백 → 바깥 트랜잭션 비오염 → 폴백 UPDATE 커밋 성공)은
+ * 실제 H2 UNIQUE 제약을 사용하는 {@code RegisterDeviceTokenServiceConcurrencyTest}
+ * ({@code @DataJpaTest})에서 검증한다.</p>
+ */
 @ExtendWith(MockitoExtension.class)
 class RegisterDeviceTokenServiceTest {
 
@@ -26,13 +35,13 @@ class RegisterDeviceTokenServiceTest {
     private DeviceTokenRepository deviceTokenRepository;
 
     @Mock
-    private SnowflakeIdGenerator idGenerator;
+    private DeviceTokenInserter deviceTokenInserter;
 
     private RegisterDeviceTokenService registerDeviceTokenService;
 
     @BeforeEach
     void setUp() {
-        registerDeviceTokenService = new RegisterDeviceTokenService(deviceTokenRepository, idGenerator);
+        registerDeviceTokenService = new RegisterDeviceTokenService(deviceTokenRepository, deviceTokenInserter);
     }
 
     @Nested
@@ -40,25 +49,31 @@ class RegisterDeviceTokenServiceTest {
     class Register {
 
         @Test
-        @DisplayName("새 토큰 등록 성공")
-        void should_registerNewToken_when_tokenNotExists() {
+        @DisplayName("새 토큰 등록은 DeviceTokenInserter(REQUIRES_NEW)에 위임한다")
+        void should_delegateToInserter_when_tokenNotExists() {
             // given
             Long userId = 1L;
             String token = "new-fcm-token";
             DeviceToken.DeviceType deviceType = DeviceToken.DeviceType.ANDROID;
 
+            DeviceToken inserted = DeviceToken.builder()
+                    .id(100L)
+                    .userId(userId)
+                    .token(token)
+                    .deviceType(deviceType)
+                    .build();
+
             given(deviceTokenRepository.findByToken(token)).willReturn(Optional.empty());
-            given(idGenerator.nextId()).willReturn(100L);
-            given(deviceTokenRepository.save(any(DeviceToken.class))).willAnswer(invocation -> invocation.getArgument(0));
+            given(deviceTokenInserter.insertNew(userId, token, deviceType)).willReturn(inserted);
 
             // when
             DeviceToken result = registerDeviceTokenService.register(userId, token, deviceType);
 
-            // then
+            // then: 신규 INSERT는 inserter에 위임되고, 서비스가 직접 save()로 INSERT하지 않는다
             assertThat(result.getUserId()).isEqualTo(userId);
             assertThat(result.getToken()).isEqualTo(token);
-            assertThat(result.getDeviceType()).isEqualTo(deviceType);
-            assertThat(result.isActive()).isTrue();
+            verify(deviceTokenInserter).insertNew(userId, token, deviceType);
+            verify(deviceTokenRepository, org.mockito.Mockito.never()).save(any(DeviceToken.class));
         }
 
         @Test
@@ -83,8 +98,9 @@ class RegisterDeviceTokenServiceTest {
             // when
             DeviceToken result = registerDeviceTokenService.register(userId, token, deviceType);
 
-            // then
+            // then: 기존 레코드 재사용 경로는 inserter를 거치지 않는다
             assertThat(result.isActive()).isTrue();
+            verify(deviceTokenInserter, org.mockito.Mockito.never()).insertNew(any(), any(), any());
         }
 
         @Test
@@ -111,8 +127,7 @@ class RegisterDeviceTokenServiceTest {
 
             // then: UNIQUE 충돌을 유발할 수 있는 delete는 호출되지 않아야 한다
             verify(deviceTokenRepository, org.mockito.Mockito.never()).deleteByToken(token);
-            // 새 엔티티를 만들지 않으므로 ID 생성도 호출되지 않는다 (동일 레코드 재사용)
-            verify(idGenerator, org.mockito.Mockito.never()).nextId();
+            verify(deviceTokenInserter, org.mockito.Mockito.never()).insertNew(any(), any(), any());
             // 기존 레코드의 ID를 유지한 채 소유자/타입/활성 상태만 갱신
             assertThat(result.getId()).isEqualTo(100L);
             assertThat(result.getUserId()).isEqualTo(newUserId);
@@ -123,10 +138,10 @@ class RegisterDeviceTokenServiceTest {
         }
 
         @Test
-        @DisplayName("동시 등록 경합 - 신규 INSERT가 UNIQUE 위반 시 재조회 후 같은 사용자로 UPDATE 폴백")
-        void should_fallbackToUpdate_when_concurrentInsertViolatesUniqueForSameUser() {
-            // given: findByToken은 처음엔 empty(신규로 판단) → INSERT 시도가 UNIQUE 위반 →
-            //        재조회 시 다른 요청이 먼저 INSERT한 동일 사용자 레코드가 존재
+        @DisplayName("신규 INSERT가 UNIQUE 위반 시 재조회 후 같은 사용자로 UPDATE 폴백 경로를 탄다")
+        void should_routeToReactivateFallback_when_inserterThrowsForSameUser() {
+            // given: inserter(REQUIRES_NEW)가 UNIQUE 위반을 던지면(독립 트랜잭션에서 롤백됨),
+            //        바깥 트랜잭션은 깨끗하므로 재조회 후 UPDATE 폴백을 수행
             Long userId = 1L;
             String token = "racing-fcm-token";
             DeviceToken.DeviceType deviceType = DeviceToken.DeviceType.ANDROID;
@@ -140,28 +155,26 @@ class RegisterDeviceTokenServiceTest {
             concurrentlyInserted.deactivate();
 
             given(deviceTokenRepository.findByToken(token))
-                    .willReturn(Optional.empty())          // 최초 조회: 신규로 판단
-                    .willReturn(Optional.of(concurrentlyInserted)); // 폴백 재조회: 경쟁 레코드 발견
-            given(idGenerator.nextId()).willReturn(100L);
-            given(deviceTokenRepository.save(any(DeviceToken.class)))
-                    .willThrow(new DataIntegrityViolationException("duplicate token")) // 신규 INSERT 실패
-                    .willAnswer(invocation -> invocation.getArgument(0));              // 폴백 UPDATE 성공
+                    .willReturn(Optional.empty())                    // 최초 조회: 신규로 판단
+                    .willReturn(Optional.of(concurrentlyInserted));  // 폴백 재조회: 경쟁 레코드 발견
+            given(deviceTokenInserter.insertNew(userId, token, deviceType))
+                    .willThrow(new DataIntegrityViolationException("duplicate token"));
+            given(deviceTokenRepository.save(any(DeviceToken.class))).willAnswer(invocation -> invocation.getArgument(0));
 
             // when
             DeviceToken result = registerDeviceTokenService.register(userId, token, deviceType);
 
-            // then: 새 ID(100L)로 INSERT가 아닌, 기존 경쟁 레코드(200L)를 UPDATE하여 반환
+            // then: 새 ID로 INSERT가 아닌, 기존 경쟁 레코드(200L)를 UPDATE하여 반환
             assertThat(result.getId()).isEqualTo(200L);
             assertThat(result.getUserId()).isEqualTo(userId);
-            assertThat(result.getToken()).isEqualTo(token);
             assertThat(result.isActive()).isTrue();
             verify(deviceTokenRepository, org.mockito.Mockito.times(2)).findByToken(token);
             verify(deviceTokenRepository).save(concurrentlyInserted);
         }
 
         @Test
-        @DisplayName("동시 등록 경합 - 신규 INSERT가 UNIQUE 위반 시 재조회 후 다른 사용자 레코드를 소유자 이전 UPDATE 폴백")
-        void should_fallbackToTransfer_when_concurrentInsertViolatesUniqueForAnotherUser() {
+        @DisplayName("신규 INSERT가 UNIQUE 위반 시 다른 사용자 레코드를 소유자 이전 UPDATE 폴백 경로를 탄다")
+        void should_routeToTransferFallback_when_inserterThrowsForAnotherUser() {
             // given: 다른 사용자가 먼저 같은 토큰을 INSERT한 상태에서 우리 INSERT가 UNIQUE 위반
             Long newUserId = 2L;
             String token = "racing-fcm-token";
@@ -177,10 +190,9 @@ class RegisterDeviceTokenServiceTest {
             given(deviceTokenRepository.findByToken(token))
                     .willReturn(Optional.empty())
                     .willReturn(Optional.of(concurrentlyInserted));
-            given(idGenerator.nextId()).willReturn(101L);
-            given(deviceTokenRepository.save(any(DeviceToken.class)))
-                    .willThrow(new DataIntegrityViolationException("duplicate token"))
-                    .willAnswer(invocation -> invocation.getArgument(0));
+            given(deviceTokenInserter.insertNew(newUserId, token, newDeviceType))
+                    .willThrow(new DataIntegrityViolationException("duplicate token"));
+            given(deviceTokenRepository.save(any(DeviceToken.class))).willAnswer(invocation -> invocation.getArgument(0));
 
             // when
             DeviceToken result = registerDeviceTokenService.register(newUserId, token, newDeviceType);

--- a/src/test/java/com/cotalk/application/service/notification/RegisterDeviceTokenServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/notification/RegisterDeviceTokenServiceTest.java
@@ -87,30 +87,38 @@ class RegisterDeviceTokenServiceTest {
         }
 
         @Test
-        @DisplayName("토큰이 다른 사용자에게 있으면 새 사용자로 이전")
+        @DisplayName("토큰이 다른 사용자에게 있으면 delete+insert 없이 기존 레코드를 UPDATE하여 새 사용자로 이전")
         void should_transferToken_when_tokenBelongsToAnotherUser() {
             // given
             Long newUserId = 2L;
             String token = "existing-fcm-token";
-            DeviceToken.DeviceType deviceType = DeviceToken.DeviceType.ANDROID;
+            DeviceToken.DeviceType newDeviceType = DeviceToken.DeviceType.IOS;
 
             DeviceToken existingToken = DeviceToken.builder()
                     .id(100L)
                     .userId(1L)  // 다른 사용자
                     .token(token)
-                    .deviceType(deviceType)
+                    .deviceType(DeviceToken.DeviceType.ANDROID)
                     .build();
+            existingToken.deactivate();
 
             given(deviceTokenRepository.findByToken(token)).willReturn(Optional.of(existingToken));
-            given(idGenerator.nextId()).willReturn(200L);
             given(deviceTokenRepository.save(any(DeviceToken.class))).willAnswer(invocation -> invocation.getArgument(0));
 
             // when
-            DeviceToken result = registerDeviceTokenService.register(newUserId, token, deviceType);
+            DeviceToken result = registerDeviceTokenService.register(newUserId, token, newDeviceType);
 
-            // then
-            verify(deviceTokenRepository).deleteByToken(token);
+            // then: UNIQUE 충돌을 유발할 수 있는 delete는 호출되지 않아야 한다
+            verify(deviceTokenRepository, org.mockito.Mockito.never()).deleteByToken(token);
+            // 새 엔티티를 만들지 않으므로 ID 생성도 호출되지 않는다 (동일 레코드 재사용)
+            verify(idGenerator, org.mockito.Mockito.never()).nextId();
+            // 기존 레코드의 ID를 유지한 채 소유자/타입/활성 상태만 갱신
+            assertThat(result.getId()).isEqualTo(100L);
             assertThat(result.getUserId()).isEqualTo(newUserId);
+            assertThat(result.getToken()).isEqualTo(token);
+            assertThat(result.getDeviceType()).isEqualTo(newDeviceType);
+            assertThat(result.isActive()).isTrue();
+            verify(deviceTokenRepository).save(existingToken);
         }
     }
 

--- a/src/test/java/com/cotalk/infrastructure/push/FcmPushNotificationSenderTest.java
+++ b/src/test/java/com/cotalk/infrastructure/push/FcmPushNotificationSenderTest.java
@@ -1,7 +1,5 @@
 package com.cotalk.infrastructure.push;
 
-import com.cotalk.domain.entity.DeviceToken;
-import com.cotalk.domain.port.outbound.DeviceTokenRepository;
 import com.cotalk.domain.port.outbound.PushNotificationSender.PushTarget;
 import com.google.firebase.messaging.*;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,7 +14,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -31,13 +28,13 @@ class FcmPushNotificationSenderTest {
     private FirebaseMessaging firebaseMessaging;
 
     @Mock
-    private DeviceTokenRepository deviceTokenRepository;
+    private InvalidTokenDeactivator invalidTokenDeactivator;
 
     private FcmPushNotificationSender sender;
 
     @BeforeEach
     void setUp() {
-        sender = new FcmPushNotificationSender(firebaseMessaging, deviceTokenRepository);
+        sender = new FcmPushNotificationSender(firebaseMessaging, invalidTokenDeactivator);
     }
 
     @Nested
@@ -49,7 +46,7 @@ class FcmPushNotificationSenderTest {
         void should_ReturnFalse_when_FirebaseNotConfigured() {
             // given
             FcmPushNotificationSender senderWithoutFirebase =
-                    new FcmPushNotificationSender(null, deviceTokenRepository);
+                    new FcmPushNotificationSender(null, invalidTokenDeactivator);
 
             // when
             boolean result = senderWithoutFirebase.send("token", "title", "body", Map.of(), null);
@@ -80,56 +77,39 @@ class FcmPushNotificationSenderTest {
         }
 
         @Test
-        @DisplayName("UNREGISTERED 에러 시 토큰을 비활성화한다")
+        @DisplayName("UNREGISTERED 에러 시 토큰 비활성화를 별도 컴포넌트에 위임한다")
         void should_DeactivateToken_when_UnregisteredError() throws FirebaseMessagingException {
             // given
             String token = "invalid-token";
-            DeviceToken deviceToken = DeviceToken.builder()
-                    .id(1L)
-                    .userId(1L)
-                    .token(token)
-                    .deviceType(DeviceToken.DeviceType.ANDROID)
-                    .active(true)
-                    .build();
 
             FirebaseMessagingException exception = mock(FirebaseMessagingException.class);
             given(exception.getMessagingErrorCode()).willReturn(MessagingErrorCode.UNREGISTERED);
             given(firebaseMessaging.send(any(Message.class))).willThrow(exception);
-            given(deviceTokenRepository.findByToken(token)).willReturn(Optional.of(deviceToken));
 
             // when
             boolean result = sender.send(token, "title", "body", Map.of(), null);
 
-            // then
+            // then: 비활성화는 별도 트랜잭션을 가진 컴포넌트로 위임된다
             assertThat(result).isFalse();
-            verify(deviceTokenRepository).save(deviceToken);
-            assertThat(deviceToken.isActive()).isFalse();
+            verify(invalidTokenDeactivator).deactivateToken(token);
         }
 
         @Test
-        @DisplayName("INVALID_ARGUMENT 에러 시 토큰을 비활성화한다")
+        @DisplayName("INVALID_ARGUMENT 에러 시 토큰 비활성화를 별도 컴포넌트에 위임한다")
         void should_DeactivateToken_when_InvalidArgumentError() throws FirebaseMessagingException {
             // given
             String token = "malformed-token";
-            DeviceToken deviceToken = DeviceToken.builder()
-                    .id(1L)
-                    .userId(1L)
-                    .token(token)
-                    .deviceType(DeviceToken.DeviceType.IOS)
-                    .active(true)
-                    .build();
 
             FirebaseMessagingException exception = mock(FirebaseMessagingException.class);
             given(exception.getMessagingErrorCode()).willReturn(MessagingErrorCode.INVALID_ARGUMENT);
             given(firebaseMessaging.send(any(Message.class))).willThrow(exception);
-            given(deviceTokenRepository.findByToken(token)).willReturn(Optional.of(deviceToken));
 
             // when
             boolean result = sender.send(token, "title", "body", Map.of(), null);
 
             // then
             assertThat(result).isFalse();
-            verify(deviceTokenRepository).save(deviceToken);
+            verify(invalidTokenDeactivator).deactivateToken(token);
         }
 
         @Test
@@ -148,26 +128,7 @@ class FcmPushNotificationSenderTest {
 
             // then
             assertThat(result).isFalse();
-            verify(deviceTokenRepository, never()).findByToken(anyString());
-        }
-
-        @Test
-        @DisplayName("존재하지 않는 토큰은 비활성화를 건너뛴다")
-        void should_SkipDeactivation_when_TokenNotFound() throws FirebaseMessagingException {
-            // given
-            String token = "unknown-token";
-
-            FirebaseMessagingException exception = mock(FirebaseMessagingException.class);
-            given(exception.getMessagingErrorCode()).willReturn(MessagingErrorCode.UNREGISTERED);
-            given(firebaseMessaging.send(any(Message.class))).willThrow(exception);
-            given(deviceTokenRepository.findByToken(token)).willReturn(Optional.empty());
-
-            // when
-            boolean result = sender.send(token, "title", "body", Map.of(), null);
-
-            // then
-            assertThat(result).isFalse();
-            verify(deviceTokenRepository, never()).save(any());
+            verifyNoInteractions(invalidTokenDeactivator);
         }
     }
 
@@ -180,7 +141,7 @@ class FcmPushNotificationSenderTest {
         void should_ReturnZero_when_FirebaseNotConfigured() {
             // given
             FcmPushNotificationSender senderWithoutFirebase =
-                    new FcmPushNotificationSender(null, deviceTokenRepository);
+                    new FcmPushNotificationSender(null, invalidTokenDeactivator);
             List<String> tokens = List.of("token1", "token2");
 
             // when
@@ -245,23 +206,12 @@ class FcmPushNotificationSenderTest {
             given(firebaseMessaging.sendEachForMulticast(any(MulticastMessage.class)))
                     .willReturn(batchResponse);
 
-            DeviceToken invalidDeviceToken = DeviceToken.builder()
-                    .id(2L)
-                    .userId(2L)
-                    .token("invalid-token")
-                    .deviceType(DeviceToken.DeviceType.ANDROID)
-                    .active(true)
-                    .build();
-            given(deviceTokenRepository.findByToken("invalid-token"))
-                    .willReturn(Optional.of(invalidDeviceToken));
-
             // when
             int result = sender.sendMultiple(tokens, "title", "body", Map.of(), null);
 
-            // then
+            // then: 무효 토큰만 별도 트랜잭션 컴포넌트로 비활성화 위임
             assertThat(result).isEqualTo(1);
-            verify(deviceTokenRepository).save(invalidDeviceToken);
-            assertThat(invalidDeviceToken.isActive()).isFalse();
+            verify(invalidTokenDeactivator).deactivateTokens(List.of("invalid-token"));
         }
 
         @Test
@@ -332,7 +282,7 @@ class FcmPushNotificationSenderTest {
 
             // then
             assertThat(result).isZero();
-            verify(deviceTokenRepository, never()).findByToken(anyString());
+            verifyNoInteractions(invalidTokenDeactivator);
         }
     }
 
@@ -345,7 +295,7 @@ class FcmPushNotificationSenderTest {
         void should_ReturnZero_when_FirebaseNotConfigured() {
             // given
             FcmPushNotificationSender senderWithoutFirebase =
-                    new FcmPushNotificationSender(null, deviceTokenRepository);
+                    new FcmPushNotificationSender(null, invalidTokenDeactivator);
             List<PushTarget> targets = List.of(new PushTarget("token1", 3));
 
             // when
@@ -417,23 +367,12 @@ class FcmPushNotificationSenderTest {
             given(batchResponse.getResponses()).willReturn(List.of(successResponse, failResponse));
             given(firebaseMessaging.sendEach(anyList())).willReturn(batchResponse);
 
-            DeviceToken invalidDeviceToken = DeviceToken.builder()
-                    .id(2L)
-                    .userId(2L)
-                    .token("invalid-token")
-                    .deviceType(DeviceToken.DeviceType.IOS)
-                    .active(true)
-                    .build();
-            given(deviceTokenRepository.findByToken("invalid-token"))
-                    .willReturn(Optional.of(invalidDeviceToken));
-
             // when
             int result = sender.sendEachWithBadge(targets, "title", "body", Map.of(), null);
 
-            // then
+            // then: 무효 토큰만 별도 트랜잭션 컴포넌트로 비활성화 위임
             assertThat(result).isEqualTo(1);
-            verify(deviceTokenRepository).save(invalidDeviceToken);
-            assertThat(invalidDeviceToken.isActive()).isFalse();
+            verify(invalidTokenDeactivator).deactivateTokens(List.of("invalid-token"));
         }
 
         @Test

--- a/src/test/java/com/cotalk/infrastructure/push/InvalidTokenDeactivatorTest.java
+++ b/src/test/java/com/cotalk/infrastructure/push/InvalidTokenDeactivatorTest.java
@@ -1,0 +1,118 @@
+package com.cotalk.infrastructure.push;
+
+import com.cotalk.domain.entity.DeviceToken;
+import com.cotalk.domain.port.outbound.DeviceTokenRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * InvalidTokenDeactivator 테스트.
+ *
+ * <p>FCM 전송 실패 토큰의 비활성화(DB 쓰기)가 FCM 전송과 분리된 컴포넌트에서
+ * 수행되는지 검증한다. 트랜잭션 적용 자체는 별도 빈으로 분리하여 self-invocation
+ * 프록시 함정을 회피했으며, 본 단위 테스트는 비활성화 로직의 동작을 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("InvalidTokenDeactivator")
+class InvalidTokenDeactivatorTest {
+
+    @Mock
+    private DeviceTokenRepository deviceTokenRepository;
+
+    private InvalidTokenDeactivator deactivator;
+
+    @BeforeEach
+    void setUp() {
+        deactivator = new InvalidTokenDeactivator(deviceTokenRepository);
+    }
+
+    @Test
+    @DisplayName("존재하는 토큰을 비활성화하고 저장한다")
+    void should_deactivateAndSave_when_tokenExists() {
+        // given
+        String token = "invalid-token";
+        DeviceToken deviceToken = DeviceToken.builder()
+                .id(1L)
+                .userId(1L)
+                .token(token)
+                .deviceType(DeviceToken.DeviceType.ANDROID)
+                .active(true)
+                .build();
+        given(deviceTokenRepository.findByToken(token)).willReturn(Optional.of(deviceToken));
+
+        // when
+        deactivator.deactivateToken(token);
+
+        // then
+        verify(deviceTokenRepository).save(deviceToken);
+        assertThat(deviceToken.isActive()).isFalse();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 토큰은 저장을 건너뛴다")
+    void should_skipSave_when_tokenNotFound() {
+        // given
+        String token = "unknown-token";
+        given(deviceTokenRepository.findByToken(token)).willReturn(Optional.empty());
+
+        // when
+        deactivator.deactivateToken(token);
+
+        // then
+        verify(deviceTokenRepository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("여러 토큰을 비활성화한다")
+    void should_deactivateMultiple_when_tokensProvided() {
+        // given
+        DeviceToken token1 = DeviceToken.builder()
+                .id(1L).userId(1L).token("t1")
+                .deviceType(DeviceToken.DeviceType.ANDROID).active(true).build();
+        DeviceToken token2 = DeviceToken.builder()
+                .id(2L).userId(2L).token("t2")
+                .deviceType(DeviceToken.DeviceType.IOS).active(true).build();
+        given(deviceTokenRepository.findByToken("t1")).willReturn(Optional.of(token1));
+        given(deviceTokenRepository.findByToken("t2")).willReturn(Optional.of(token2));
+
+        // when
+        deactivator.deactivateTokens(List.of("t1", "t2"));
+
+        // then
+        verify(deviceTokenRepository).save(token1);
+        verify(deviceTokenRepository).save(token2);
+        assertThat(token1.isActive()).isFalse();
+        assertThat(token2.isActive()).isFalse();
+    }
+
+    @Test
+    @DisplayName("목록 중 존재하지 않는 토큰은 건너뛴다")
+    void should_skipMissingTokens_when_someTokensNotFound() {
+        // given
+        DeviceToken token1 = DeviceToken.builder()
+                .id(1L).userId(1L).token("t1")
+                .deviceType(DeviceToken.DeviceType.ANDROID).active(true).build();
+        given(deviceTokenRepository.findByToken("t1")).willReturn(Optional.of(token1));
+        given(deviceTokenRepository.findByToken("missing")).willReturn(Optional.empty());
+
+        // when
+        deactivator.deactivateTokens(List.of("t1", "missing"));
+
+        // then
+        verify(deviceTokenRepository).save(token1);
+        verify(deviceTokenRepository, never()).save(org.mockito.ArgumentMatchers.argThat(
+                dt -> dt != null && "missing".equals(dt.getToken())));
+    }
+}


### PR DESCRIPTION
## 배경 (점검 P3 2건)

1. **FCM 네트워크 호출이 `@Transactional` 안에서 실행 → DB 커넥션 점유**
   `FcmPushNotificationSender`의 `send`/`sendMultiple`/`sendEachWithBadge`가 `@Transactional`인데, 내부에서 FCM 원격 호출(수백ms~수초)을 수행하여 그 왕복 내내 DB 커넥션을 점유했다. `SendMessageService`는 의도적으로 트랜잭션 밖에서 푸시를 호출(커넥션 점유 회피)하는데, 어댑터가 다시 트랜잭션을 열어 그 최적화를 무력화했다.

2. **디바이스 토큰 소유자 이전 시 같은 트랜잭션 delete→insert로 UNIQUE 충돌 가능**
   `RegisterDeviceTokenService.register`에서 다른 사용자가 같은 토큰을 등록하면 `deleteByToken(token)` 후 동일 `token`(unique)으로 새 엔티티를 `save`했다. Hibernate flush 순서에 따라 INSERT가 DELETE보다 먼저 DB에 도달하면 UNIQUE 위반이 발생할 수 있었다.

## 변경

1. **FCM 전송 / 실패 토큰 비활성화 트랜잭션 분리**
   - 세 public 메서드에서 `@Transactional` 제거 → FCM 호출은 트랜잭션 밖에서 실행
   - 무효 토큰 비활성화(DB 쓰기)는 신규 `InvalidTokenDeactivator`(별도 빈)의 `@Transactional` 메서드로 위임 → 짧은 독립 트랜잭션으로 커넥션 점유 최소화
   - **self-invocation 프록시 함정 회피**: 비활성화 `@Transactional`을 동일 클래스가 아닌 외부 빈으로 분리하여 호출이 Spring AOP 프록시를 거치도록 함
   - 전송 결과/배지/토큰 비활성화 의미는 그대로 보존

2. **토큰 소유자 이전을 UPDATE로 처리**
   - delete+insert 대신 `DeviceToken.transferTo(newUserId, newDeviceType)`로 기존 레코드의 소유자/타입/active만 UPDATE → UNIQUE 충돌 회피
   - 토큰 1개=1소유자, 재등록 시 활성화라는 기존 의미 보존

## 검증
- `./gradlew test` 그린, `./gradlew build` 성공 (ArchUnit 위반 없음, JaCoCo 게이트 통과)
- 추가/갱신 테스트:
  - `InvalidTokenDeactivatorTest`: 비활성화 동작(존재/미존재/다중)
  - `FcmPushNotificationSenderTest`: FCM 실패 시 비활성화가 별도 컴포넌트로 위임됨을 검증
  - `RegisterDeviceTokenServiceTest`: 이전 시 delete/ID생성 미호출 + 동일 레코드 UPDATE 검증
  - `DeviceTokenRepositoryAdapterTest`(@DataJpaTest): 실제 H2에서 토큰 이전 시 UNIQUE 위반 없이 소유자 변경·활성화 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)