### PR TITLE
fix(message): 메시지 삭제 시간 제한 정리 및 파일 스토리지 고아 방지

### DIFF
--- a/src/main/java/com/cotalk/application/service/message/DeleteMessageService.java
+++ b/src/main/java/com/cotalk/application/service/message/DeleteMessageService.java
@@ -5,18 +5,34 @@ import com.cotalk.domain.exception.MessageNotFoundException;
 import com.cotalk.domain.exception.ResourceAccessDeniedException;
 import com.cotalk.domain.port.inbound.message.DeleteMessageUseCase;
 import com.cotalk.domain.port.outbound.ChatMessageBroker;
+import com.cotalk.domain.port.outbound.FileStorage;
 import com.cotalk.domain.port.outbound.MessageRepository;
 import com.cotalk.domain.port.outbound.TimeProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 메시지 삭제 유스케이스 구현체.
  * 메시지를 소프트 삭제하고 실시간으로 채팅방 참여자들에게 알린다.
+ *
+ * <p><b>삭제 정책:</b> 삭제는 "본인이 보낸 메시지"에 한해 허용되는 소프트 삭제이며,
+ * 일반 메신저 동작과 동일하게 <b>작성 후 시간이 지나도 본인 메시지는 삭제할 수 있다</b>
+ * (수정과 달리 시간 제한을 두지 않는다).
+ *
+ * <p><b>스토리지 정리:</b> 파일/이미지 메시지를 삭제하면 스토리지에 남는 고아 객체를 막기 위해
+ * {@code fileUrl}/{@code thumbnailUrl}이 가리키는 스토리지 객체를 정리한다. 외부 스토리지 호출은
+ * DB 트랜잭션 경계 밖(커밋 이후)에서 수행하며, 정리에 실패하더라도 메시지 삭제 자체는 성공한다
+ * (실패는 로깅으로 처리하고 후속 정리 잡에 맡긴다).
  *
  * @author seunggu.lee
  */
@@ -26,13 +42,21 @@ import java.time.ZoneOffset;
 @Transactional
 public class DeleteMessageService implements DeleteMessageUseCase {
 
+    /**
+     * 업로드 객체 키의 최상위 디렉터리.
+     * {@code UploadFileService.generateStoragePath}가 생성하는 {@code uploads/{userId}/...} 규칙과 일치한다.
+     */
+    private static final String UPLOAD_ROOT = "uploads";
+
     private final MessageRepository messageRepository;
     private final ChatMessageBroker chatMessageBroker;
     private final TimeProvider timeProvider;
+    private final FileStorage fileStorage;
 
     /**
      * 메시지를 삭제한다.
      * 본인이 보낸 메시지만 삭제할 수 있으며, 소프트 삭제 방식으로 처리된다.
+     * 파일/이미지 메시지인 경우 스토리지 원본을 커밋 이후 별도로 정리한다.
      *
      * @param messageId 삭제할 메시지 ID
      * @param userId 요청 사용자 ID
@@ -54,11 +78,9 @@ public class DeleteMessageService implements DeleteMessageUseCase {
             throw ResourceAccessDeniedException.messageAlreadyDeleted();
         }
 
-        // 5분 초과 여부 확인
+        // 본인 메시지의 (소프트)삭제는 시간 제한 없이 허용한다.
+        // 5분 제한은 메시지 "수정"(UpdateMessageService)에만 적용된다.
         var now = timeProvider.now();
-        if (message.isEditTimeExpired(now)) {
-            throw ResourceAccessDeniedException.messageTimeExpired();
-        }
 
         // 메시지 삭제 (소프트 삭제)
         message.delete(now);
@@ -68,6 +90,129 @@ public class DeleteMessageService implements DeleteMessageUseCase {
 
         // 채팅방 참여자들에게 메시지 삭제 이벤트 브로드캐스트
         publishMessageDeletedEvent(message.getChatRoomId(), messageId, userId);
+
+        // 파일/이미지 메시지면 스토리지 원본을 트랜잭션 밖(커밋 이후)에서 정리한다.
+        scheduleStorageCleanup(message, messageId);
+    }
+
+    /**
+     * 파일/이미지 메시지의 스토리지 원본 정리를 예약한다.
+     * <p>
+     * 외부 스토리지 삭제는 DB 트랜잭션 안에서 수행하면 안 되므로, 트랜잭션 동기화가 활성화된 경우
+     * 커밋 이후({@link TransactionSynchronization#afterCommit()})로 미룬다. 트랜잭션이 없는 경우
+     * (예: 단위 테스트)에는 즉시 수행한다. 정리 실패는 메시지 삭제에 영향을 주지 않고 로깅만 한다.
+     * </p>
+     *
+     * @param message   삭제된 메시지
+     * @param messageId 메시지 ID (로깅용)
+     */
+    private void scheduleStorageCleanup(Message message, Long messageId) {
+        List<String> objectKeys = collectStorageKeys(message);
+        if (objectKeys.isEmpty()) {
+            return;
+        }
+
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    cleanupStorage(objectKeys, messageId);
+                }
+            });
+        } else {
+            cleanupStorage(objectKeys, messageId);
+        }
+    }
+
+    /**
+     * 메시지의 파일/썸네일 URL에서 스토리지 객체 키를 추출한다.
+     * 파일/이미지 메시지가 아니거나 URL이 본 서버 업로드 경로가 아니면 빈 목록을 반환한다.
+     *
+     * @param message 대상 메시지
+     * @return 정리해야 할 스토리지 객체 키 목록
+     */
+    private List<String> collectStorageKeys(Message message) {
+        List<String> keys = new ArrayList<>();
+        if (!message.isFile() && !message.isImage()) {
+            return keys;
+        }
+        addObjectKey(keys, message.getFileUrl());
+        addObjectKey(keys, message.getThumbnailUrl());
+        return keys;
+    }
+
+    /**
+     * URL에서 업로드 객체 키({@code uploads/{userId}/...})를 추출해 목록에 추가한다.
+     * 본 서버 업로드 경로가 아니면 추가하지 않는다.
+     *
+     * @param keys 객체 키 목록
+     * @param url  파일/썸네일 URL
+     */
+    private void addObjectKey(List<String> keys, String url) {
+        String key = extractObjectKey(url);
+        if (key != null && !keys.contains(key)) {
+            keys.add(key);
+        }
+    }
+
+    /**
+     * 파일 URL에서 스토리지 객체 키를 추출한다.
+     * <p>
+     * 업로드는 {@code {baseUrl}/.../uploads/{userId}/{file}} 형태의 URL을 저장하므로,
+     * path에서 {@code uploads} 세그먼트부터 끝까지를 객체 키로 사용한다
+     * ({@code UploadFileService}가 생성하는 키 규칙과 일치).
+     * </p>
+     *
+     * @param url 파일 URL (절대/상대)
+     * @return 추출된 객체 키, 추출할 수 없으면 {@code null}
+     */
+    private String extractObjectKey(String url) {
+        if (url == null || url.isBlank()) {
+            return null;
+        }
+
+        String path;
+        try {
+            path = new URI(url).getPath();
+        } catch (URISyntaxException e) {
+            log.warn("Failed to parse file URL for storage cleanup: {}", url);
+            return null;
+        }
+        if (path == null || path.isBlank()) {
+            return null;
+        }
+
+        String[] segments = path.split("/");
+        for (int i = 0; i < segments.length; i++) {
+            if (UPLOAD_ROOT.equals(segments[i]) && i + 2 < segments.length && !segments[i + 2].isEmpty()) {
+                StringBuilder key = new StringBuilder(UPLOAD_ROOT);
+                for (int j = i + 1; j < segments.length; j++) {
+                    if (!segments[j].isEmpty()) {
+                        key.append('/').append(segments[j]);
+                    }
+                }
+                return key.toString();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 스토리지 객체들을 삭제한다. 개별 삭제 실패는 로깅만 하고 전체 흐름을 중단하지 않는다.
+     *
+     * @param objectKeys 삭제할 스토리지 객체 키 목록
+     * @param messageId  메시지 ID (로깅용)
+     */
+    private void cleanupStorage(List<String> objectKeys, Long messageId) {
+        for (String key : objectKeys) {
+            try {
+                fileStorage.delete(key);
+                log.info("Storage object cleaned up for deleted message: messageId={}, key={}", messageId, key);
+            } catch (Exception e) {
+                // 스토리지 정리 실패는 메시지 삭제 성공에 영향을 주지 않는다(고아 객체는 후속 정리 잡에 맡긴다).
+                log.warn("Failed to clean up storage object for deleted message: messageId={}, key={}", messageId, key, e);
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/cotalk/application/service/message/DeleteMessageService.java
+++ b/src/main/java/com/cotalk/application/service/message/DeleteMessageService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
@@ -89,7 +90,8 @@ public class DeleteMessageService implements DeleteMessageUseCase {
         log.info("Message deleted: messageId={}, userId={}", messageId, userId);
 
         // 채팅방 참여자들에게 메시지 삭제 이벤트 브로드캐스트
-        publishMessageDeletedEvent(message.getChatRoomId(), messageId, userId);
+        // 삭제 시각(now)을 그대로 넘겨 message.delete(now)와 이벤트 시각을 단일 타임스탬프로 일관화한다.
+        publishMessageDeletedEvent(message.getChatRoomId(), messageId, userId, now);
 
         // 파일/이미지 메시지면 스토리지 원본을 트랜잭션 밖(커밋 이후)에서 정리한다.
         scheduleStorageCleanup(message, messageId);
@@ -194,6 +196,11 @@ public class DeleteMessageService implements DeleteMessageUseCase {
                 return key.toString();
             }
         }
+
+        // URL은 존재하나 업로드 키 규칙(uploads/{userId}/{file})에 맞지 않아 키를 추출하지 못한 경우.
+        // 조용히 null을 반환하면 정리 대상에서 누락돼 고아 객체가 추적 없이 누적되므로 로그를 남긴다
+        // (경로 규칙 변경/레거시 마이그레이션 URL 등 사후 추적용).
+        log.warn("Could not extract upload object key from file URL; storage object may be left orphaned: {}", url);
         return null;
     }
 
@@ -221,8 +228,9 @@ public class DeleteMessageService implements DeleteMessageUseCase {
      * @param chatRoomId 채팅방 ID
      * @param messageId  삭제된 메시지 ID
      * @param deletedBy  삭제한 사용자 ID
+     * @param deletedAt  삭제 시각 (소프트 삭제에 사용한 시각과 동일한 값을 전달해 일관성 유지)
      */
-    private void publishMessageDeletedEvent(Long chatRoomId, Long messageId, Long deletedBy) {
+    private void publishMessageDeletedEvent(Long chatRoomId, Long messageId, Long deletedBy, LocalDateTime deletedAt) {
         String eventId = "message-deleted:" + chatRoomId + ":" + messageId;
 
         chatMessageBroker.publishRoomEvent(
@@ -234,7 +242,7 @@ public class DeleteMessageService implements DeleteMessageUseCase {
                         chatRoomId,
                         messageId,
                         deletedBy,
-                        timeProvider.now().toInstant(ZoneOffset.UTC).toEpochMilli()
+                        deletedAt.toInstant(ZoneOffset.UTC).toEpochMilli()
                 )
         );
 

--- a/src/test/java/com/cotalk/application/service/message/DeleteMessageServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/message/DeleteMessageServiceTest.java
@@ -4,6 +4,7 @@ import com.cotalk.domain.entity.Message;
 import com.cotalk.domain.exception.MessageNotFoundException;
 import com.cotalk.domain.exception.ResourceAccessDeniedException;
 import com.cotalk.domain.port.outbound.ChatMessageBroker;
+import com.cotalk.domain.port.outbound.FileStorage;
 import com.cotalk.domain.port.outbound.MessageRepository;
 import com.cotalk.domain.port.outbound.TimeProvider;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -36,13 +38,16 @@ class DeleteMessageServiceTest {
     @Mock
     private TimeProvider timeProvider;
 
+    @Mock
+    private FileStorage fileStorage;
+
     private DeleteMessageService service;
 
     private static final LocalDateTime FIXED_NOW = LocalDateTime.of(2026, 1, 1, 12, 0);
 
     @BeforeEach
     void setUp() {
-        service = new DeleteMessageService(messageRepository, chatMessageBroker, timeProvider);
+        service = new DeleteMessageService(messageRepository, chatMessageBroker, timeProvider, fileStorage);
     }
 
     @Test
@@ -136,9 +141,9 @@ class DeleteMessageServiceTest {
     }
 
     @Test
-    @DisplayName("5분 초과된 메시지 삭제 시 예외")
-    void should_throwException_when_messageOlderThan5Minutes() {
-        // given
+    @DisplayName("작성 후 5분이 지나도 본인 메시지는 삭제할 수 있다")
+    void should_deleteMessage_when_olderThan5Minutes() {
+        // given - 본인 삭제(소프트 삭제)는 시간 제한 없이 허용한다.
         Long messageId = 100L;
         Long userId = 1L;
 
@@ -155,11 +160,131 @@ class DeleteMessageServiceTest {
         ReflectionTestUtils.setField(message, "createdAt", FIXED_NOW.minusMinutes(6));
 
         given(messageRepository.findById(messageId)).willReturn(Optional.of(message));
+        given(messageRepository.save(any(Message.class))).willAnswer(inv -> inv.getArgument(0));
         given(timeProvider.now()).willReturn(FIXED_NOW);
 
-        // when & then
-        assertThatThrownBy(() -> service.deleteMessage(messageId, userId))
-                .isInstanceOf(ResourceAccessDeniedException.class)
-                .hasMessageContaining("5분");
+        // when
+        service.deleteMessage(messageId, userId);
+
+        // then
+        assertThat(message.isDeleted()).isTrue();
+        assertThat(message.getDeletedAt()).isEqualTo(FIXED_NOW);
+        verify(messageRepository).save(message);
+    }
+
+    @Test
+    @DisplayName("파일 메시지 삭제 시 스토리지 원본을 정리한다")
+    void should_cleanupStorage_when_deletingFileMessage() {
+        // given
+        Long messageId = 100L;
+        Long userId = 1L;
+
+        Message message = Message.builder()
+                .id(messageId)
+                .chatRoomId(10L)
+                .senderId(userId)
+                .content("file.pdf")
+                .type(Message.MessageType.FILE)
+                .fileUrl("http://localhost:9000/cotalk/uploads/1/abcd-1234.pdf")
+                .fileName("file.pdf")
+                .deleted(false)
+                .build();
+
+        given(messageRepository.findById(messageId)).willReturn(Optional.of(message));
+        given(messageRepository.save(any(Message.class))).willAnswer(inv -> inv.getArgument(0));
+        given(timeProvider.now()).willReturn(FIXED_NOW);
+
+        // when
+        service.deleteMessage(messageId, userId);
+
+        // then - URL이 가리키는 스토리지 객체 키(uploads/...)를 삭제해야 한다.
+        verify(fileStorage).delete("uploads/1/abcd-1234.pdf");
+    }
+
+    @Test
+    @DisplayName("파일 메시지 삭제 시 썸네일이 있으면 함께 정리한다")
+    void should_cleanupThumbnail_when_deletingImageMessageWithThumbnail() {
+        // given
+        Long messageId = 100L;
+        Long userId = 1L;
+
+        Message message = Message.builder()
+                .id(messageId)
+                .chatRoomId(10L)
+                .senderId(userId)
+                .content("image.png")
+                .type(Message.MessageType.IMAGE)
+                .fileUrl("http://localhost:9000/cotalk/uploads/1/image-key.png")
+                .thumbnailUrl("http://localhost:9000/cotalk/uploads/1/thumb-key.png")
+                .deleted(false)
+                .build();
+
+        given(messageRepository.findById(messageId)).willReturn(Optional.of(message));
+        given(messageRepository.save(any(Message.class))).willAnswer(inv -> inv.getArgument(0));
+        given(timeProvider.now()).willReturn(FIXED_NOW);
+
+        // when
+        service.deleteMessage(messageId, userId);
+
+        // then
+        verify(fileStorage).delete("uploads/1/image-key.png");
+        verify(fileStorage).delete("uploads/1/thumb-key.png");
+    }
+
+    @Test
+    @DisplayName("텍스트 메시지 삭제 시에는 스토리지를 호출하지 않는다")
+    void should_notTouchStorage_when_deletingTextMessage() {
+        // given
+        Long messageId = 100L;
+        Long userId = 1L;
+
+        Message message = Message.builder()
+                .id(messageId)
+                .chatRoomId(10L)
+                .senderId(userId)
+                .content("텍스트 메시지")
+                .type(Message.MessageType.TEXT)
+                .deleted(false)
+                .build();
+
+        given(messageRepository.findById(messageId)).willReturn(Optional.of(message));
+        given(messageRepository.save(any(Message.class))).willAnswer(inv -> inv.getArgument(0));
+        given(timeProvider.now()).willReturn(FIXED_NOW);
+
+        // when
+        service.deleteMessage(messageId, userId);
+
+        // then
+        verify(fileStorage, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("스토리지 정리에 실패해도 메시지 삭제 자체는 성공한다")
+    void should_succeedDelete_when_storageCleanupFails() {
+        // given
+        Long messageId = 100L;
+        Long userId = 1L;
+
+        Message message = Message.builder()
+                .id(messageId)
+                .chatRoomId(10L)
+                .senderId(userId)
+                .content("file.pdf")
+                .type(Message.MessageType.FILE)
+                .fileUrl("http://localhost:9000/cotalk/uploads/1/key.pdf")
+                .deleted(false)
+                .build();
+
+        given(messageRepository.findById(messageId)).willReturn(Optional.of(message));
+        given(messageRepository.save(any(Message.class))).willAnswer(inv -> inv.getArgument(0));
+        given(timeProvider.now()).willReturn(FIXED_NOW);
+        org.mockito.BDDMockito.willThrow(new RuntimeException("storage down"))
+                .given(fileStorage).delete(any());
+
+        // when & then - 예외가 전파되지 않고 삭제가 완료된다.
+        service.deleteMessage(messageId, userId);
+
+        assertThat(message.isDeleted()).isTrue();
+        verify(messageRepository).save(message);
     }
 }

--- a/src/test/java/com/cotalk/application/service/message/DeleteMessageServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/message/DeleteMessageServiceTest.java
@@ -15,8 +15,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import org.junit.jupiter.api.AfterEach;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -25,6 +30,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
 class DeleteMessageServiceTest {
@@ -48,6 +54,14 @@ class DeleteMessageServiceTest {
     @BeforeEach
     void setUp() {
         service = new DeleteMessageService(messageRepository, chatMessageBroker, timeProvider, fileStorage);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // 트랜잭션 동기화를 직접 켠 테스트가 누수되지 않도록 정리한다.
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
     }
 
     @Test
@@ -286,5 +300,82 @@ class DeleteMessageServiceTest {
 
         assertThat(message.isDeleted()).isTrue();
         verify(messageRepository).save(message);
+    }
+
+    // === 트랜잭션 경계 검증 ===
+    // 프로덕션은 @Transactional이라 항상 트랜잭션 동기화가 활성(isSynchronizationActive()==true)이고,
+    // 스토리지 정리는 afterCommit 콜백으로 미뤄진다. 아래 테스트는 동기화를 직접 켜서
+    // "정리가 커밋 시점까지 지연되는지"와 "afterCommit 실행 시 실제로 정리되는지(롤백 시 미정리)"를
+    // 실제 프로덕션 경로로 검증한다.
+
+    @Test
+    @DisplayName("트랜잭션 활성 시 스토리지 정리는 커밋 전에는 실행되지 않고 afterCommit에서 실행된다")
+    void should_deferStorageCleanup_until_afterCommit_when_transactionActive() {
+        // given - 프로덕션과 동일하게 트랜잭션 동기화를 활성화한다.
+        TransactionSynchronizationManager.initSynchronization();
+
+        Long messageId = 100L;
+        Long userId = 1L;
+
+        Message message = Message.builder()
+                .id(messageId)
+                .chatRoomId(10L)
+                .senderId(userId)
+                .content("file.pdf")
+                .type(Message.MessageType.FILE)
+                .fileUrl("http://localhost:9000/cotalk/uploads/1/deferred-key.pdf")
+                .fileName("file.pdf")
+                .deleted(false)
+                .build();
+
+        given(messageRepository.findById(messageId)).willReturn(Optional.of(message));
+        given(messageRepository.save(any(Message.class))).willAnswer(inv -> inv.getArgument(0));
+        given(timeProvider.now()).willReturn(FIXED_NOW);
+
+        // when - 메서드 실행만으로는 (= 커밋 전) 스토리지 정리가 일어나면 안 된다.
+        service.deleteMessage(messageId, userId);
+
+        // then - 콜백만 등록되고 아직 삭제는 호출되지 않았다(즉시 else 브랜치를 타지 않았음을 보장).
+        verifyNoInteractions(fileStorage);
+        List<TransactionSynchronization> syncs = TransactionSynchronizationManager.getSynchronizations();
+        assertThat(syncs).hasSize(1);
+
+        // when - 실제 커밋 시점을 모사해 afterCommit을 트리거하면 정리가 수행된다(프로덕션 경로).
+        syncs.forEach(TransactionSynchronization::afterCommit);
+
+        // then
+        verify(fileStorage).delete("uploads/1/deferred-key.pdf");
+    }
+
+    @Test
+    @DisplayName("트랜잭션이 롤백되어 afterCommit이 호출되지 않으면 스토리지는 정리되지 않는다")
+    void should_notCleanupStorage_when_transactionRolledBack() {
+        // given - 트랜잭션 동기화를 활성화한다(롤백 시 afterCommit 미호출 상황을 모사).
+        TransactionSynchronizationManager.initSynchronization();
+
+        Long messageId = 100L;
+        Long userId = 1L;
+
+        Message message = Message.builder()
+                .id(messageId)
+                .chatRoomId(10L)
+                .senderId(userId)
+                .content("file.pdf")
+                .type(Message.MessageType.FILE)
+                .fileUrl("http://localhost:9000/cotalk/uploads/1/rollback-key.pdf")
+                .fileName("file.pdf")
+                .deleted(false)
+                .build();
+
+        given(messageRepository.findById(messageId)).willReturn(Optional.of(message));
+        given(messageRepository.save(any(Message.class))).willAnswer(inv -> inv.getArgument(0));
+        given(timeProvider.now()).willReturn(FIXED_NOW);
+
+        // when - 삭제는 수행하되 afterCommit을 트리거하지 않는다(= 롤백되어 커밋이 일어나지 않은 경우).
+        service.deleteMessage(messageId, userId);
+
+        // then - 커밋이 없으므로 스토리지 정리는 절대 일어나지 않아야 한다(고아 미생성 보장).
+        verifyNoInteractions(fileStorage);
+        assertThat(TransactionSynchronizationManager.getSynchronizations()).hasSize(1);
     }
 }


### PR DESCRIPTION
## 배경
메시지 삭제(`DeleteMessageService`)에서 2가지 결함을 확인하고 수정한다.

1. **본인 메시지 5분 삭제 제한 (UX)**: 삭제는 본인이 보낸 메시지에 대한 소프트 삭제(`isSentBy` 검증)인데, 수정과 동일한 `isEditTimeExpired`(5분) 제한이 걸려 있어 작성 후 5분이 지나면 본인 메시지조차 삭제할 수 없었다. 일반 메신저는 본인 메시지 삭제에 시간 제한을 두지 않는다.
2. **파일 메시지 소프트삭제 시 스토리지 고아**: 파일/이미지 메시지를 삭제해도 `fileUrl`/`thumbnailUrl`이 가리키는 실제 스토리지 객체가 정리되지 않아 고아 파일이 누적됐다.

## 삭제 의미 (코드 확인 결과)
- `deleteMessage(messageId, userId)`는 **본인이 보낸 메시지에 한정된 소프트 삭제**다(`message.isSentBy(userId)` 검증, `message.delete()`는 `deleted=true`/`deletedAt`만 설정).
- 코드에는 "전송취소(모두에게)" vs "나만 삭제" 구분이 없다. 단일 self-delete이며, 삭제 후 방에 `MESSAGE_DELETED` 이벤트를 브로드캐스트한다(사실상 본인에 의한 모두 삭제).
- `isEditTimeExpired`(5분)는 **수정(`UpdateMessageService`)과 삭제가 공유**하던 검사다.

## 변경
### 1) 삭제 시간 정책
- **본인 메시지의 소프트 삭제는 시간 제한 없이 허용**하도록 삭제 경로의 5분 검사를 제거했다.
- 5분 제한은 **메시지 "수정"(`UpdateMessageService`)에는 그대로 유지**한다(수정은 내용 변조 창을 제한하는 의미가 있으므로 보수적으로 보존).
- 근거: 본인 메시지 삭제에 부당하게 걸려 있던 제한 제거 = 표준 메신저 동작. 제품 의도가 "수정·삭제 모두 5분"이었다면 본인 삭제에 한해 완화하는 것이 UX상 합리적이며, 그 trade-off를 본 PR에 명시한다.

### 2) 스토리지 정리 (트랜잭션 경계 준수)
- 파일/이미지 메시지 삭제 시 `fileUrl`/`thumbnailUrl`에서 업로드 객체 키(`uploads/{userId}/...`, `UploadFileService.generateStoragePath` 규칙과 일치)를 추출해 `FileStorage.delete(key)`로 정리한다.
- **트랜잭션 경계**: 외부 스토리지 호출을 DB 트랜잭션 안에서 하지 않는다. 트랜잭션 동기화가 활성화된 경우 `TransactionSynchronization.afterCommit()`로 미뤄 **커밋 이후**에 정리하고, 트랜잭션이 없으면(예: 단위 테스트) 즉시 정리한다.
- **실패 처리**: 스토리지 정리 실패는 `catch` 후 `warn` 로깅만 하고 전파하지 않는다 → 메시지 삭제 자체는 항상 성공(고아 객체는 후속 정리 잡에 맡김).
- 의존 방향: 애플리케이션이 도메인 아웃바운드 포트 `FileStorage`만 의존(인프라 직접 의존 없음) → ArchUnit 위반 없음.

## 테스트 (TDD)
- 작성 후 5분 경과해도 본인 메시지 삭제 성공
- 파일 메시지 삭제 시 객체 키(`uploads/...`) 정리 호출 검증(mock)
- 썸네일 동반 정리 검증
- 텍스트 메시지는 스토리지 미호출
- 스토리지 정리 실패 시에도 삭제 성공
- 수정(`UpdateMessageService`)의 5분 제한은 그대로 유지됨을 회귀로 확인

## 검증
- `./gradlew build` 성공 (전체 테스트 + ArchUnit + JaCoCo 60% 게이트 통과, 격리된 worktree에서 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)