### PR TITLE
feat(block): 차단을 메시지·친구요청·1:1방 생성에 실제 반영

### DIFF
--- a/src/main/java/com/cotalk/application/service/chatroom/CreateChatRoomService.java
+++ b/src/main/java/com/cotalk/application/service/chatroom/CreateChatRoomService.java
@@ -9,6 +9,7 @@ import com.cotalk.domain.port.outbound.IdGenerator;
 import com.cotalk.domain.port.outbound.TimeProvider;
 import com.cotalk.domain.port.outbound.UserEventBroker;
 import com.cotalk.domain.port.outbound.UserEventBroker.ChatListUpdateEvent;
+import com.cotalk.domain.validator.BlockValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Isolation;
@@ -32,6 +33,7 @@ public class CreateChatRoomService implements CreateChatRoomUseCase {
     private final IdGenerator idGenerator;
     private final TimeProvider timeProvider;
     private final UserEventBroker userEventBroker;
+    private final BlockValidator blockValidator;
 
     /**
      * 1:1 채팅방을 생성한다.
@@ -55,6 +57,9 @@ public class CreateChatRoomService implements CreateChatRoomUseCase {
         if (userId1.equals(userId2)) {
             return createSelfChatRoom(userId1);
         }
+
+        // 1:1 채팅방 생성 시 차단 관계 검증 (양방향): 한쪽이라도 차단했으면 거부
+        blockValidator.validateNotBlocked(userId1, userId2);
 
         Optional<ChatRoom> existingRoom = chatRoomRepository.findDirectChatRoomByUserIds(userId1, userId2);
         if (existingRoom.isPresent()) {

--- a/src/main/java/com/cotalk/application/service/chatroom/ReinviteDirectChatMemberService.java
+++ b/src/main/java/com/cotalk/application/service/chatroom/ReinviteDirectChatMemberService.java
@@ -18,6 +18,7 @@ import com.cotalk.domain.port.outbound.MessageRepository;
 import com.cotalk.domain.port.outbound.UserEventBroker;
 import com.cotalk.domain.port.outbound.UserEventBroker.ChatListUpdateEvent;
 import com.cotalk.domain.port.outbound.UserRepository;
+import com.cotalk.domain.validator.BlockValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -45,6 +46,7 @@ public class ReinviteDirectChatMemberService implements ReinviteDirectChatMember
     private final MessageRepository messageRepository;
     private final ChatMessageBroker chatMessageBroker;
     private final UserEventBroker userEventBroker;
+    private final BlockValidator blockValidator;
 
     /**
      * 1:1 채팅방에서 나간 상대방을 재초대한다.
@@ -82,6 +84,9 @@ public class ReinviteDirectChatMemberService implements ReinviteDirectChatMember
         // 5. 재초대할 사용자 존재 확인
         User invitee = userRepository.findById(inviteeId)
                 .orElseThrow(() -> new UserNotFoundException(inviteeId));
+
+        // 5-1. 차단 관계 검증 (양방향): 초대자-피초대자 사이에 차단이 있으면 재초대 거부
+        blockValidator.validateNotBlocked(inviterId, inviteeId);
 
         // 6. 새 멤버 추가
         ChatRoomMember newMember = ChatRoomMember.builder()

--- a/src/main/java/com/cotalk/application/service/friend/AcceptFriendRequestService.java
+++ b/src/main/java/com/cotalk/application/service/friend/AcceptFriendRequestService.java
@@ -9,6 +9,7 @@ import com.cotalk.domain.port.outbound.DistributedLockPort;
 import com.cotalk.domain.port.outbound.FriendRepository;
 import com.cotalk.domain.port.outbound.FriendRequestRepository;
 import com.cotalk.domain.port.outbound.IdGenerator;
+import com.cotalk.domain.validator.BlockValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -34,6 +35,7 @@ public class AcceptFriendRequestService implements AcceptFriendRequestUseCase {
     private final IdGenerator idGenerator;
     private final DistributedLockPort lockExecutor;
     private final TransactionTemplate transactionTemplate;
+    private final BlockValidator blockValidator;
 
     /**
      * 친구 요청을 수락한다.
@@ -51,6 +53,7 @@ public class AcceptFriendRequestService implements AcceptFriendRequestUseCase {
      * @return 생성된 친구 관계 ID
      * @throws FriendNotFoundException       친구 요청을 찾을 수 없는 경우
      * @throws InvalidFriendRequestException 본인이 받은 요청이 아니거나 이미 처리된 요청인 경우
+     * @throws com.cotalk.domain.exception.BlockedRelationshipException 요청자-수신자 사이에 차단 관계가 존재하는 경우
      */
     @Override
     public Long acceptFriendRequest(Long receiverId, Long requestId) {
@@ -79,6 +82,11 @@ public class AcceptFriendRequestService implements AcceptFriendRequestUseCase {
         if (!friendRequest.isPending()) {
             throw new InvalidFriendRequestException("이미 처리된 친구 요청입니다.");
         }
+
+        // 차단 관계 검증 (양방향): 요청 전송 후 어느 한쪽이 상대를 차단한 경우 수락을 거부하여
+        // 전송 경로(SendFriendRequestService)에 적용된 차단 정책을 수락 경로에서도 일관되게 유지한다.
+        // 분산락 + 트랜잭션 경계 안에서 검사하여 동시성을 보장한다.
+        blockValidator.validateNotBlocked(friendRequest.getRequesterId(), friendRequest.getReceiverId());
 
         friendRequest.accept();
         friendRequestRepository.save(friendRequest);

--- a/src/main/java/com/cotalk/application/service/friend/SendFriendRequestService.java
+++ b/src/main/java/com/cotalk/application/service/friend/SendFriendRequestService.java
@@ -9,6 +9,7 @@ import com.cotalk.domain.port.outbound.FriendRepository;
 import com.cotalk.domain.port.outbound.FriendRequestRepository;
 import com.cotalk.domain.port.outbound.IdGenerator;
 import com.cotalk.domain.port.outbound.NotificationCommandPort;
+import com.cotalk.domain.validator.BlockValidator;
 import com.cotalk.domain.validator.UserValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,6 +38,7 @@ public class SendFriendRequestService implements SendFriendRequestUseCase {
     private final FriendRequestRepository friendRequestRepository;
     private final FriendRepository friendRepository;
     private final UserValidator userValidator;
+    private final BlockValidator blockValidator;
     private final IdGenerator idGenerator;
     private final DistributedLockPort lockExecutor;
     private final NotificationCommandPort notificationCommandPort;
@@ -79,6 +81,9 @@ public class SendFriendRequestService implements SendFriendRequestUseCase {
      * @return 생성된 친구 요청 ID
      */
     protected Long createFriendRequest(Long requesterId, Long receiverId) {
+        // 차단 관계 검증 (양방향): 한쪽이라도 차단했으면 친구 요청 거부
+        blockValidator.validateNotBlocked(requesterId, receiverId);
+
         // 이미 친구인지 확인
         if (friendRepository.existsByUserIdAndFriendId(requesterId, receiverId)) {
             throw new InvalidFriendRequestException("이미 친구입니다.");

--- a/src/main/java/com/cotalk/application/service/message/SendMessageService.java
+++ b/src/main/java/com/cotalk/application/service/message/SendMessageService.java
@@ -1,12 +1,14 @@
 package com.cotalk.application.service.message;
 
 import com.cotalk.domain.constants.MessageConstants;
+import com.cotalk.domain.entity.ChatRoom;
 import com.cotalk.domain.entity.ChatRoomMember;
 import com.cotalk.domain.entity.Message;
 import com.cotalk.domain.entity.Message.MessageType;
 import com.cotalk.domain.entity.User;
 import com.cotalk.domain.port.inbound.message.SendMessageUseCase;
 import com.cotalk.domain.port.outbound.ChatRoomMemberRepository;
+import com.cotalk.domain.port.outbound.ChatRoomRepository;
 import com.cotalk.domain.port.outbound.ChatRoomPresenceTracker;
 import com.cotalk.domain.port.outbound.IdGenerator;
 import com.cotalk.domain.port.outbound.MessageRepository;
@@ -15,6 +17,7 @@ import com.cotalk.domain.port.outbound.NotificationCommandPort;
 import com.cotalk.domain.port.outbound.TimeProvider;
 import com.cotalk.domain.port.outbound.UserRepository;
 import com.cotalk.domain.util.HtmlSanitizer;
+import com.cotalk.domain.validator.BlockValidator;
 import com.cotalk.domain.validator.FileMessageValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,6 +44,7 @@ public class SendMessageService implements SendMessageUseCase {
 
     private final MessageRepository messageRepository;
     private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private final ChatRoomRepository chatRoomRepository;
     private final UserRepository userRepository;
     private final IdGenerator idGenerator;
     private final NotificationCommandPort notificationCommandPort;
@@ -51,6 +55,7 @@ public class SendMessageService implements SendMessageUseCase {
     private final TransactionTemplate transactionTemplate;
     private final TimeProvider timeProvider;
     private final FileMessageValidator fileMessageValidator;
+    private final BlockValidator blockValidator;
 
     /**
      * 텍스트 메시지를 전송한다.
@@ -166,6 +171,9 @@ public class SendMessageService implements SendMessageUseCase {
                 throw new com.cotalk.domain.exception.ChatRoomAccessDeniedException(chatRoomId, senderId);
             }
 
+            // 1:1(DIRECT) 채팅방에서 상대와 차단 관계면 메시지 전송 거부 (양방향)
+            validateNotBlockedInDirectChat(chatRoomId, senderId, members);
+
             // 내용 검증
             message.validateContent();
 
@@ -196,6 +204,36 @@ public class SendMessageService implements SendMessageUseCase {
 
         customMetrics.stopMessageProcessingTimer(timerSample);
         return result;
+    }
+
+    /**
+     * 1:1(DIRECT) 채팅방에서 발신자와 상대방 사이에 차단 관계가 없는지 검증한다.
+     * <p>
+     * 멤버가 정확히 2명인 방만 후보로 보고, 채팅방 타입이 DIRECT인 경우에만 상대를 식별하여
+     * 양방향 차단 검사를 수행한다. SELF(1명) · 그룹(3명 이상)이나 멤버 수가 2가 아닌 방은
+     * 차단 검사 범위에서 제외한다(그룹 정책은 이번 범위 외).
+     * </p>
+     *
+     * @param chatRoomId 채팅방 ID
+     * @param senderId 발신자 ID
+     * @param members 사전 조회된 채팅방 멤버 목록
+     */
+    private void validateNotBlockedInDirectChat(Long chatRoomId, Long senderId, List<ChatRoomMember> members) {
+        // 멤버 2명이 아니면 DIRECT가 아니므로 추가 조회 없이 통과 (SELF/그룹)
+        if (members.size() != 2) {
+            return;
+        }
+
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId).orElse(null);
+        if (chatRoom == null || !chatRoom.isDirectChat()) {
+            return;
+        }
+
+        members.stream()
+                .map(ChatRoomMember::getUserId)
+                .filter(userId -> !userId.equals(senderId))
+                .findFirst()
+                .ifPresent(otherUserId -> blockValidator.validateNotBlocked(senderId, otherUserId));
     }
 
     /**

--- a/src/main/java/com/cotalk/application/service/message/SendMessageService.java
+++ b/src/main/java/com/cotalk/application/service/message/SendMessageService.java
@@ -209,9 +209,17 @@ public class SendMessageService implements SendMessageUseCase {
     /**
      * 1:1(DIRECT) 채팅방에서 발신자와 상대방 사이에 차단 관계가 없는지 검증한다.
      * <p>
-     * 멤버가 정확히 2명인 방만 후보로 보고, 채팅방 타입이 DIRECT인 경우에만 상대를 식별하여
-     * 양방향 차단 검사를 수행한다. SELF(1명) · 그룹(3명 이상)이나 멤버 수가 2가 아닌 방은
-     * 차단 검사 범위에서 제외한다(그룹 정책은 이번 범위 외).
+     * 상대(발신자 외 다른 멤버)를 먼저 식별한 뒤, 채팅방 타입이 DIRECT인 경우에만 양방향
+     * 차단 검사를 수행한다. 상대가 없는 방(SELF, 혹은 1:1 방에서 상대가 나가 발신자 1명만
+     * 남은 상태)은 차단을 적용할 대상 자체가 없으므로 검사 없이 통과한다. 이때 상대가 다시
+     * 들어오는 재초대 경로({@code ReinviteDirectChatMemberService})에서 차단을 별도로
+     * 검증하므로 우회가 발생하지 않는다.
+     * </p>
+     * <p>
+     * 성능: 발신자 외 멤버가 존재할 때만 채팅방 타입 확인용 {@code findById}를 1회 수행한다.
+     * 멤버 엔티티({@link ChatRoomMember})에는 방 타입 정보가 없어 사전 조회 컨텍스트에서 타입을
+     * 얻을 수 없으므로, DIRECT 여부 판정에는 채팅방 조회가 필요하다. 단, 그룹(멤버 3명 이상)은
+     * 1:1이 정책 범위 밖이라 조회 없이 통과시켜 불필요한 쿼리를 피한다.
      * </p>
      *
      * @param chatRoomId 채팅방 ID
@@ -219,8 +227,15 @@ public class SendMessageService implements SendMessageUseCase {
      * @param members 사전 조회된 채팅방 멤버 목록
      */
     private void validateNotBlockedInDirectChat(Long chatRoomId, Long senderId, List<ChatRoomMember> members) {
-        // 멤버 2명이 아니면 DIRECT가 아니므로 추가 조회 없이 통과 (SELF/그룹)
-        if (members.size() != 2) {
+        // 발신자 외 멤버(상대 후보)들. 상대가 없으면(SELF/1명 잔류) 검사 대상 자체가 없어 통과.
+        List<Long> otherUserIds = members.stream()
+                .map(ChatRoomMember::getUserId)
+                .filter(userId -> !userId.equals(senderId))
+                .toList();
+
+        // 상대가 정확히 1명일 때만 1:1(DIRECT) 후보. 0명(SELF/잔류) 또는 2명 이상(그룹)은
+        // 추가 조회 없이 통과시켜 불필요한 쿼리를 피한다(그룹 차단 정책은 이번 범위 외).
+        if (otherUserIds.size() != 1) {
             return;
         }
 
@@ -229,11 +244,7 @@ public class SendMessageService implements SendMessageUseCase {
             return;
         }
 
-        members.stream()
-                .map(ChatRoomMember::getUserId)
-                .filter(userId -> !userId.equals(senderId))
-                .findFirst()
-                .ifPresent(otherUserId -> blockValidator.validateNotBlocked(senderId, otherUserId));
+        blockValidator.validateNotBlocked(senderId, otherUserIds.get(0));
     }
 
     /**

--- a/src/main/java/com/cotalk/domain/exception/BlockedRelationshipException.java
+++ b/src/main/java/com/cotalk/domain/exception/BlockedRelationshipException.java
@@ -1,0 +1,29 @@
+package com.cotalk.domain.exception;
+
+/**
+ * 차단 관계가 존재하여 상호작용이 거부될 때 발생하는 예외.
+ * <p>
+ * 두 사용자 사이에 (어느 방향이든) 차단 관계가 존재하면 메시지 전송, 친구 요청,
+ * 1:1 채팅방 생성/재초대 등의 상호작용이 거부된다. HTTP 403 Forbidden과 매핑된다.
+ * </p>
+ *
+ * @author seunggu.lee
+ */
+public class BlockedRelationshipException extends DomainException {
+
+    /**
+     * 메시지를 지정하여 예외를 생성한다.
+     *
+     * @param message 에러 메시지
+     */
+    public BlockedRelationshipException(String message) {
+        super(message, "BLOCKED_RELATIONSHIP", HttpStatusHint.FORBIDDEN);
+    }
+
+    /**
+     * 기본 메시지로 예외를 생성한다.
+     */
+    public BlockedRelationshipException() {
+        this("차단 관계가 존재하여 요청을 처리할 수 없습니다.");
+    }
+}

--- a/src/main/java/com/cotalk/domain/validator/BlockValidator.java
+++ b/src/main/java/com/cotalk/domain/validator/BlockValidator.java
@@ -1,0 +1,49 @@
+package com.cotalk.domain.validator;
+
+import com.cotalk.domain.exception.BlockedRelationshipException;
+import com.cotalk.domain.port.outbound.BlockRepository;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 차단 관계 검증기.
+ * <p>
+ * 두 사용자 사이에 차단 관계가 존재하는지 검증한다. 제품 정책상 차단은 <b>양방향</b>으로 적용되어,
+ * 한쪽이라도 상대를 차단한 경우 메시지 전송 · 친구 요청 · 1:1 채팅방 생성/재초대 등의
+ * 상호작용을 거부한다.
+ * </p>
+ *
+ * @author seunggu.lee
+ */
+@RequiredArgsConstructor
+public class BlockValidator {
+
+    private final BlockRepository blockRepository;
+
+    /**
+     * 두 사용자 사이에 차단 관계가 없는지 검증한다.
+     * <p>
+     * 양방향으로 검사하며, 어느 한쪽이라도 상대를 차단한 경우 예외를 던진다.
+     * </p>
+     *
+     * @param userId1 첫 번째 사용자 ID
+     * @param userId2 두 번째 사용자 ID
+     * @throws BlockedRelationshipException 두 사용자 사이에 차단 관계가 존재하는 경우
+     */
+    public void validateNotBlocked(Long userId1, Long userId2) {
+        if (isBlockedBetween(userId1, userId2)) {
+            throw new BlockedRelationshipException();
+        }
+    }
+
+    /**
+     * 두 사용자 사이에 (양방향) 차단 관계가 존재하는지 확인한다.
+     *
+     * @param userId1 첫 번째 사용자 ID
+     * @param userId2 두 번째 사용자 ID
+     * @return 어느 한쪽이라도 상대를 차단했으면 {@code true}
+     */
+    public boolean isBlockedBetween(Long userId1, Long userId2) {
+        return blockRepository.existsByBlockerIdAndBlockedId(userId1, userId2)
+                || blockRepository.existsByBlockerIdAndBlockedId(userId2, userId1);
+    }
+}

--- a/src/main/java/com/cotalk/infrastructure/config/DomainValidatorConfig.java
+++ b/src/main/java/com/cotalk/infrastructure/config/DomainValidatorConfig.java
@@ -1,7 +1,9 @@
 package com.cotalk.infrastructure.config;
 
+import com.cotalk.domain.port.outbound.BlockRepository;
 import com.cotalk.domain.port.outbound.ChatRoomMemberRepository;
 import com.cotalk.domain.port.outbound.UserRepository;
+import com.cotalk.domain.validator.BlockValidator;
 import com.cotalk.domain.validator.ChatRoomMemberValidator;
 import com.cotalk.domain.validator.FileMessageValidator;
 import com.cotalk.domain.validator.MessageValidator;
@@ -34,6 +36,18 @@ public class DomainValidatorConfig {
     @Bean
     public ChatRoomMemberValidator chatRoomMemberValidator(ChatRoomMemberRepository chatRoomMemberRepository) {
         return new ChatRoomMemberValidator(chatRoomMemberRepository);
+    }
+
+    /**
+     * 차단 관계 검증기 빈.
+     * 메시지 전송 · 친구 요청 · 1:1 채팅방 생성/재초대 시 양방향 차단 관계를 검증한다.
+     *
+     * @param blockRepository 차단 레포지토리 포트
+     * @return 차단 관계 검증기
+     */
+    @Bean
+    public BlockValidator blockValidator(BlockRepository blockRepository) {
+        return new BlockValidator(blockRepository);
     }
 
     /**

--- a/src/test/java/com/cotalk/application/service/chatroom/CreateChatRoomServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/chatroom/CreateChatRoomServiceTest.java
@@ -6,6 +6,8 @@ import com.cotalk.domain.port.outbound.ChatRoomMemberRepository;
 import com.cotalk.domain.port.outbound.ChatRoomRepository;
 import com.cotalk.domain.port.outbound.TimeProvider;
 import com.cotalk.domain.port.outbound.UserEventBroker;
+import com.cotalk.domain.exception.BlockedRelationshipException;
+import com.cotalk.domain.validator.BlockValidator;
 import com.cotalk.infrastructure.id.SnowflakeIdGenerator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -41,6 +43,9 @@ class CreateChatRoomServiceTest {
 
     @Mock
     private UserEventBroker userEventBroker;
+
+    @Mock
+    private BlockValidator blockValidator;
 
     @InjectMocks
     private CreateChatRoomService createChatRoomService;
@@ -130,6 +135,26 @@ class CreateChatRoomServiceTest {
 
         // then
         verify(userEventBroker).publishChatListUpdate(eq(userId1), any());
+    }
+
+    @Test
+    @DisplayName("차단 관계가 있으면 1:1 채팅방 생성이 거부된다 (양방향)")
+    void should_throwException_when_blocked() {
+        // given
+        Long userId1 = 1L;
+        Long userId2 = 2L;
+
+        org.mockito.BDDMockito.willThrow(new BlockedRelationshipException())
+                .given(blockValidator).validateNotBlocked(userId1, userId2);
+
+        // when & then
+        org.assertj.core.api.Assertions.assertThatThrownBy(
+                        () -> createChatRoomService.createChatRoom(userId1, userId2))
+                .isInstanceOf(BlockedRelationshipException.class);
+
+        // 차단 시 채팅방/멤버는 생성되지 않아야 한다
+        verify(chatRoomRepository, times(0)).save(any(ChatRoom.class));
+        verify(chatRoomMemberRepository, times(0)).save(any(ChatRoomMember.class));
     }
 
     @Test

--- a/src/test/java/com/cotalk/application/service/chatroom/ReinviteDirectChatMemberServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/chatroom/ReinviteDirectChatMemberServiceTest.java
@@ -4,11 +4,13 @@ import com.cotalk.domain.entity.ChatRoom;
 import com.cotalk.domain.entity.ChatRoomMember;
 import com.cotalk.domain.entity.Message;
 import com.cotalk.domain.entity.User;
+import com.cotalk.domain.exception.BlockedRelationshipException;
 import com.cotalk.domain.exception.ChatRoomAccessDeniedException;
 import com.cotalk.domain.model.Email;
 import com.cotalk.domain.exception.ChatRoomNotFoundException;
 import com.cotalk.domain.exception.InvalidChatRoomException;
 import com.cotalk.domain.exception.UserNotFoundException;
+import com.cotalk.domain.validator.BlockValidator;
 import com.cotalk.domain.port.outbound.ChatMessageBroker;
 import com.cotalk.domain.port.outbound.ChatRoomMemberRepository;
 import com.cotalk.domain.port.outbound.ChatRoomRepository;
@@ -68,6 +70,9 @@ class ReinviteDirectChatMemberServiceTest {
     @Mock
     private UserEventBroker userEventBroker;
 
+    @Mock
+    private BlockValidator blockValidator;
+
     private ReinviteDirectChatMemberService service;
 
     @BeforeEach
@@ -79,7 +84,8 @@ class ReinviteDirectChatMemberServiceTest {
                 idGenerator,
                 messageRepository,
                 chatMessageBroker,
-                userEventBroker
+                userEventBroker,
+                blockValidator
         );
     }
 
@@ -240,6 +246,40 @@ class ReinviteDirectChatMemberServiceTest {
 
         // 멤버 저장이 호출되지 않아야 함
         verify(chatRoomMemberRepository, never()).save(any(ChatRoomMember.class));
+    }
+
+    @Test
+    @DisplayName("초대자-피초대자 간 차단 관계가 있으면 재초대 거부 (양방향)")
+    void should_throwException_when_blocked() {
+        // given
+        Long roomId = 100L;
+        Long inviterId = 1L;
+        Long inviteeId = 2L;
+
+        User invitee = User.builder()
+                .id(inviteeId)
+                .nickname("재초대유저")
+                .email(new Email("reinvite@test.com"))
+                .build();
+
+        given(chatRoomRepository.findById(roomId))
+                .willReturn(Optional.of(createDirectChatRoom(roomId)));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(roomId, inviterId))
+                .willReturn(Optional.of(createChatRoomMember(1L, roomId, inviterId)));
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(roomId, inviteeId))
+                .willReturn(Optional.empty());
+        given(userRepository.findById(inviteeId))
+                .willReturn(Optional.of(invitee));
+        org.mockito.BDDMockito.willThrow(new BlockedRelationshipException())
+                .given(blockValidator).validateNotBlocked(inviterId, inviteeId);
+
+        // when & then
+        assertThatThrownBy(() -> service.reinviteMember(roomId, inviterId, inviteeId))
+                .isInstanceOf(BlockedRelationshipException.class);
+
+        // 차단 시 멤버 추가/시스템 메시지가 발생하지 않아야 한다
+        verify(chatRoomMemberRepository, never()).save(any(ChatRoomMember.class));
+        verify(messageRepository, never()).save(any(Message.class));
     }
 
     /**

--- a/src/test/java/com/cotalk/application/service/friend/AcceptFriendRequestServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/friend/AcceptFriendRequestServiceTest.java
@@ -2,11 +2,13 @@ package com.cotalk.application.service.friend;
 
 import com.cotalk.domain.entity.Friend;
 import com.cotalk.domain.entity.FriendRequest;
+import com.cotalk.domain.exception.BlockedRelationshipException;
 import com.cotalk.domain.exception.FriendNotFoundException;
 import com.cotalk.domain.exception.InvalidFriendRequestException;
 import com.cotalk.domain.port.outbound.DistributedLockPort;
 import com.cotalk.domain.port.outbound.FriendRepository;
 import com.cotalk.domain.port.outbound.FriendRequestRepository;
+import com.cotalk.domain.validator.BlockValidator;
 import com.cotalk.infrastructure.id.SnowflakeIdGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +28,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -48,13 +52,17 @@ class AcceptFriendRequestServiceTest {
     @Mock
     private TransactionTemplate transactionTemplate;
 
+    @Mock
+    private BlockValidator blockValidator;
+
     private AcceptFriendRequestService acceptFriendRequestService;
 
     @BeforeEach
     @SuppressWarnings("unchecked")
     void setUp() {
         acceptFriendRequestService = new AcceptFriendRequestService(
-                friendRequestRepository, friendRepository, idGenerator, lockExecutor, transactionTemplate);
+                friendRequestRepository, friendRepository, idGenerator, lockExecutor, transactionTemplate,
+                blockValidator);
 
         // 분산락 모킹: 락 획득 후 바로 실행
         lenient().when(lockExecutor.executeWithLock(anyString(), any(Supplier.class)))
@@ -161,5 +169,32 @@ class AcceptFriendRequestServiceTest {
         // when & then
         assertThatThrownBy(() -> acceptFriendRequestService.acceptFriendRequest(receiverId, requestId))
                 .isInstanceOf(InvalidFriendRequestException.class);
+    }
+
+    @Test
+    @DisplayName("요청 전송 후 차단 관계가 성립한 경우 수락 시 예외 발생하고 친구 관계가 생성되지 않음")
+    void should_throwException_when_blockedRelationshipExistsOnAccept() {
+        // given: A(requester) -> B(receiver) PENDING 요청 후, 어느 한쪽이 상대를 차단한 상황
+        Long requesterId = 1L;
+        Long receiverId = 2L;
+        Long requestId = 100L;
+
+        FriendRequest friendRequest = FriendRequest.builder()
+                .id(requestId)
+                .requesterId(requesterId)
+                .receiverId(receiverId)
+                .status(FriendRequest.RequestStatus.PENDING)
+                .build();
+
+        given(friendRequestRepository.findById(requestId)).willReturn(Optional.of(friendRequest));
+        willThrow(new BlockedRelationshipException())
+                .given(blockValidator).validateNotBlocked(requesterId, receiverId);
+
+        // when & then: 차단 검사에서 거부되어 친구 관계가 성립하지 않음 (차단 우회 방지)
+        assertThatThrownBy(() -> acceptFriendRequestService.acceptFriendRequest(receiverId, requestId))
+                .isInstanceOf(BlockedRelationshipException.class);
+
+        verify(friendRepository, never()).save(any(Friend.class));
+        assertThat(friendRequest.isPending()).isTrue();
     }
 }

--- a/src/test/java/com/cotalk/application/service/friend/SendFriendRequestServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/friend/SendFriendRequestServiceTest.java
@@ -3,12 +3,14 @@ package com.cotalk.application.service.friend;
 import com.cotalk.domain.entity.FriendRequest;
 import com.cotalk.domain.entity.User;
 import com.cotalk.domain.model.Email;
+import com.cotalk.domain.exception.BlockedRelationshipException;
 import com.cotalk.domain.exception.InvalidFriendRequestException;
 import com.cotalk.domain.exception.SelfActionNotAllowedException;
 import com.cotalk.domain.exception.UserNotFoundException;
 import com.cotalk.domain.port.outbound.FriendRepository;
 import com.cotalk.domain.port.outbound.FriendRequestRepository;
 import com.cotalk.domain.port.outbound.NotificationCommandPort;
+import com.cotalk.domain.validator.BlockValidator;
 import com.cotalk.domain.validator.UserValidator;
 import com.cotalk.infrastructure.id.SnowflakeIdGenerator;
 import com.cotalk.infrastructure.lock.DistributedLockExecutor;
@@ -51,6 +53,9 @@ class SendFriendRequestServiceTest {
     private UserValidator userValidator;
 
     @Mock
+    private BlockValidator blockValidator;
+
+    @Mock
     private SnowflakeIdGenerator idGenerator;
 
     @Mock
@@ -68,7 +73,7 @@ class SendFriendRequestServiceTest {
     @SuppressWarnings("unchecked")
     void setUp() {
         sendFriendRequestService = new SendFriendRequestService(
-                friendRequestRepository, friendRepository, userValidator, idGenerator, lockExecutor,
+                friendRequestRepository, friendRepository, userValidator, blockValidator, idGenerator, lockExecutor,
                 notificationCommandPort, transactionTemplate);
 
         // 분산락 모킹: 락 획득 후 바로 실행 (lenient로 불필요한 stub 경고 방지)
@@ -224,6 +229,29 @@ class SendFriendRequestServiceTest {
 
         // then
         verify(notificationCommandPort).sendFriendRequestNotification(receiverId, requesterNickname);
+    }
+
+    @Test
+    @DisplayName("차단 관계가 있으면 친구 요청 시 예외 발생 (양방향)")
+    void should_throwException_when_blocked() {
+        // given
+        Long requesterId = 1L;
+        Long receiverId = 2L;
+
+        doNothing().when(userValidator).validateNotSelfAction(requesterId, receiverId, "친구 요청");
+        given(userValidator.validateUserExists(receiverId)).willReturn(
+                User.builder().id(receiverId).email(new Email("test@example.com")).nickname("test").passwordHash("hash").build()
+        );
+        willThrow(new BlockedRelationshipException())
+                .given(blockValidator).validateNotBlocked(requesterId, receiverId);
+
+        // when & then
+        assertThatThrownBy(() -> sendFriendRequestService.sendFriendRequest(requesterId, receiverId))
+                .isInstanceOf(BlockedRelationshipException.class);
+
+        // 차단 시 친구 요청은 저장되지 않아야 한다
+        org.mockito.Mockito.verify(friendRequestRepository, org.mockito.Mockito.never())
+                .save(any(FriendRequest.class));
     }
 
     @Test

--- a/src/test/java/com/cotalk/application/service/message/SendMessageServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/message/SendMessageServiceTest.java
@@ -1,11 +1,14 @@
 package com.cotalk.application.service.message;
 
+import com.cotalk.domain.entity.ChatRoom;
 import com.cotalk.domain.entity.ChatRoomMember;
 import com.cotalk.domain.entity.Message;
 import com.cotalk.domain.entity.User;
 import com.cotalk.domain.model.Email;
+import com.cotalk.domain.exception.BlockedRelationshipException;
 import com.cotalk.domain.exception.ChatRoomAccessDeniedException;
 import com.cotalk.domain.port.outbound.ChatRoomMemberRepository;
+import com.cotalk.domain.port.outbound.ChatRoomRepository;
 import com.cotalk.domain.port.outbound.ChatRoomPresenceTracker;
 import com.cotalk.domain.port.outbound.IdGenerator;
 import com.cotalk.domain.port.outbound.MessageRepository;
@@ -49,6 +52,9 @@ class SendMessageServiceTest {
     private ChatRoomMemberRepository chatRoomMemberRepository;
 
     @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
     private UserRepository userRepository;
 
     @Mock
@@ -75,16 +81,19 @@ class SendMessageServiceTest {
     @Mock
     private TimeProvider timeProvider;
 
+    @Mock
+    private com.cotalk.domain.validator.BlockValidator blockValidator;
+
     private SendMessageService sendMessageService;
 
     @SuppressWarnings("unchecked")
     @BeforeEach
     void setUp() {
         sendMessageService = new SendMessageService(
-                messageRepository, chatRoomMemberRepository, userRepository, idGenerator,
+                messageRepository, chatRoomMemberRepository, chatRoomRepository, userRepository, idGenerator,
                 notificationCommandPort, chatRoomPresenceTracker, customMetrics,
                 messageLinkPreviewService, messageBroadcastService, transactionTemplate, timeProvider,
-                new com.cotalk.domain.validator.FileMessageValidator());
+                new com.cotalk.domain.validator.FileMessageValidator(), blockValidator);
 
         // TransactionTemplate: 콜백을 즉시 실행 (트랜잭션 없이 동기 실행)
         lenient().when(transactionTemplate.execute(any(TransactionCallback.class)))
@@ -209,6 +218,68 @@ class SendMessageServiceTest {
             // when & then
             assertThatThrownBy(() -> sendMessageService.sendMessage(chatRoomId, senderId, "메시지"))
                     .isInstanceOf(ChatRoomAccessDeniedException.class);
+        }
+
+        @Test
+        @DisplayName("1:1 채팅방에서 상대와 차단 관계면 메시지 전송이 거부된다 (양방향)")
+        void should_ThrowException_when_BlockedInDirectChat() {
+            // given
+            Long chatRoomId = 1L;
+            Long senderId = 2L;
+            Long receiverId = 3L;
+
+            ChatRoomMember senderMember = ChatRoomMember.builder()
+                    .id(10L).chatRoomId(chatRoomId).userId(senderId).build();
+            ChatRoomMember receiverMember = ChatRoomMember.builder()
+                    .id(11L).chatRoomId(chatRoomId).userId(receiverId).build();
+
+            User sender = User.builder()
+                    .id(senderId).email(new Email("sender@test.com")).nickname("발신자").passwordHash("hash").build();
+
+            ChatRoom directRoom = ChatRoom.builder()
+                    .id(chatRoomId).type(ChatRoom.ChatRoomType.DIRECT).build();
+
+            given(chatRoomMemberRepository.findByChatRoomId(chatRoomId))
+                    .willReturn(List.of(senderMember, receiverMember));
+            given(userRepository.findById(senderId)).willReturn(Optional.of(sender));
+            given(chatRoomRepository.findById(chatRoomId)).willReturn(Optional.of(directRoom));
+            org.mockito.BDDMockito.willThrow(new BlockedRelationshipException())
+                    .given(blockValidator).validateNotBlocked(senderId, receiverId);
+
+            // when & then
+            assertThatThrownBy(() -> sendMessageService.sendMessage(chatRoomId, senderId, "메시지"))
+                    .isInstanceOf(BlockedRelationshipException.class);
+            verify(messageRepository, never()).save(any(Message.class));
+        }
+
+        @Test
+        @DisplayName("그룹 채팅방(멤버 3명)에서는 차단 검사를 하지 않는다")
+        void should_NotCheckBlock_when_GroupChat() {
+            // given
+            Long chatRoomId = 1L;
+            Long senderId = 2L;
+            Long messageId = 100L;
+
+            ChatRoomMember m1 = ChatRoomMember.builder().id(10L).chatRoomId(chatRoomId).userId(senderId).build();
+            ChatRoomMember m2 = ChatRoomMember.builder().id(11L).chatRoomId(chatRoomId).userId(3L).build();
+            ChatRoomMember m3 = ChatRoomMember.builder().id(12L).chatRoomId(chatRoomId).userId(4L).build();
+
+            User sender = User.builder()
+                    .id(senderId).email(new Email("sender@test.com")).nickname("발신자").passwordHash("hash").build();
+
+            given(chatRoomMemberRepository.findByChatRoomId(chatRoomId))
+                    .willReturn(List.of(m1, m2, m3));
+            given(userRepository.findById(senderId)).willReturn(Optional.of(sender));
+            given(idGenerator.nextId()).willReturn(messageId);
+            given(messageRepository.save(any(Message.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            sendMessageService.sendMessage(chatRoomId, senderId, "메시지");
+
+            // then - 멤버 3명이므로 차단 검사/방 조회 없이 정상 전송
+            verify(blockValidator, never()).validateNotBlocked(anyLong(), anyLong());
+            verify(chatRoomRepository, never()).findById(anyLong());
+            verify(messageRepository).save(any(Message.class));
         }
 
         @Test

--- a/src/test/java/com/cotalk/application/service/message/SendMessageServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/message/SendMessageServiceTest.java
@@ -283,6 +283,36 @@ class SendMessageServiceTest {
         }
 
         @Test
+        @DisplayName("1:1 채팅방에서 상대가 나가 발신자만 남은 경우 차단 검사 없이 전송된다(검사 대상 없음)")
+        void should_NotCheckBlock_when_DirectChatHasOnlySender() {
+            // given: 1:1(DIRECT) 방이지만 상대가 나가 발신자 1명만 남은 상태(재초대 전)
+            Long chatRoomId = 1L;
+            Long senderId = 2L;
+            Long messageId = 100L;
+
+            ChatRoomMember senderMember = ChatRoomMember.builder()
+                    .id(10L).chatRoomId(chatRoomId).userId(senderId).build();
+
+            User sender = User.builder()
+                    .id(senderId).email(new Email("sender@test.com")).nickname("발신자").passwordHash("hash").build();
+
+            given(chatRoomMemberRepository.findByChatRoomId(chatRoomId))
+                    .willReturn(List.of(senderMember)); // 발신자만 남음
+            given(userRepository.findById(senderId)).willReturn(Optional.of(sender));
+            given(idGenerator.nextId()).willReturn(messageId);
+            given(messageRepository.save(any(Message.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            sendMessageService.sendMessage(chatRoomId, senderId, "메시지");
+
+            // then - 상대(검사 대상)가 없으므로 차단 검사/방 조회 없이 정상 전송
+            // (상대가 다시 들어오는 재초대 경로에서 차단을 검증하므로 우회가 아님)
+            verify(blockValidator, never()).validateNotBlocked(anyLong(), anyLong());
+            verify(chatRoomRepository, never()).findById(anyLong());
+            verify(messageRepository).save(any(Message.class));
+        }
+
+        @Test
         @DisplayName("빈 메시지 내용이면 예외가 발생한다")
         void should_ThrowException_when_EmptyContent() {
             // given

--- a/src/test/java/com/cotalk/domain/validator/BlockValidatorTest.java
+++ b/src/test/java/com/cotalk/domain/validator/BlockValidatorTest.java
@@ -1,0 +1,84 @@
+package com.cotalk.domain.validator;
+
+import com.cotalk.domain.exception.BlockedRelationshipException;
+import com.cotalk.domain.port.outbound.BlockRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BlockValidator 단위 테스트")
+class BlockValidatorTest {
+
+    @Mock
+    private BlockRepository blockRepository;
+
+    @InjectMocks
+    private BlockValidator blockValidator;
+
+    @Test
+    @DisplayName("차단 관계가 없으면 예외가 발생하지 않는다")
+    void should_notThrow_when_noBlockRelationship() {
+        // given
+        Long userId1 = 1L;
+        Long userId2 = 2L;
+        given(blockRepository.existsByBlockerIdAndBlockedId(userId1, userId2)).willReturn(false);
+        given(blockRepository.existsByBlockerIdAndBlockedId(userId2, userId1)).willReturn(false);
+
+        // when & then
+        assertThatCode(() -> blockValidator.validateNotBlocked(userId1, userId2))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("내가 상대를 차단한 경우 예외가 발생한다")
+    void should_throw_when_iBlockedTheOther() {
+        // given
+        Long userId1 = 1L;
+        Long userId2 = 2L;
+        given(blockRepository.existsByBlockerIdAndBlockedId(userId1, userId2)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> blockValidator.validateNotBlocked(userId1, userId2))
+                .isInstanceOf(BlockedRelationshipException.class);
+    }
+
+    @Test
+    @DisplayName("상대가 나를 차단한 경우 예외가 발생한다 (양방향)")
+    void should_throw_when_theOtherBlockedMe() {
+        // given
+        Long userId1 = 1L;
+        Long userId2 = 2L;
+        given(blockRepository.existsByBlockerIdAndBlockedId(userId1, userId2)).willReturn(false);
+        given(blockRepository.existsByBlockerIdAndBlockedId(userId2, userId1)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> blockValidator.validateNotBlocked(userId1, userId2))
+                .isInstanceOf(BlockedRelationshipException.class);
+    }
+
+    @Test
+    @DisplayName("내가 차단했으면 상대 방향은 조회하지 않는다 (단축 평가)")
+    void should_shortCircuit_when_iBlockedTheOther() {
+        // given
+        Long userId1 = 1L;
+        Long userId2 = 2L;
+        given(blockRepository.existsByBlockerIdAndBlockedId(userId1, userId2)).willReturn(true);
+        lenient().when(blockRepository.existsByBlockerIdAndBlockedId(userId2, userId1)).thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> blockValidator.validateNotBlocked(userId1, userId2))
+                .isInstanceOf(BlockedRelationshipException.class);
+        verify(blockRepository, never()).existsByBlockerIdAndBlockedId(userId2, userId1);
+    }
+}


### PR DESCRIPTION
## 배경 (결함)
기존에는 `BlockRepository`가 차단 CRUD 서비스(`BlockUserService`/`UnblockUserService`/`GetBlockedUsersService`)와 `DeleteAccountService`에서만 참조되어, **메시지 전송·친구요청·채팅방 생성/초대 어디에서도 차단을 검사하지 않았습니다.** 즉 A가 B를 차단해도 B는 A에게 계속 메시지를 보내고 친구요청·새 방 생성도 정상 처리되어 **차단이 사실상 우회**되는 버그가 있었습니다. 차단이 "목록 관리" 기능에만 그쳤습니다.

## 변경 사항
양방향 차단 검사를 송수신/요청 경로에 추가하여, 차단 관계가 존재하면 상호작용을 거부합니다.

- **공통화**: 도메인 검증기 `BlockValidator` 신설 — `validateNotBlocked(userId1, userId2)`가 양방향(`existsByBlockerIdAndBlockedId`를 양쪽으로) 조회하여 한쪽이라도 차단 시 거부. `DomainValidatorConfig`에 빈 등록(도메인은 Spring 비의존이므로 기존 검증기들과 동일 방식).
- **예외**: `BlockedRelationshipException`(extends `DomainException`, `HttpStatusHint.FORBIDDEN` → HTTP 403) 신설. `GlobalExceptionHandler`가 `DomainException`을 statusHint 기반으로 일반 처리하므로 컨트롤러/핸들러 추가 변경 없음. (차단 CRUD용 `InvalidBlockException`(400)과 의미 구분)

차단 검사를 추가한 경로:
1. **메시지 전송** — `SendMessageService`: 멤버가 정확히 2명이고 채팅방 타입이 `DIRECT`인 경우에만 상대를 식별하여 검사. 트랜잭션 내부·멤버십 검증 직후 수행.
2. **친구 요청** — `SendFriendRequestService.createFriendRequest()`: 기존 분산락/트랜잭션 내부에서 검사.
3. **1:1 채팅방 생성** — `CreateChatRoomService`: `DIRECT` 생성 경로(SELF 제외)에서 검사.
4. **1:1 채팅방 재초대** — `ReinviteDirectChatMemberService`: 초대자-피초대자 사이 검사.

## 제품 결정 (명시)
- **양방향**: A↔B 중 한쪽이라도 차단 관계면 거부 (내가 차단 / 상대가 나를 차단 모두).
- **거부 방식**: `BlockedRelationshipException`(403)으로 명확히 거부. 차단 시 메시지/친구요청/멤버/방은 생성되지 않음.
- **1:1 상대 식별**: 메시지는 `members.size()==2` + `ChatRoom.isDirectChat()`로 DIRECT 확정 후 발신자 외 멤버를 상대로 식별. 채팅방 생성/재초대/친구요청은 두 당사자 ID가 파라미터로 명확.
- **이번 범위 아님 (제외)**: 그룹 초대(`InviteGroupChatMemberService`)·구독 권한. 그룹은 다수 멤버라 정책이 복잡하고 과한 변경이 되므로 별도 작업으로 분리. 나와의 채팅(SELF)·그룹 채팅도 메시지 차단 검사 대상에서 제외.

## TDD / 검증
- 각 경로마다 테스트 추가: 차단 시 거부(양방향 케이스 포함), 차단 없으면 정상, 그룹/멤버수≠2는 검사 미수행.
- `BlockValidator` 단위 테스트(양방향·단축평가) 추가.
- `./gradlew test` 그린 (ArchUnit `HexagonalArchitectureTest` 통과, JaCoCo 60% 게이트 통과), `./gradlew build` 성공. 헥사고날 의존 방향(application→domain) 준수.