### PR TITLE
feat(file): 파일 메시지 불투명 식별자(object-id) 수용 — 하위호환

### DIFF
--- a/src/main/java/com/cotalk/adapter/inbound/rest/ChatMessageController.java
+++ b/src/main/java/com/cotalk/adapter/inbound/rest/ChatMessageController.java
@@ -94,6 +94,8 @@ public class ChatMessageController {
             @AuthenticationPrincipal CustomUserPrincipal principal,
             @Valid @RequestBody SendFileMessageRequest request) {
         SendMessageUseCase.FileMessageCommand command = new SendMessageUseCase.FileMessageCommand(
+                request.objectId(),
+                request.thumbnailObjectId(),
                 request.fileUrl(),
                 request.fileName(),
                 request.fileSize(),

--- a/src/main/java/com/cotalk/adapter/inbound/rest/FileController.java
+++ b/src/main/java/com/cotalk/adapter/inbound/rest/FileController.java
@@ -59,6 +59,7 @@ public class FileController {
         FileUploadResult result = uploadFileUseCase.uploadFile(command);
 
         return ResponseEntity.ok(FileUploadResponse.of(
+                result.objectId(),
                 result.fileUrl(),
                 result.fileName(),
                 result.contentType(),

--- a/src/main/java/com/cotalk/adapter/inbound/rest/dto/auth/FileUploadResponse.java
+++ b/src/main/java/com/cotalk/adapter/inbound/rest/dto/auth/FileUploadResponse.java
@@ -3,7 +3,9 @@ package com.cotalk.adapter.inbound.rest.dto.auth;
 /**
  * 파일 업로드 응답 DTO.
  *
- * @param fileUrl     업로드된 파일 URL
+ * @param objectId    업로드된 객체의 불투명 식별자(저장 객체 키). 파일 메시지 전송 시 이 값을 보내면
+ *                    서버가 소유·존재를 검증하고 URL/메타를 재구성한다(권장).
+ * @param fileUrl     업로드된 파일 URL (하위호환용)
  * @param fileName    파일명
  * @param contentType 콘텐츠 타입
  * @param fileSize    파일 크기 (바이트)
@@ -11,6 +13,7 @@ package com.cotalk.adapter.inbound.rest.dto.auth;
  * @author seunggu.lee
  */
 public record FileUploadResponse(
+        String objectId,
         String fileUrl,
         String fileName,
         String contentType,
@@ -21,6 +24,7 @@ public record FileUploadResponse(
     /**
      * FileUploadResponse를 생성한다.
      *
+     * @param objectId    업로드된 객체의 불투명 식별자(저장 객체 키)
      * @param fileUrl     업로드된 파일 URL
      * @param fileName    파일명
      * @param contentType 콘텐츠 타입
@@ -28,7 +32,8 @@ public record FileUploadResponse(
      * @param isImage     이미지 여부
      * @return FileUploadResponse 인스턴스
      */
-    public static FileUploadResponse of(String fileUrl, String fileName, String contentType, long fileSize, boolean isImage) {
-        return new FileUploadResponse(fileUrl, fileName, contentType, fileSize, isImage);
+    public static FileUploadResponse of(String objectId, String fileUrl, String fileName,
+                                        String contentType, long fileSize, boolean isImage) {
+        return new FileUploadResponse(objectId, fileUrl, fileName, contentType, fileSize, isImage);
     }
 }

--- a/src/main/java/com/cotalk/adapter/inbound/rest/dto/message/SendFileMessageRequest.java
+++ b/src/main/java/com/cotalk/adapter/inbound/rest/dto/message/SendFileMessageRequest.java
@@ -48,14 +48,32 @@ public record SendFileMessageRequest(
 ) {
 
     /**
+     * 불투명 식별자(object-id) 방식 여부.
+     *
+     * @return {@code objectId}가 존재하면 true
+     */
+    public boolean usesObjectId() {
+        return hasText(objectId);
+    }
+
+    /**
      * {@code objectId} 또는 {@code fileUrl} 중 하나는 반드시 제공되어야 한다.
      *
      * @return 둘 중 하나라도 존재하면 true
      */
     @AssertTrue(message = "objectId 또는 fileUrl 중 하나는 필수입니다.")
     public boolean isFileSourceProvided() {
-        return (objectId != null && !objectId.isBlank())
-                || (fileUrl != null && !fileUrl.isBlank());
+        return usesObjectId() || hasText(fileUrl);
+    }
+
+    /**
+     * 문자열이 null/공백이 아닌 실제 값을 가지는지 확인한다.
+     *
+     * @param value 검사할 문자열
+     * @return null도 공백도 아니면 true
+     */
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
     }
 
     /**

--- a/src/main/java/com/cotalk/adapter/inbound/rest/dto/message/SendFileMessageRequest.java
+++ b/src/main/java/com/cotalk/adapter/inbound/rest/dto/message/SendFileMessageRequest.java
@@ -1,24 +1,39 @@
 package com.cotalk.adapter.inbound.rest.dto.message;
 
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 /**
  * 파일 메시지 전송 요청 DTO.
+ * <p>
+ * 두 가지 방식을 모두 수용한다(하위호환).
+ * <ul>
+ *   <li><b>신규(권장)</b>: {@code objectId}(업로드 응답이 발급한 불투명 저장 객체 키)를 보낸다.
+ *       서버가 소유·존재를 검증하고 {@code fileUrl}/{@code contentType}/{@code fileSize}를 재구성한다.</li>
+ *   <li><b>기존</b>: {@code fileUrl}/{@code contentType}을 직접 보낸다(서버사이드 화이트리스트 검증).</li>
+ * </ul>
+ * {@code objectId} 또는 {@code fileUrl} 중 적어도 하나는 반드시 있어야 한다.
+ * </p>
  *
- * @param chatRoomId   채팅방 ID
- * @param fileUrl      파일 URL
- * @param fileName     파일명
- * @param fileSize     파일 크기 (bytes)
- * @param contentType  파일 MIME 타입
- * @param thumbnailUrl 썸네일 URL (이미지인 경우)
+ * @param chatRoomId        채팅방 ID
+ * @param objectId          불투명 저장 객체 키(신규 방식, 선택)
+ * @param thumbnailObjectId 썸네일 불투명 저장 객체 키(신규 방식, 선택)
+ * @param fileUrl           파일 URL(기존 방식, 선택)
+ * @param fileName          파일명
+ * @param fileSize          파일 크기 (bytes)
+ * @param contentType       파일 MIME 타입 (기존 방식 필수, 신규 방식에서는 저장소 메타 부재 시 폴백 힌트)
+ * @param thumbnailUrl      썸네일 URL (이미지인 경우; 기존 방식)
  * @author seunggu.lee
  */
 public record SendFileMessageRequest(
         @NotNull(message = "채팅방 ID는 필수입니다.")
         Long chatRoomId,
 
-        @NotBlank(message = "파일 URL은 필수입니다.")
+        String objectId,
+
+        String thumbnailObjectId,
+
         String fileUrl,
 
         @NotBlank(message = "파일명은 필수입니다.")
@@ -27,14 +42,24 @@ public record SendFileMessageRequest(
         @NotNull(message = "파일 크기는 필수입니다.")
         Long fileSize,
 
-        @NotBlank(message = "파일 형식은 필수입니다.")
         String contentType,
 
         String thumbnailUrl  // 선택 (이미지인 경우)
 ) {
 
     /**
-     * 파일 메시지 전송 요청을 생성합니다.
+     * {@code objectId} 또는 {@code fileUrl} 중 하나는 반드시 제공되어야 한다.
+     *
+     * @return 둘 중 하나라도 존재하면 true
+     */
+    @AssertTrue(message = "objectId 또는 fileUrl 중 하나는 필수입니다.")
+    public boolean isFileSourceProvided() {
+        return (objectId != null && !objectId.isBlank())
+                || (fileUrl != null && !fileUrl.isBlank());
+    }
+
+    /**
+     * 기존 방식(fileUrl) 파일 메시지 전송 요청을 생성합니다(하위호환 팩토리).
      *
      * @param chatRoomId   채팅방 ID
      * @param fileUrl      파일 URL
@@ -47,6 +72,6 @@ public record SendFileMessageRequest(
     public static SendFileMessageRequest of(Long chatRoomId, String fileUrl,
                                              String fileName, Long fileSize, String contentType,
                                              String thumbnailUrl) {
-        return new SendFileMessageRequest(chatRoomId, fileUrl, fileName, fileSize, contentType, thumbnailUrl);
+        return new SendFileMessageRequest(chatRoomId, null, null, fileUrl, fileName, fileSize, contentType, thumbnailUrl);
     }
 }

--- a/src/main/java/com/cotalk/adapter/inbound/websocket/ChatWebSocketController.java
+++ b/src/main/java/com/cotalk/adapter/inbound/websocket/ChatWebSocketController.java
@@ -142,7 +142,10 @@ public class ChatWebSocketController {
     public void sendFileMessage(@Payload FileMessageRequest request, StompHeaderAccessor headerAccessor) {
         Long authenticatedUserId = extractUserId(headerAccessor);
 
-        if (request == null || request.roomId() == null || request.fileUrl() == null || request.fileUrl().isBlank()) {
+        // 파일 소스: 신규(object-id) 또는 기존(fileUrl) 중 하나는 반드시 있어야 한다(하위호환).
+        boolean hasObjectId = request != null && request.objectId() != null && !request.objectId().isBlank();
+        boolean hasFileUrl = request != null && request.fileUrl() != null && !request.fileUrl().isBlank();
+        if (request == null || request.roomId() == null || (!hasObjectId && !hasFileUrl)) {
             log.warn("Invalid file message request from user {}: {}", authenticatedUserId, request);
             return;
         }
@@ -160,6 +163,8 @@ public class ChatWebSocketController {
         log.debug("Received file message from authenticated user {} to room {}", authenticatedUserId, request.roomId());
 
         FileMessageCommand command = new FileMessageCommand(
+                request.objectId(),
+                request.thumbnailObjectId(),
                 request.fileUrl(),
                 request.fileName(),
                 request.fileSize(),
@@ -365,7 +370,13 @@ public class ChatWebSocketController {
             return false;
         }
 
-        // contentType 검증: 허용 목록에 있는지 확인
+        // object-id 방식: contentType은 서버가 저장 메타로 재구성하므로 여기서는 선택.
+        // 단, contentType이 제공된 경우엔 허용 목록 검증을 유지한다.
+        if (request.usesObjectId()) {
+            return request.contentType() == null || isAllowedContentType(request.contentType());
+        }
+
+        // 기존(fileUrl) 방식: contentType 필수 + 허용 목록 검증
         if (request.contentType() == null) {
             return false;
         }

--- a/src/main/java/com/cotalk/adapter/inbound/websocket/ChatWebSocketController.java
+++ b/src/main/java/com/cotalk/adapter/inbound/websocket/ChatWebSocketController.java
@@ -370,17 +370,31 @@ public class ChatWebSocketController {
             return false;
         }
 
-        // object-id 방식: contentType은 서버가 저장 메타로 재구성하므로 여기서는 선택.
-        // 단, contentType이 제공된 경우엔 허용 목록 검증을 유지한다.
-        if (request.usesObjectId()) {
-            return request.contentType() == null || isAllowedContentType(request.contentType());
-        }
+        // object-id 방식: contentType은 서버(resolver)가 저장 메타로 재구성하므로 여기서는 선택(생략 가능).
+        //   - contentType 미제공: 통과(서버가 재구성)
+        //   - contentType 제공: 허용 목록 검증 유지(위조 차단)
+        // 기존(fileUrl) 방식: contentType 필수 + 허용 목록 검증.
+        boolean contentTypeOptional = request.usesObjectId();
+        return isContentTypeAcceptable(request.contentType(), contentTypeOptional);
+    }
 
-        // 기존(fileUrl) 방식: contentType 필수 + 허용 목록 검증
-        if (request.contentType() == null) {
-            return false;
+    /**
+     * contentType이 메시지 전송에 허용되는 상태인지 확인합니다.
+     * <p>
+     * {@code optional}이 true(object-id 방식)면 contentType 미제공은 통과하고, 제공된 경우에만
+     * 허용 목록을 검증합니다(서버 resolver가 저장 메타로 재구성). {@code optional}이 false(fileUrl 방식)면
+     * contentType은 필수이며 허용 목록 검증을 통과해야 합니다.
+     * </p>
+     *
+     * @param contentType 검증할 content type (null 허용)
+     * @param optional    contentType 생략 가능 여부(object-id 방식이면 true)
+     * @return 허용되면 true, 그렇지 않으면 false
+     */
+    private boolean isContentTypeAcceptable(String contentType, boolean optional) {
+        if (contentType == null) {
+            return optional;
         }
-        return isAllowedContentType(request.contentType());
+        return isAllowedContentType(contentType);
     }
 
     /**

--- a/src/main/java/com/cotalk/adapter/inbound/websocket/dto/FileMessageRequest.java
+++ b/src/main/java/com/cotalk/adapter/inbound/websocket/dto/FileMessageRequest.java
@@ -3,20 +3,39 @@ package com.cotalk.adapter.inbound.websocket.dto;
 /**
  * 파일 첨부 메시지 전송 요청 DTO.
  * WebSocket을 통해 클라이언트로부터 수신되는 파일 메시지 요청입니다.
+ * <p>
+ * 하위호환을 위해 두 방식을 모두 수용한다. {@code objectId}(업로드가 발급한 불투명 저장 객체 키)를
+ * 보내면 서버가 소유·존재를 검증하고 URL/메타를 재구성한다. {@code objectId}가 없으면 {@code fileUrl}을
+ * 직접 받아 서버사이드 화이트리스트 검증을 수행한다.
+ * </p>
  *
- * @param roomId       채팅방 ID
- * @param fileUrl      업로드된 파일의 URL
- * @param fileName     파일명
- * @param fileSize     파일 크기 (바이트)
- * @param contentType  파일의 MIME 타입
- * @param thumbnailUrl 썸네일 이미지 URL (이미지/동영상 파일인 경우)
+ * @param roomId            채팅방 ID
+ * @param objectId          불투명 저장 객체 키(신규 방식, 선택)
+ * @param thumbnailObjectId 썸네일 불투명 저장 객체 키(신규 방식, 선택)
+ * @param fileUrl           업로드된 파일의 URL(기존 방식, 선택)
+ * @param fileName          파일명
+ * @param fileSize          파일 크기 (바이트)
+ * @param contentType       파일의 MIME 타입
+ * @param thumbnailUrl      썸네일 이미지 URL (이미지/동영상 파일인 경우; 기존 방식)
  * @author seunggu.lee
  */
 public record FileMessageRequest(
         Long roomId,
+        String objectId,
+        String thumbnailObjectId,
         String fileUrl,
         String fileName,
         Long fileSize,
         String contentType,
         String thumbnailUrl
-) {}
+) {
+
+    /**
+     * 불투명 식별자(object-id) 방식 여부.
+     *
+     * @return {@code objectId}가 존재하면 true
+     */
+    public boolean usesObjectId() {
+        return objectId != null && !objectId.isBlank();
+    }
+}

--- a/src/main/java/com/cotalk/adapter/inbound/websocket/dto/FileMessageRequest.java
+++ b/src/main/java/com/cotalk/adapter/inbound/websocket/dto/FileMessageRequest.java
@@ -36,6 +36,16 @@ public record FileMessageRequest(
      * @return {@code objectId}가 존재하면 true
      */
     public boolean usesObjectId() {
-        return objectId != null && !objectId.isBlank();
+        return hasText(objectId);
+    }
+
+    /**
+     * 문자열이 null/공백이 아닌 실제 값을 가지는지 확인한다.
+     *
+     * @param value 검사할 문자열
+     * @return null도 공백도 아니면 true
+     */
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
     }
 }

--- a/src/main/java/com/cotalk/application/service/message/SendMessageService.java
+++ b/src/main/java/com/cotalk/application/service/message/SendMessageService.java
@@ -201,12 +201,17 @@ public class SendMessageService implements SendMessageUseCase {
     /**
      * 두 전송 방식의 검증·재구성 결과를 공통 표현으로 담는 내부 값 객체.
      *
+     * <p>{@code fileSize}는 nullable({@code Long})이다. object-id 경로는 size 확정 불가 시
+     * {@link FileObjectResolver}가 예외로 거부하므로 항상 non-null이지만, 기존(fileUrl) 하위호환
+     * 경로는 클라이언트가 size를 생략(null)할 수 있어 그대로 허용한다(이 PR 이전 동작 유지).
+     * {@code Message.fileSize} 역시 nullable이라 null이 그대로 저장된다.</p>
+     *
      * @param fileUrl      최종 파일 URL(서버 재구성 또는 검증된 클라이언트 값)
      * @param contentType  최종 contentType
-     * @param fileSize     최종 파일 크기
+     * @param fileSize     최종 파일 크기(fileUrl 하위호환 경로에서는 null 허용)
      * @param thumbnailUrl 최종 썸네일 URL(없으면 null)
      */
-    private record ResolvedFileMeta(String fileUrl, String contentType, long fileSize, String thumbnailUrl) {}
+    private record ResolvedFileMeta(String fileUrl, String contentType, Long fileSize, String thumbnailUrl) {}
 
     /**
      * 메시지 저장을 위한 공통 로직을 실행하고, 사전 조회한 컨텍스트를 함께 반환한다.

--- a/src/main/java/com/cotalk/application/service/message/SendMessageService.java
+++ b/src/main/java/com/cotalk/application/service/message/SendMessageService.java
@@ -16,6 +16,7 @@ import com.cotalk.domain.port.outbound.MetricsPort;
 import com.cotalk.domain.port.outbound.NotificationCommandPort;
 import com.cotalk.domain.port.outbound.TimeProvider;
 import com.cotalk.domain.port.outbound.UserRepository;
+import com.cotalk.domain.service.FileObjectResolver;
 import com.cotalk.domain.util.HtmlSanitizer;
 import com.cotalk.domain.validator.BlockValidator;
 import com.cotalk.domain.validator.FileMessageValidator;
@@ -55,6 +56,7 @@ public class SendMessageService implements SendMessageUseCase {
     private final TransactionTemplate transactionTemplate;
     private final TimeProvider timeProvider;
     private final FileMessageValidator fileMessageValidator;
+    private final FileObjectResolver fileObjectResolver;
     private final BlockValidator blockValidator;
 
     /**
@@ -116,30 +118,93 @@ public class SendMessageService implements SendMessageUseCase {
 
     @Override
     public SendResult sendFileMessageWithContext(Long chatRoomId, Long senderId, FileMessageCommand command) {
-        // 서버사이드 검증: 클라이언트가 보낸 contentType/fileUrl을 신뢰하지 않고 재검증한다.
-        // - contentType: 업로드 허용 MIME 목록 재검증
-        // - fileUrl/thumbnailUrl: 본 서버 업로드 경로(uploads/{senderId}/...) 소유 여부 검증
-        fileMessageValidator.validate(senderId, command.contentType(), command.fileUrl(), command.thumbnailUrl());
+        // 하위호환: 두 방식을 모두 수용한다.
+        // - 신규(object-id): 클라이언트는 업로드가 발급한 불투명 식별자만 보낸다. 서버가 소유·존재를
+        //   검증하고 fileUrl/contentType/size를 저장 메타로 재구성한다(클라이언트 URL/타입 위조 차단).
+        // - 기존(fileUrl): 클라이언트가 보낸 contentType/fileUrl을 #166 서버사이드 화이트리스트로 재검증한다.
+        ResolvedFileMeta meta = command.usesObjectId()
+                ? resolveByObjectId(senderId, command)
+                : validateByFileUrl(senderId, command);
+
+        MessageType messageType = resolveMessageType(meta.contentType());
 
         Message message = Message.builder()
                 .id(idGenerator.nextId())
                 .chatRoomId(chatRoomId)
                 .senderId(senderId)
                 .content(command.fileName())
-                .type(command.getMessageType())
-                .fileUrl(command.fileUrl())
+                .type(messageType)
+                .fileUrl(meta.fileUrl())
                 .fileName(command.fileName())
-                .fileSize(command.fileSize())
-                .fileContentType(command.contentType())
-                .thumbnailUrl(command.thumbnailUrl())
+                .fileSize(meta.fileSize())
+                .fileContentType(meta.contentType())
+                .thumbnailUrl(meta.thumbnailUrl())
                 .build();
 
-        String notificationContent = command.getMessageType() == MessageType.IMAGE
+        String notificationContent = messageType == MessageType.IMAGE
                 ? "📷 사진을 보냈습니다."
                 : "📎 파일을 보냈습니다: " + command.fileName();
 
         return doSendMessage(chatRoomId, senderId, message, notificationContent);
     }
+
+    /**
+     * 불투명 식별자(object-id) 방식으로 파일 메타를 재구성한다.
+     * 본문/썸네일 모두 소유·존재 검증 후 서버가 URL을 재구성한다.
+     *
+     * @param senderId 발신자 ID
+     * @param command  파일 메시지 명령(object-id 포함)
+     * @return 서버가 재구성한 파일 메타
+     */
+    private ResolvedFileMeta resolveByObjectId(Long senderId, FileMessageCommand command) {
+        FileObjectResolver.ResolvedFileObject resolved =
+                fileObjectResolver.resolve(senderId, command.objectId(), command.contentType(), command.fileSize());
+
+        String thumbnailUrl = null;
+        if (command.thumbnailObjectId() != null && !command.thumbnailObjectId().isBlank()) {
+            // 썸네일도 소유·존재 검증 후 URL 재구성(타입 힌트는 본문과 동일 정책으로 둔다)
+            thumbnailUrl = fileObjectResolver
+                    .resolve(senderId, command.thumbnailObjectId(), command.contentType(), command.fileSize())
+                    .fileUrl();
+        }
+        return new ResolvedFileMeta(resolved.fileUrl(), resolved.contentType(), resolved.fileSize(), thumbnailUrl);
+    }
+
+    /**
+     * 기존 방식(fileUrl 직접 전송)으로 파일 메타를 검증한다(#166 화이트리스트).
+     *
+     * @param senderId 발신자 ID
+     * @param command  파일 메시지 명령(fileUrl 포함)
+     * @return 클라이언트가 보낸 값을 검증한 파일 메타
+     */
+    private ResolvedFileMeta validateByFileUrl(Long senderId, FileMessageCommand command) {
+        fileMessageValidator.validate(senderId, command.contentType(), command.fileUrl(), command.thumbnailUrl());
+        return new ResolvedFileMeta(
+                command.fileUrl(), command.contentType(), command.fileSize(), command.thumbnailUrl());
+    }
+
+    /**
+     * contentType으로 메시지 타입을 결정한다.
+     *
+     * @param contentType MIME 타입
+     * @return 이미지면 IMAGE, 그 외 FILE
+     */
+    private MessageType resolveMessageType(String contentType) {
+        if (contentType != null && contentType.startsWith("image/")) {
+            return MessageType.IMAGE;
+        }
+        return MessageType.FILE;
+    }
+
+    /**
+     * 두 전송 방식의 검증·재구성 결과를 공통 표현으로 담는 내부 값 객체.
+     *
+     * @param fileUrl      최종 파일 URL(서버 재구성 또는 검증된 클라이언트 값)
+     * @param contentType  최종 contentType
+     * @param fileSize     최종 파일 크기
+     * @param thumbnailUrl 최종 썸네일 URL(없으면 null)
+     */
+    private record ResolvedFileMeta(String fileUrl, String contentType, long fileSize, String thumbnailUrl) {}
 
     /**
      * 메시지 저장을 위한 공통 로직을 실행하고, 사전 조회한 컨텍스트를 함께 반환한다.

--- a/src/main/java/com/cotalk/application/service/message/SendMessageService.java
+++ b/src/main/java/com/cotalk/application/service/message/SendMessageService.java
@@ -162,9 +162,11 @@ public class SendMessageService implements SendMessageUseCase {
 
         String thumbnailUrl = null;
         if (command.thumbnailObjectId() != null && !command.thumbnailObjectId().isBlank()) {
-            // 썸네일도 소유·존재 검증 후 URL 재구성(타입 힌트는 본문과 동일 정책으로 둔다)
+            // 썸네일은 본문과 별개의 저장 객체(자기 contentType/size 메타를 가진다)이므로,
+            // 본문 힌트를 넘기지 않고 자기 메타로 resolve한다. 본문 힌트를 넘기면 저장소 메타가
+            // 부재한 경우 썸네일이 본문 메타(예: video/mp4 크기)로 오염될 수 있다.
             thumbnailUrl = fileObjectResolver
-                    .resolve(senderId, command.thumbnailObjectId(), command.contentType(), command.fileSize())
+                    .resolve(senderId, command.thumbnailObjectId())
                     .fileUrl();
         }
         return new ResolvedFileMeta(resolved.fileUrl(), resolved.contentType(), resolved.fileSize(), thumbnailUrl);

--- a/src/main/java/com/cotalk/domain/port/inbound/file/UploadFileUseCase.java
+++ b/src/main/java/com/cotalk/domain/port/inbound/file/UploadFileUseCase.java
@@ -38,12 +38,15 @@ public interface UploadFileUseCase {
     /**
      * 파일 업로드 결과.
      *
-     * @param fileUrl 업로드된 파일 URL
+     * @param objectId 업로드된 객체의 불투명 식별자(저장 객체 키). 파일 메시지 전송 시 이 값을 보내면
+     *                 서버가 소유·존재를 검증하고 URL/메타를 재구성한다(클라이언트 URL 위조 방지).
+     * @param fileUrl 업로드된 파일 URL(하위호환용. 신규 클라이언트는 {@code objectId}만 사용 권장)
      * @param fileName 저장된 파일명
      * @param contentType 파일 MIME 타입
      * @param fileSize 파일 크기
      */
     record FileUploadResult(
+            String objectId,
             String fileUrl,
             String fileName,
             String contentType,

--- a/src/main/java/com/cotalk/domain/port/inbound/message/SendMessageUseCase.java
+++ b/src/main/java/com/cotalk/domain/port/inbound/message/SendMessageUseCase.java
@@ -96,20 +96,59 @@ public interface SendMessageUseCase {
 
     /**
      * 파일 메시지 전송 명령.
+     * <p>
+     * 두 가지 방식을 모두 수용한다(하위호환).
+     * <ul>
+     *   <li><b>신규(권장)</b>: {@code objectId}(업로드가 발급한 불투명 저장 객체 키)를 보내면
+     *       서버가 소유·존재를 검증하고 URL/contentType/size를 재구성한다. 이때 {@code thumbnailObjectId}로
+     *       썸네일도 object-id로 보낼 수 있다.</li>
+     *   <li><b>기존</b>: {@code objectId}가 없으면 {@code fileUrl}/{@code contentType} 등을 직접 받아
+     *       서버사이드 URL 화이트리스트 검증(#166)을 수행한다.</li>
+     * </ul>
+     * {@code contentType}/{@code fileSize}는 object-id 방식에서도 저장소 메타가 없을 때의 폴백 힌트로 쓰인다.
+     * </p>
      *
-     * @param fileUrl 파일 URL
-     * @param fileName 파일명
+     * @param objectId          불투명 저장 객체 키(신규 방식, 선택)
+     * @param thumbnailObjectId 썸네일 불투명 저장 객체 키(신규 방식, 선택)
+     * @param fileUrl 파일 URL(기존 방식)
+     * @param fileName 파일명(표시용)
      * @param fileSize 파일 크기
      * @param contentType 파일 MIME 타입
-     * @param thumbnailUrl 썸네일 URL (이미지인 경우, 선택)
+     * @param thumbnailUrl 썸네일 URL (이미지인 경우, 선택; 기존 방식)
      */
     record FileMessageCommand(
+            String objectId,
+            String thumbnailObjectId,
             String fileUrl,
             String fileName,
             Long fileSize,
             String contentType,
             String thumbnailUrl
     ) {
+        /**
+         * 기존 방식(object-id 없음) 명령을 생성한다(하위호환 팩토리).
+         *
+         * @param fileUrl 파일 URL
+         * @param fileName 파일명
+         * @param fileSize 파일 크기
+         * @param contentType 파일 MIME 타입
+         * @param thumbnailUrl 썸네일 URL
+         * @return object-id가 없는 FileMessageCommand
+         */
+        public static FileMessageCommand ofUrl(String fileUrl, String fileName, Long fileSize,
+                                               String contentType, String thumbnailUrl) {
+            return new FileMessageCommand(null, null, fileUrl, fileName, fileSize, contentType, thumbnailUrl);
+        }
+
+        /**
+         * 불투명 식별자(object-id) 방식 여부.
+         *
+         * @return {@code objectId}가 존재하면 true
+         */
+        public boolean usesObjectId() {
+            return objectId != null && !objectId.isBlank();
+        }
+
         /**
          * 메시지 타입을 결정한다.
          *

--- a/src/main/java/com/cotalk/domain/port/inbound/message/SendMessageUseCase.java
+++ b/src/main/java/com/cotalk/domain/port/inbound/message/SendMessageUseCase.java
@@ -146,7 +146,7 @@ public interface SendMessageUseCase {
          * @return {@code objectId}가 존재하면 true
          */
         public boolean usesObjectId() {
-            return objectId != null && !objectId.isBlank();
+            return hasText(objectId);
         }
 
         /**
@@ -159,6 +159,16 @@ public interface SendMessageUseCase {
                 return MessageType.IMAGE;
             }
             return MessageType.FILE;
+        }
+
+        /**
+         * 문자열이 null/공백이 아닌 실제 값을 가지는지 확인한다.
+         *
+         * @param value 검사할 문자열
+         * @return null도 공백도 아니면 true
+         */
+        private static boolean hasText(String value) {
+            return value != null && !value.isBlank();
         }
     }
 }

--- a/src/main/java/com/cotalk/domain/port/outbound/FileStorage.java
+++ b/src/main/java/com/cotalk/domain/port/outbound/FileStorage.java
@@ -1,6 +1,7 @@
 package com.cotalk.domain.port.outbound;
 
 import java.io.InputStream;
+import java.util.Optional;
 
 /**
  * 파일 저장소 아웃바운드 포트.
@@ -45,4 +46,39 @@ public interface FileStorage {
      * @return Pre-signed URL
      */
     String generatePresignedUrl(String fileName, int expirationMinutes);
+
+    /**
+     * 저장된 객체 키(object id)로부터 접근 가능한 URL을 재구성한다.
+     * <p>
+     * 불투명 식별자(object-id) 기반 파일 메시지 전송에서, 클라이언트가 임의의 URL을
+     * 주입하지 못하도록 서버가 저장 객체 키만으로 URL을 다시 만든다.
+     * 업로드 시 {@link #upload(InputStream, String, String, long)}이 반환한 URL과 동일한
+     * 규칙(공개 URL 또는 Pre-signed URL)으로 생성한다.
+     * </p>
+     *
+     * @param objectKey 저장 객체 키 (예: {@code uploads/{userId}/{uuid}.ext})
+     * @return 해당 객체에 접근할 수 있는 URL
+     */
+    String resolveUrl(String objectKey);
+
+    /**
+     * 저장된 객체의 메타데이터(MIME 타입·크기)를 조회한다.
+     * <p>
+     * object-id 기반 전송 시 클라이언트가 보낸 contentType/size를 신뢰하지 않고
+     * 저장소가 기록한 실제 메타데이터로 재구성하기 위해 사용한다. 메타데이터를 알 수 없는
+     * 구현체(예: InMemory)는 {@link Optional#empty()}를 반환할 수 있다.
+     * </p>
+     *
+     * @param objectKey 저장 객체 키
+     * @return 객체 메타데이터. 존재하지 않거나 알 수 없으면 빈 Optional
+     */
+    Optional<StoredObjectMetadata> getMetadata(String objectKey);
+
+    /**
+     * 저장된 객체의 메타데이터.
+     *
+     * @param contentType 저장소가 기록한 MIME 타입 (없으면 null)
+     * @param fileSize    저장소가 기록한 크기(bytes). 알 수 없으면 음수
+     */
+    record StoredObjectMetadata(String contentType, long fileSize) {}
 }

--- a/src/main/java/com/cotalk/domain/service/FileObjectResolver.java
+++ b/src/main/java/com/cotalk/domain/service/FileObjectResolver.java
@@ -138,13 +138,21 @@ public class FileObjectResolver {
     }
 
     /**
-     * 저장소 메타데이터의 size를 우선 사용하고, 없으면 힌트로 폴백한다(폴백도 없으면 0).
+     * 저장소 메타데이터의 size를 우선 사용하고, 없으면 힌트로 폴백한다.
+     * <p>
+     * 저장소 메타도 없고 클라이언트 힌트도 없으면 size를 확정할 수 없으므로 예외를 던진다.
+     * contentType과 동일하게 "확정 불가 시 거부" 정책을 적용하여, 0과 같은 의미 없는 값이
+     * 조용히 저장되는 것을 막는다.
+     * </p>
      */
     private long resolveFileSize(StoredObjectMetadata metadata, Long hintFileSize) {
         if (metadata != null && metadata.fileSize() >= 0) {
             return metadata.fileSize();
         }
-        return hintFileSize != null ? hintFileSize : 0L;
+        if (hintFileSize != null) {
+            return hintFileSize;
+        }
+        throw new FileUploadException("파일 크기를 확인할 수 없습니다.");
     }
 
     /**

--- a/src/main/java/com/cotalk/domain/service/FileObjectResolver.java
+++ b/src/main/java/com/cotalk/domain/service/FileObjectResolver.java
@@ -1,0 +1,182 @@
+package com.cotalk.domain.service;
+
+import com.cotalk.domain.exception.FileUploadException;
+import com.cotalk.domain.port.outbound.FileStorage;
+import com.cotalk.domain.port.outbound.FileStorage.StoredObjectMetadata;
+
+import java.util.Optional;
+
+/**
+ * 불투명 식별자(object-id) 기반 파일 메시지 메타 재구성기.
+ * <p>
+ * 파일 메시지 전송 시 클라이언트가 임의의 {@code fileUrl}/{@code contentType}/{@code fileSize}를
+ * 주입하는 대신, 업로드가 발급한 <b>불투명 저장 객체 키(object-id)</b>만 보내도록 하는 근본 해결책의
+ * 서버 측 구성 요소다. object-id가 주어지면 다음을 수행한다.
+ * </p>
+ * <ol>
+ *   <li><b>소유 검증</b>: object-id가 {@code uploads/{senderId}/{file}} 구조에 정확히 속하는지 확인하여
+ *       타인 소유 객체를 메시지에 붙이지 못하게 한다. 경로 탈출({@code ..}) 세그먼트는 거부한다.</li>
+ *   <li><b>존재 검증</b>: 저장소에 실제로 객체가 존재하는지 확인한다.</li>
+ *   <li><b>메타 재구성</b>: 저장소가 기록한 메타데이터(또는 부재 시 클라이언트 힌트)로 contentType/size를
+ *       정하고, 저장소 포트로 접근 URL을 다시 만든다. 이로써 클라이언트가 URL/타입을 위조할 여지를 없앤다.</li>
+ * </ol>
+ * <p>
+ * contentType은 {@link UploadFileService#ALLOWED_CONTENT_TYPES} 허용 목록으로 재검증한다.
+ * </p>
+ *
+ * @author seunggu.lee
+ * @see FileStorage
+ * @see UploadFileService
+ */
+public class FileObjectResolver {
+
+    /**
+     * 업로드 객체 키의 최상위 디렉터리.
+     * {@code UploadFileService.generateStoragePath}가 생성하는 {@code uploads/{userId}/...} 규칙과 일치한다.
+     */
+    private static final String UPLOAD_ROOT = "uploads";
+
+    private final FileStorage fileStorage;
+
+    /**
+     * FileObjectResolver를 생성한다.
+     *
+     * @param fileStorage 파일 저장소 포트
+     */
+    public FileObjectResolver(FileStorage fileStorage) {
+        this.fileStorage = fileStorage;
+    }
+
+    /**
+     * object-id로 파일 메타를 재구성한다(힌트 없음).
+     *
+     * @param senderId 발신자(현재 인증된 사용자) ID
+     * @param objectId 업로드가 발급한 불투명 저장 객체 키
+     * @return 재구성된 파일 객체(URL·contentType·size)
+     * @throws FileUploadException 소유/존재/타입 검증에 실패한 경우
+     */
+    public ResolvedFileObject resolve(Long senderId, String objectId) {
+        return resolve(senderId, objectId, null, null);
+    }
+
+    /**
+     * object-id로 파일 메타를 재구성한다.
+     * <p>
+     * 저장소 메타데이터를 우선 사용하고, 저장소가 메타데이터를 제공하지 않는 경우에 한해
+     * 클라이언트가 보낸 힌트({@code hintContentType}/{@code hintFileSize})로 폴백한다.
+     * 어느 경우든 contentType은 허용 목록으로 재검증된다.
+     * </p>
+     *
+     * @param senderId        발신자 ID
+     * @param objectId        불투명 저장 객체 키
+     * @param hintContentType 클라이언트가 보낸 contentType 힌트(저장소 메타 부재 시 폴백, null 허용)
+     * @param hintFileSize    클라이언트가 보낸 size 힌트(저장소 메타 부재 시 폴백, null 허용)
+     * @return 재구성된 파일 객체
+     * @throws FileUploadException 소유/존재/타입 검증에 실패한 경우
+     */
+    public ResolvedFileObject resolve(Long senderId, String objectId, String hintContentType, Long hintFileSize) {
+        String key = normalizeAndValidateOwnership(senderId, objectId);
+
+        Optional<StoredObjectMetadata> metadata = fileStorage.getMetadata(key);
+
+        // 메타데이터가 있으면 존재가 보장된다. 없으면 exists로 별도 확인한다.
+        if (metadata.isEmpty() && !fileStorage.exists(key)) {
+            throw new FileUploadException("업로드된 파일을 찾을 수 없습니다: " + objectId);
+        }
+
+        String contentType = resolveContentType(metadata.orElse(null), hintContentType);
+        validateContentType(contentType);
+
+        long fileSize = resolveFileSize(metadata.orElse(null), hintFileSize);
+        String fileUrl = fileStorage.resolveUrl(key);
+
+        return new ResolvedFileObject(fileUrl, contentType, fileSize);
+    }
+
+    /**
+     * object-id가 발신자 소유 업로드 경로({@code uploads/{senderId}/{file}})에 정확히 속하는지 검증하고,
+     * 선행 슬래시를 제거한 정규화 키를 반환한다.
+     *
+     * @param senderId 발신자 ID
+     * @param objectId 검증할 object-id
+     * @return 정규화된 저장 객체 키
+     * @throws FileUploadException 구조가 맞지 않거나 타인 소유이거나 경로 탈출이 있는 경우
+     */
+    private String normalizeAndValidateOwnership(Long senderId, String objectId) {
+        if (objectId == null || objectId.isBlank()) {
+            throw invalidObjectId(objectId);
+        }
+        String key = stripLeadingSlash(objectId.trim());
+        String[] segments = key.split("/");
+
+        for (String segment : segments) {
+            if ("..".equals(segment) || segment.isEmpty()) {
+                throw invalidObjectId(objectId);
+            }
+        }
+
+        // 정확히 uploads/{senderId}/{file...} 구조여야 한다.
+        if (segments.length < 3
+                || !UPLOAD_ROOT.equals(segments[0])
+                || !String.valueOf(senderId).equals(segments[1])) {
+            throw invalidObjectId(objectId);
+        }
+        return key;
+    }
+
+    /**
+     * 저장소 메타데이터의 contentType을 우선 사용하고, 없으면 힌트로 폴백한다.
+     */
+    private String resolveContentType(StoredObjectMetadata metadata, String hintContentType) {
+        if (metadata != null && metadata.contentType() != null && !metadata.contentType().isBlank()) {
+            return metadata.contentType();
+        }
+        if (hintContentType != null && !hintContentType.isBlank()) {
+            return hintContentType;
+        }
+        throw new FileUploadException("파일 형식을 확인할 수 없습니다.");
+    }
+
+    /**
+     * 저장소 메타데이터의 size를 우선 사용하고, 없으면 힌트로 폴백한다(폴백도 없으면 0).
+     */
+    private long resolveFileSize(StoredObjectMetadata metadata, Long hintFileSize) {
+        if (metadata != null && metadata.fileSize() >= 0) {
+            return metadata.fileSize();
+        }
+        return hintFileSize != null ? hintFileSize : 0L;
+    }
+
+    /**
+     * contentType이 업로드 허용 목록에 포함되는지 검증한다.
+     *
+     * @param contentType 검증할 MIME 타입
+     * @throws FileUploadException 허용 목록에 없는 경우
+     */
+    private void validateContentType(String contentType) {
+        if (contentType == null || !UploadFileService.ALLOWED_CONTENT_TYPES.contains(contentType)) {
+            throw FileUploadException.invalidFileType(contentType);
+        }
+    }
+
+    private String stripLeadingSlash(String path) {
+        int i = 0;
+        while (i < path.length() && path.charAt(i) == '/') {
+            i++;
+        }
+        return path.substring(i);
+    }
+
+    private FileUploadException invalidObjectId(String objectId) {
+        return new FileUploadException("신뢰할 수 없는 파일 식별자입니다: " + objectId);
+    }
+
+    /**
+     * 재구성된 파일 객체.
+     *
+     * @param fileUrl     서버가 저장 객체 키로부터 재구성한 접근 URL
+     * @param contentType 검증된 MIME 타입
+     * @param fileSize    파일 크기(bytes)
+     */
+    public record ResolvedFileObject(String fileUrl, String contentType, long fileSize) {}
+}

--- a/src/main/java/com/cotalk/domain/service/UploadFileService.java
+++ b/src/main/java/com/cotalk/domain/service/UploadFileService.java
@@ -114,7 +114,9 @@ public class UploadFileService implements UploadFileUseCase {
                     command.fileSize()
             );
 
+            // storagePath(=저장 객체 키)가 곧 불투명 식별자(object-id)다.
             return new FileUploadResult(
+                    storagePath,
                     fileUrl,
                     extractFileName(storagePath),
                     command.contentType(),

--- a/src/main/java/com/cotalk/infrastructure/config/DomainValidatorConfig.java
+++ b/src/main/java/com/cotalk/infrastructure/config/DomainValidatorConfig.java
@@ -8,6 +8,8 @@ import com.cotalk.domain.validator.ChatRoomMemberValidator;
 import com.cotalk.domain.validator.FileMessageValidator;
 import com.cotalk.domain.validator.MessageValidator;
 import com.cotalk.domain.validator.UserValidator;
+import com.cotalk.domain.port.outbound.FileStorage;
+import com.cotalk.domain.service.FileObjectResolver;
 import com.cotalk.infrastructure.config.properties.MinioProperties;
 import com.cotalk.infrastructure.storage.InMemoryFileStorage;
 import org.springframework.context.annotation.Bean;
@@ -75,6 +77,21 @@ public class DomainValidatorConfig {
             allowedBaseUrls.add(InMemoryFileStorage.BASE_URL);
         }
         return new FileMessageValidator(allowedBaseUrls);
+    }
+
+    /**
+     * 불투명 식별자(object-id) 기반 파일 메시지 메타 재구성기 빈.
+     * <p>
+     * 업로드가 발급한 저장 객체 키만으로 소유·존재를 검증하고 URL/메타를 재구성한다.
+     * 파일 저장소 포트({@link FileStorage})에 의존한다.
+     * </p>
+     *
+     * @param fileStorage 파일 저장소 포트(MinIO 또는 InMemory)
+     * @return FileObjectResolver
+     */
+    @Bean
+    public FileObjectResolver fileObjectResolver(FileStorage fileStorage) {
+        return new FileObjectResolver(fileStorage);
     }
 
     private void addBaseWithBucket(List<String> target, String baseUrl, String bucket) {

--- a/src/main/java/com/cotalk/infrastructure/storage/InMemoryFileStorage.java
+++ b/src/main/java/com/cotalk/infrastructure/storage/InMemoryFileStorage.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 
 import java.io.InputStream;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -32,6 +33,7 @@ public class InMemoryFileStorage implements FileStorage {
     public static final String BASE_URL = "http://localhost:8080/files";
 
     private final Map<String, byte[]> storage = new ConcurrentHashMap<>();
+    private final Map<String, String> contentTypes = new ConcurrentHashMap<>();
     private final String baseUrl;
 
     /**
@@ -57,10 +59,40 @@ public class InMemoryFileStorage implements FileStorage {
         try {
             byte[] data = inputStream.readAllBytes();
             storage.put(fileName, data);
-            return baseUrl + "/" + fileName;
+            if (contentType != null) {
+                contentTypes.put(fileName, contentType);
+            }
+            return resolveUrl(fileName);
         } catch (Exception e) {
             throw new RuntimeException("Failed to read file", e);
         }
+    }
+
+    /**
+     * 저장 객체 키로부터 접근 URL을 재구성한다.
+     * 업로드 시 반환하는 URL과 동일하게 {@code baseUrl/objectKey} 형태를 반환한다.
+     *
+     * @param objectKey 저장 객체 키
+     * @return 접근 가능한 URL
+     */
+    @Override
+    public String resolveUrl(String objectKey) {
+        return baseUrl + "/" + objectKey;
+    }
+
+    /**
+     * 메모리에 저장된 객체의 메타데이터(MIME 타입·크기)를 조회한다.
+     *
+     * @param objectKey 저장 객체 키
+     * @return 객체 메타데이터. 존재하지 않으면 빈 Optional
+     */
+    @Override
+    public Optional<StoredObjectMetadata> getMetadata(String objectKey) {
+        byte[] data = storage.get(objectKey);
+        if (data == null) {
+            return Optional.empty();
+        }
+        return Optional.of(new StoredObjectMetadata(contentTypes.get(objectKey), data.length));
     }
 
     /**
@@ -71,6 +103,7 @@ public class InMemoryFileStorage implements FileStorage {
     @Override
     public void delete(String fileName) {
         storage.remove(fileName);
+        contentTypes.remove(fileName);
     }
 
     /**
@@ -114,5 +147,6 @@ public class InMemoryFileStorage implements FileStorage {
      */
     public void clear() {
         storage.clear();
+        contentTypes.clear();
     }
 }

--- a/src/main/java/com/cotalk/infrastructure/storage/MinioFileStorage.java
+++ b/src/main/java/com/cotalk/infrastructure/storage/MinioFileStorage.java
@@ -16,6 +16,7 @@ import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignReques
 
 import java.io.InputStream;
 import java.time.Duration;
+import java.util.Optional;
 
 /**
  * MinIO 기반 파일 저장소 구현체.
@@ -160,14 +161,50 @@ public class MinioFileStorage implements FileStorage {
 
             log.info("File uploaded successfully: {}", fileName);
 
-            // Return public URL or generate one
-            if (publicUrl != null && !publicUrl.isEmpty()) {
-                return publicUrl + "/" + bucketName + "/" + fileName;
-            }
-            return generatePresignedUrl(fileName, 60 * 24 * 7); // 7 days default
+            return resolveUrl(fileName);
         } catch (Exception e) {
             log.error("Failed to upload file: {}", fileName, e);
             throw FileUploadException.uploadFailed(e);
+        }
+    }
+
+    /**
+     * 저장 객체 키로부터 접근 URL을 재구성한다.
+     * 공개 URL이 설정되어 있으면 {@code publicUrl/bucket/objectKey} 직접 URL을,
+     * 없으면 7일 유효기간의 Pre-signed URL을 반환한다.
+     * 업로드 시 반환하는 URL과 동일한 규칙을 사용한다.
+     *
+     * @param objectKey 저장 객체 키
+     * @return 접근 가능한 URL
+     */
+    @Override
+    public String resolveUrl(String objectKey) {
+        if (publicUrl != null && !publicUrl.isEmpty()) {
+            return publicUrl + "/" + bucketName + "/" + objectKey;
+        }
+        return generatePresignedUrl(objectKey, 60 * 24 * 7); // 7 days default
+    }
+
+    /**
+     * MinIO에 저장된 객체의 메타데이터(MIME 타입·크기)를 조회한다.
+     *
+     * @param objectKey 저장 객체 키
+     * @return 객체 메타데이터. 존재하지 않으면 빈 Optional
+     */
+    @Override
+    public Optional<StoredObjectMetadata> getMetadata(String objectKey) {
+        try {
+            HeadObjectResponse head = s3Client.headObject(HeadObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(objectKey)
+                    .build());
+            long size = head.contentLength() != null ? head.contentLength() : -1L;
+            return Optional.of(new StoredObjectMetadata(head.contentType(), size));
+        } catch (NoSuchKeyException e) {
+            return Optional.empty();
+        } catch (Exception e) {
+            log.warn("Failed to fetch object metadata for key '{}': {}", objectKey, e.getMessage());
+            return Optional.empty();
         }
     }
 

--- a/src/test/java/com/cotalk/adapter/inbound/rest/ChatMessageControllerTest.java
+++ b/src/test/java/com/cotalk/adapter/inbound/rest/ChatMessageControllerTest.java
@@ -120,7 +120,7 @@ class ChatMessageControllerTest {
         @WithMockCustomUser(userId = 1L)
         void should_returnCreated_when_validImageMessage() throws Exception {
             // given
-            SendFileMessageRequest request = new SendFileMessageRequest(
+            SendFileMessageRequest request = SendFileMessageRequest.of(
                     100L,
                     "https://example.com/image.png",
                     "image.png",
@@ -162,7 +162,7 @@ class ChatMessageControllerTest {
         @WithMockCustomUser(userId = 1L)
         void should_returnCreated_when_validFileMessage() throws Exception {
             // given
-            SendFileMessageRequest request = new SendFileMessageRequest(
+            SendFileMessageRequest request = SendFileMessageRequest.of(
                     100L,
                     "https://example.com/file.pdf",
                     "document.pdf",

--- a/src/test/java/com/cotalk/adapter/inbound/rest/FileControllerTest.java
+++ b/src/test/java/com/cotalk/adapter/inbound/rest/FileControllerTest.java
@@ -60,6 +60,7 @@ class FileControllerTest {
             );
 
             FileUploadResult result = new FileUploadResult(
+                    "uploads/1/abc123.jpg",
                     "https://storage.example.com/uploads/1/abc123.jpg",
                     "abc123.jpg",
                     "image/jpeg",
@@ -72,6 +73,7 @@ class FileControllerTest {
             mockMvc.perform(multipart("/api/v1/files/upload")
                             .file(file))
                     .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.objectId").value(result.objectId()))
                     .andExpect(jsonPath("$.fileUrl").value(result.fileUrl()))
                     .andExpect(jsonPath("$.fileName").value(result.fileName()))
                     .andExpect(jsonPath("$.contentType").value("image/jpeg"))
@@ -92,6 +94,7 @@ class FileControllerTest {
             );
 
             FileUploadResult result = new FileUploadResult(
+                    "uploads/1/abc123.pdf",
                     "https://storage.example.com/uploads/1/abc123.pdf",
                     "abc123.pdf",
                     "application/pdf",

--- a/src/test/java/com/cotalk/adapter/inbound/websocket/ChatWebSocketControllerTest.java
+++ b/src/test/java/com/cotalk/adapter/inbound/websocket/ChatWebSocketControllerTest.java
@@ -155,6 +155,8 @@ class ChatWebSocketControllerTest {
         // given
         FileMessageRequest request = new FileMessageRequest(
                 100L,
+                null,
+                null,
                 "https://storage.example.com/file.pdf",
                 "document.pdf",
                 1024L,
@@ -207,6 +209,8 @@ class ChatWebSocketControllerTest {
         // given
         FileMessageRequest request = new FileMessageRequest(
                 100L,
+                null,
+                null,
                 "https://storage.example.com/image.jpg",
                 "photo.jpg",
                 2048L,
@@ -320,6 +324,8 @@ class ChatWebSocketControllerTest {
         String tooLongFileName = "a".repeat(256) + ".jpg";
         FileMessageRequest request = new FileMessageRequest(
                 100L,
+                null,
+                null,
                 "https://storage.example.com/image.jpg",
                 tooLongFileName,
                 1024L,
@@ -340,6 +346,8 @@ class ChatWebSocketControllerTest {
         // given
         FileMessageRequest request = new FileMessageRequest(
                 100L,
+                null,
+                null,
                 "https://storage.example.com/image.jpg",
                 "",
                 1024L,
@@ -360,6 +368,8 @@ class ChatWebSocketControllerTest {
         // given
         FileMessageRequest request = new FileMessageRequest(
                 100L,
+                null,
+                null,
                 "https://storage.example.com/malicious.exe",
                 "malicious.exe",
                 1024L,
@@ -399,6 +409,8 @@ class ChatWebSocketControllerTest {
         // given
         FileMessageRequest request = new FileMessageRequest(
                 100L,
+                null,
+                null,
                 "https://storage.example.com/file.pdf",
                 "document.pdf",
                 1024L,

--- a/src/test/java/com/cotalk/application/service/message/SendMessageServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/message/SendMessageServiceTest.java
@@ -642,6 +642,42 @@ class SendMessageServiceTest {
             assertThat(result.getFileUrl()).isEqualTo("http://localhost:8080/files/uploads/2/3f9-uuid.jpg");
             verify(messageRepository).save(any(Message.class));
         }
+
+        @Test
+        @DisplayName("기존(fileUrl) 방식에서 fileSize가 null이어도 NPE 없이 허용한다(하위호환)")
+        void should_AllowNullFileSize_when_fileUrlWithNullSize() {
+            // given: WS FileMessageRequest.fileSize는 Long이며 bean validation이 없어 null이 올 수 있다.
+            // 이 PR 이전 fileUrl 경로는 Message.fileSize(=Long)에 null을 그대로 저장해 허용했다.
+            Long chatRoomId = 1L;
+            Long senderId = 2L;
+            Long messageId = 100L;
+
+            ChatRoomMember member = ChatRoomMember.builder()
+                    .id(10L).chatRoomId(chatRoomId).userId(senderId).build();
+            User sender = User.builder()
+                    .id(senderId).email(new Email("sender@test.com")).nickname("발신자").passwordHash("hash").build();
+
+            SendMessageUseCase.FileMessageCommand command = SendMessageUseCase.FileMessageCommand.ofUrl(
+                    "http://localhost:8080/files/uploads/2/3f9-uuid.jpg",
+                    "photo.jpg",
+                    null, // fileSize null → 이전엔 허용, 회귀 시 ResolvedFileMeta 언박싱에서 NPE
+                    "image/jpeg",
+                    null
+            );
+
+            given(chatRoomMemberRepository.findByChatRoomId(chatRoomId)).willReturn(List.of(member));
+            given(userRepository.findById(senderId)).willReturn(Optional.of(sender));
+            given(idGenerator.nextId()).willReturn(messageId);
+            given(messageRepository.save(any(Message.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            Message result = sendMessageService.sendFileMessage(chatRoomId, senderId, command);
+
+            // then: NPE 없이 저장되고 fileSize는 null로 보존된다(이전 동작)
+            assertThat(result.getFileSize()).isNull();
+            assertThat(result.getFileUrl()).isEqualTo("http://localhost:8080/files/uploads/2/3f9-uuid.jpg");
+            verify(messageRepository).save(any(Message.class));
+        }
     }
 
     @Nested
@@ -699,6 +735,27 @@ class SendMessageServiceTest {
 
             given(fileObjectResolver.resolve(eq(senderId), eq("uploads/999/secret.jpg"), nullable(String.class), any()))
                     .willThrow(new com.cotalk.domain.exception.FileUploadException("신뢰할 수 없는 파일 식별자입니다"));
+
+            // when & then
+            assertThatThrownBy(() -> sendMessageService.sendFileMessage(chatRoomId, senderId, command))
+                    .isInstanceOf(com.cotalk.domain.exception.FileUploadException.class);
+            verify(messageRepository, never()).save(any(Message.class));
+        }
+
+        @Test
+        @DisplayName("object-id 경로는 size를 확정할 수 없으면 엄격하게 거부한다(fileUrl 하위호환과 구분)")
+        void should_RejectStrictly_when_ObjectIdSizeUnconfirmed() {
+            // given: object-id 경로는 fileUrl 하위호환과 달리 size 확정 불가 시 엄격하게 거부한다(1b762c6).
+            // null fileSize 허용은 오직 기존 fileUrl 경로에 한정된다.
+            Long chatRoomId = 1L;
+            Long senderId = 2L;
+
+            SendMessageUseCase.FileMessageCommand command = new SendMessageUseCase.FileMessageCommand(
+                    "uploads/2/abc.jpg", null, null, "photo.jpg", null, null, null);
+
+            // 저장소 메타도 없고 size 힌트도 null → resolver가 "파일 크기를 확인할 수 없습니다"로 거부
+            given(fileObjectResolver.resolve(eq(senderId), eq("uploads/2/abc.jpg"), nullable(String.class), nullable(Long.class)))
+                    .willThrow(new com.cotalk.domain.exception.FileUploadException("파일 크기를 확인할 수 없습니다."));
 
             // when & then
             assertThatThrownBy(() -> sendMessageService.sendFileMessage(chatRoomId, senderId, command))

--- a/src/test/java/com/cotalk/application/service/message/SendMessageServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/message/SendMessageServiceTest.java
@@ -707,7 +707,7 @@ class SendMessageServiceTest {
         }
 
         @Test
-        @DisplayName("썸네일 object-id도 소유 검증 후 URL을 재구성한다")
+        @DisplayName("썸네일 object-id는 본문 힌트 없이 자기 메타로 resolve된다")
         void should_ResolveThumbnailObjectId_when_Provided() {
             // given
             Long chatRoomId = 1L;
@@ -719,13 +719,16 @@ class SendMessageServiceTest {
             User sender = User.builder()
                     .id(senderId).email(new Email("sender@test.com")).nickname("발신자").passwordHash("hash").build();
 
+            // 본문은 video/mp4 + 큰 size, 썸네일은 별개의 image/jpeg 객체.
+            // 본문 힌트가 썸네일 resolve로 새면 썸네일 메타가 본문(video, 1024)으로 오염된다.
             SendMessageUseCase.FileMessageCommand command = new SendMessageUseCase.FileMessageCommand(
-                    "uploads/2/abc.jpg", "uploads/2/thumb.jpg", null, "photo.jpg", 1024L, null, null);
+                    "uploads/2/abc.mp4", "uploads/2/thumb.jpg", null, "video.mp4", 1024L, "video/mp4", null);
 
-            given(fileObjectResolver.resolve(eq(senderId), eq("uploads/2/abc.jpg"), nullable(String.class), any()))
+            given(fileObjectResolver.resolve(eq(senderId), eq("uploads/2/abc.mp4"), nullable(String.class), any()))
                     .willReturn(new com.cotalk.domain.service.FileObjectResolver.ResolvedFileObject(
-                            "http://localhost:8080/files/uploads/2/abc.jpg", "image/jpeg", 1024L));
-            given(fileObjectResolver.resolve(eq(senderId), eq("uploads/2/thumb.jpg"), nullable(String.class), any()))
+                            "http://localhost:8080/files/uploads/2/abc.mp4", "video/mp4", 1024L));
+            // 썸네일은 힌트 없는 2-인자 오버로드로 호출되어야 한다(자기 메타로 재구성).
+            given(fileObjectResolver.resolve(eq(senderId), eq("uploads/2/thumb.jpg")))
                     .willReturn(new com.cotalk.domain.service.FileObjectResolver.ResolvedFileObject(
                             "http://localhost:8080/files/uploads/2/thumb.jpg", "image/jpeg", 256L));
 
@@ -737,8 +740,11 @@ class SendMessageServiceTest {
             // when
             Message result = sendMessageService.sendFileMessage(chatRoomId, senderId, command);
 
-            // then
+            // then: 썸네일은 본문 힌트 없이(2-인자 오버로드) resolve되어야 한다(메타 오염 방지)
             assertThat(result.getThumbnailUrl()).isEqualTo("http://localhost:8080/files/uploads/2/thumb.jpg");
+            verify(fileObjectResolver).resolve(eq(senderId), eq("uploads/2/thumb.jpg"));
+            verify(fileObjectResolver, never())
+                    .resolve(eq(senderId), eq("uploads/2/thumb.jpg"), nullable(String.class), any());
         }
     }
 

--- a/src/test/java/com/cotalk/application/service/message/SendMessageServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/message/SendMessageServiceTest.java
@@ -84,6 +84,9 @@ class SendMessageServiceTest {
     @Mock
     private com.cotalk.domain.validator.BlockValidator blockValidator;
 
+    @Mock
+    private com.cotalk.domain.service.FileObjectResolver fileObjectResolver;
+
     private SendMessageService sendMessageService;
 
     @SuppressWarnings("unchecked")
@@ -93,7 +96,7 @@ class SendMessageServiceTest {
                 messageRepository, chatRoomMemberRepository, chatRoomRepository, userRepository, idGenerator,
                 notificationCommandPort, chatRoomPresenceTracker, customMetrics,
                 messageLinkPreviewService, messageBroadcastService, transactionTemplate, timeProvider,
-                new com.cotalk.domain.validator.FileMessageValidator(), blockValidator);
+                new com.cotalk.domain.validator.FileMessageValidator(), fileObjectResolver, blockValidator);
 
         // TransactionTemplate: 콜백을 즉시 실행 (트랜잭션 없이 동기 실행)
         lenient().when(transactionTemplate.execute(any(TransactionCallback.class)))
@@ -367,7 +370,7 @@ class SendMessageServiceTest {
                     .passwordHash("hash")
                     .build();
 
-            SendMessageUseCase.FileMessageCommand command = new SendMessageUseCase.FileMessageCommand(
+            SendMessageUseCase.FileMessageCommand command = SendMessageUseCase.FileMessageCommand.ofUrl(
                     "http://localhost:8080/files/uploads/2/abc.jpg",
                     "photo.jpg",
                     1024L,
@@ -412,7 +415,7 @@ class SendMessageServiceTest {
                     .passwordHash("hash")
                     .build();
 
-            SendMessageUseCase.FileMessageCommand command = new SendMessageUseCase.FileMessageCommand(
+            SendMessageUseCase.FileMessageCommand command = SendMessageUseCase.FileMessageCommand.ofUrl(
                     "http://localhost:8080/files/uploads/2/doc.pdf",
                     "document.pdf",
                     2048L,
@@ -442,7 +445,7 @@ class SendMessageServiceTest {
             Long chatRoomId = 1L;
             Long senderId = 2L;
 
-            SendMessageUseCase.FileMessageCommand command = new SendMessageUseCase.FileMessageCommand(
+            SendMessageUseCase.FileMessageCommand command = SendMessageUseCase.FileMessageCommand.ofUrl(
                     "http://localhost:8080/files/uploads/2/file.bin",
                     "unknown.file",
                     1024L,
@@ -473,7 +476,7 @@ class SendMessageServiceTest {
             User sender = User.builder()
                     .id(senderId).email(new Email("sender@test.com")).nickname("발신자").passwordHash("hash").build();
 
-            SendMessageUseCase.FileMessageCommand command = new SendMessageUseCase.FileMessageCommand(
+            SendMessageUseCase.FileMessageCommand command = SendMessageUseCase.FileMessageCommand.ofUrl(
                     "http://localhost:8080/files/uploads/2/abc.jpg",
                     "photo.jpg",
                     1024L,
@@ -502,7 +505,7 @@ class SendMessageServiceTest {
             Long chatRoomId = 1L;
             Long senderId = 2L;
 
-            SendMessageUseCase.FileMessageCommand command = new SendMessageUseCase.FileMessageCommand(
+            SendMessageUseCase.FileMessageCommand command = SendMessageUseCase.FileMessageCommand.ofUrl(
                     "http://localhost:8080/files/uploads/2/abc.jpg",
                     "photo.jpg",
                     1024L,
@@ -526,7 +529,7 @@ class SendMessageServiceTest {
             Long chatRoomId = 1L;
             Long senderId = 2L;
 
-            SendMessageUseCase.FileMessageCommand command = new SendMessageUseCase.FileMessageCommand(
+            SendMessageUseCase.FileMessageCommand command = SendMessageUseCase.FileMessageCommand.ofUrl(
                     "http://localhost:8080/files/uploads/2/evil.exe",
                     "evil.exe",
                     1024L,
@@ -548,7 +551,7 @@ class SendMessageServiceTest {
             Long senderId = 2L;
 
             // 본 서버 업로드 객체 경로(uploads/{senderId}/...)가 전혀 없는 외부 URL
-            SendMessageUseCase.FileMessageCommand external = new SendMessageUseCase.FileMessageCommand(
+            SendMessageUseCase.FileMessageCommand external = SendMessageUseCase.FileMessageCommand.ofUrl(
                     "https://evil.example.com/malware.jpg",
                     "photo.jpg",
                     1024L,
@@ -569,7 +572,7 @@ class SendMessageServiceTest {
             Long chatRoomId = 1L;
             Long senderId = 2L;
 
-            SendMessageUseCase.FileMessageCommand command = new SendMessageUseCase.FileMessageCommand(
+            SendMessageUseCase.FileMessageCommand command = SendMessageUseCase.FileMessageCommand.ofUrl(
                     "http://localhost:8080/files/uploads/999/abc.jpg", // 타인(999) 경로
                     "photo.jpg",
                     1024L,
@@ -590,7 +593,7 @@ class SendMessageServiceTest {
             Long chatRoomId = 1L;
             Long senderId = 2L;
 
-            SendMessageUseCase.FileMessageCommand command = new SendMessageUseCase.FileMessageCommand(
+            SendMessageUseCase.FileMessageCommand command = SendMessageUseCase.FileMessageCommand.ofUrl(
                     "http://localhost:8080/files/uploads/2/../999/secret.jpg",
                     "secret.jpg",
                     1024L,
@@ -618,7 +621,7 @@ class SendMessageServiceTest {
                     .id(senderId).email(new Email("sender@test.com")).nickname("발신자").passwordHash("hash").build();
 
             // InMemoryFileStorage가 반환하는 실제 형식: {baseUrl}/uploads/{userId}/{uuid}.ext
-            SendMessageUseCase.FileMessageCommand command = new SendMessageUseCase.FileMessageCommand(
+            SendMessageUseCase.FileMessageCommand command = SendMessageUseCase.FileMessageCommand.ofUrl(
                     "http://localhost:8080/files/uploads/2/3f9-uuid.jpg",
                     "photo.jpg",
                     1024L,
@@ -638,6 +641,104 @@ class SendMessageServiceTest {
             assertThat(result.getType()).isEqualTo(Message.MessageType.IMAGE);
             assertThat(result.getFileUrl()).isEqualTo("http://localhost:8080/files/uploads/2/3f9-uuid.jpg");
             verify(messageRepository).save(any(Message.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("불투명 식별자(object-id) 파일 메시지 전송 시")
+    class ObjectIdFileMessage {
+
+        @Test
+        @DisplayName("object-id로 전송하면 서버가 재구성한 URL/메타로 메시지를 저장한다")
+        void should_ReconstructMetaFromObjectId_when_ObjectIdProvided() {
+            // given
+            Long chatRoomId = 1L;
+            Long senderId = 2L;
+            Long messageId = 100L;
+
+            ChatRoomMember member = ChatRoomMember.builder()
+                    .id(10L).chatRoomId(chatRoomId).userId(senderId).build();
+            User sender = User.builder()
+                    .id(senderId).email(new Email("sender@test.com")).nickname("발신자").passwordHash("hash").build();
+
+            // 클라이언트는 fileUrl/contentType 없이 object-id만 보낸다(여기선 size 힌트만 동반)
+            SendMessageUseCase.FileMessageCommand command = new SendMessageUseCase.FileMessageCommand(
+                    "uploads/2/abc.jpg", null, null, "photo.jpg", 1024L, null, null);
+
+            // 서버(resolver)가 소유·존재 검증 후 URL/메타를 재구성
+            given(fileObjectResolver.resolve(eq(senderId), eq("uploads/2/abc.jpg"), nullable(String.class), any()))
+                    .willReturn(new com.cotalk.domain.service.FileObjectResolver.ResolvedFileObject(
+                            "http://localhost:8080/files/uploads/2/abc.jpg", "image/jpeg", 1024L));
+
+            given(chatRoomMemberRepository.findByChatRoomId(chatRoomId)).willReturn(List.of(member));
+            given(userRepository.findById(senderId)).willReturn(Optional.of(sender));
+            given(idGenerator.nextId()).willReturn(messageId);
+            given(messageRepository.save(any(Message.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            Message result = sendMessageService.sendFileMessage(chatRoomId, senderId, command);
+
+            // then: 서버가 재구성한 값으로 저장됨 (클라가 URL/타입을 주지 않았어도)
+            assertThat(result.getType()).isEqualTo(Message.MessageType.IMAGE);
+            assertThat(result.getFileUrl()).isEqualTo("http://localhost:8080/files/uploads/2/abc.jpg");
+            assertThat(result.getFileContentType()).isEqualTo("image/jpeg");
+            assertThat(result.getFileSize()).isEqualTo(1024L);
+            assertThat(result.getFileName()).isEqualTo("photo.jpg");
+            verify(messageRepository).save(any(Message.class));
+        }
+
+        @Test
+        @DisplayName("타인 소유 object-id면 resolver가 거부하여 저장되지 않는다")
+        void should_Reject_when_ObjectIdOwnedByAnotherUser() {
+            // given
+            Long chatRoomId = 1L;
+            Long senderId = 2L;
+
+            SendMessageUseCase.FileMessageCommand command = new SendMessageUseCase.FileMessageCommand(
+                    "uploads/999/secret.jpg", null, null, "secret.jpg", 1024L, null, null);
+
+            given(fileObjectResolver.resolve(eq(senderId), eq("uploads/999/secret.jpg"), nullable(String.class), any()))
+                    .willThrow(new com.cotalk.domain.exception.FileUploadException("신뢰할 수 없는 파일 식별자입니다"));
+
+            // when & then
+            assertThatThrownBy(() -> sendMessageService.sendFileMessage(chatRoomId, senderId, command))
+                    .isInstanceOf(com.cotalk.domain.exception.FileUploadException.class);
+            verify(messageRepository, never()).save(any(Message.class));
+        }
+
+        @Test
+        @DisplayName("썸네일 object-id도 소유 검증 후 URL을 재구성한다")
+        void should_ResolveThumbnailObjectId_when_Provided() {
+            // given
+            Long chatRoomId = 1L;
+            Long senderId = 2L;
+            Long messageId = 100L;
+
+            ChatRoomMember member = ChatRoomMember.builder()
+                    .id(10L).chatRoomId(chatRoomId).userId(senderId).build();
+            User sender = User.builder()
+                    .id(senderId).email(new Email("sender@test.com")).nickname("발신자").passwordHash("hash").build();
+
+            SendMessageUseCase.FileMessageCommand command = new SendMessageUseCase.FileMessageCommand(
+                    "uploads/2/abc.jpg", "uploads/2/thumb.jpg", null, "photo.jpg", 1024L, null, null);
+
+            given(fileObjectResolver.resolve(eq(senderId), eq("uploads/2/abc.jpg"), nullable(String.class), any()))
+                    .willReturn(new com.cotalk.domain.service.FileObjectResolver.ResolvedFileObject(
+                            "http://localhost:8080/files/uploads/2/abc.jpg", "image/jpeg", 1024L));
+            given(fileObjectResolver.resolve(eq(senderId), eq("uploads/2/thumb.jpg"), nullable(String.class), any()))
+                    .willReturn(new com.cotalk.domain.service.FileObjectResolver.ResolvedFileObject(
+                            "http://localhost:8080/files/uploads/2/thumb.jpg", "image/jpeg", 256L));
+
+            given(chatRoomMemberRepository.findByChatRoomId(chatRoomId)).willReturn(List.of(member));
+            given(userRepository.findById(senderId)).willReturn(Optional.of(sender));
+            given(idGenerator.nextId()).willReturn(messageId);
+            given(messageRepository.save(any(Message.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            Message result = sendMessageService.sendFileMessage(chatRoomId, senderId, command);
+
+            // then
+            assertThat(result.getThumbnailUrl()).isEqualTo("http://localhost:8080/files/uploads/2/thumb.jpg");
         }
     }
 

--- a/src/test/java/com/cotalk/domain/service/FileObjectResolverTest.java
+++ b/src/test/java/com/cotalk/domain/service/FileObjectResolverTest.java
@@ -127,6 +127,17 @@ class FileObjectResolverTest {
             assertThatThrownBy(() -> resolver.resolve(42L, objectId, null, null))
                     .isInstanceOf(FileUploadException.class);
         }
+
+        @Test
+        @DisplayName("메타데이터가 없고 contentType 힌트는 있으나 size 힌트가 없으면 예외를 던진다")
+        void should_Throw_when_NoMetadataAndNoSizeHint() {
+            // size를 확정할 수 없을 때 조용히 0L로 두지 않고 contentType과 동일하게 거부한다.
+            String objectId = "uploads/42/no-meta.png";
+            fileStorage.putWithoutMetadata(objectId);
+
+            assertThatThrownBy(() -> resolver.resolve(42L, objectId, "image/png", null))
+                    .isInstanceOf(FileUploadException.class);
+        }
     }
 
     /**

--- a/src/test/java/com/cotalk/domain/service/FileObjectResolverTest.java
+++ b/src/test/java/com/cotalk/domain/service/FileObjectResolverTest.java
@@ -1,0 +1,179 @@
+package com.cotalk.domain.service;
+
+import com.cotalk.domain.exception.FileUploadException;
+import com.cotalk.domain.port.outbound.FileStorage;
+import com.cotalk.domain.port.outbound.FileStorage.StoredObjectMetadata;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("FileObjectResolver")
+class FileObjectResolverTest {
+
+    private FakeFileStorage fileStorage;
+    private FileObjectResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        fileStorage = new FakeFileStorage();
+        resolver = new FileObjectResolver(fileStorage);
+    }
+
+    @Nested
+    @DisplayName("소유한 object-id로 메타 재구성 시")
+    class ResolveOwnedObject {
+
+        @Test
+        @DisplayName("URL·contentType·size를 서버 저장 메타로 재구성한다")
+        void should_ReconstructMeta_when_ObjectOwnedAndExists() {
+            String objectId = "uploads/42/abc.png";
+            fileStorage.put(objectId, "image/png", 1234L);
+
+            FileObjectResolver.ResolvedFileObject resolved = resolver.resolve(42L, objectId);
+
+            assertThat(resolved.fileUrl()).isEqualTo("http://localhost:8080/files/" + objectId);
+            assertThat(resolved.contentType()).isEqualTo("image/png");
+            assertThat(resolved.fileSize()).isEqualTo(1234L);
+        }
+    }
+
+    @Nested
+    @DisplayName("소유하지 않은 object-id 거부")
+    class RejectNotOwned {
+
+        @Test
+        @DisplayName("다른 사용자의 object-id면 예외를 던진다")
+        void should_Throw_when_ObjectOwnedByAnotherUser() {
+            String objectId = "uploads/99/secret.png";
+            fileStorage.put(objectId, "image/png", 10L);
+
+            assertThatThrownBy(() -> resolver.resolve(42L, objectId))
+                    .isInstanceOf(FileUploadException.class);
+        }
+
+        @Test
+        @DisplayName("uploads 루트가 아닌 키는 거부한다")
+        void should_Throw_when_KeyNotUnderUploadsRoot() {
+            String objectId = "etc/passwd";
+            fileStorage.put(objectId, "image/png", 10L);
+
+            assertThatThrownBy(() -> resolver.resolve(42L, objectId))
+                    .isInstanceOf(FileUploadException.class);
+        }
+
+        @Test
+        @DisplayName("경로 탈출(..) 세그먼트를 거부한다")
+        void should_Throw_when_PathTraversalSegment() {
+            assertThatThrownBy(() -> resolver.resolve(42L, "uploads/42/../99/x.png"))
+                    .isInstanceOf(FileUploadException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("존재하지 않는 object-id 거부")
+    class RejectNotExists {
+
+        @Test
+        @DisplayName("저장소에 객체가 없으면 예외를 던진다")
+        void should_Throw_when_ObjectDoesNotExist() {
+            assertThatThrownBy(() -> resolver.resolve(42L, "uploads/42/missing.png"))
+                    .isInstanceOf(FileUploadException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("contentType 검증")
+    class ContentTypeValidation {
+
+        @Test
+        @DisplayName("허용되지 않은 저장 contentType이면 예외를 던진다")
+        void should_Throw_when_StoredContentTypeNotAllowed() {
+            String objectId = "uploads/42/evil.exe";
+            fileStorage.put(objectId, "application/x-msdownload", 10L);
+
+            assertThatThrownBy(() -> resolver.resolve(42L, objectId))
+                    .isInstanceOf(FileUploadException.class);
+        }
+
+        @Test
+        @DisplayName("메타데이터가 없으면 클라이언트가 보낸 힌트 contentType으로 폴백 검증한다")
+        void should_FallbackToHint_when_MetadataMissing() {
+            String objectId = "uploads/42/no-meta.png";
+            fileStorage.putWithoutMetadata(objectId);
+
+            FileObjectResolver.ResolvedFileObject resolved =
+                    resolver.resolve(42L, objectId, "image/png", 555L);
+
+            assertThat(resolved.contentType()).isEqualTo("image/png");
+            assertThat(resolved.fileSize()).isEqualTo(555L);
+            assertThat(resolved.fileUrl()).isEqualTo("http://localhost:8080/files/" + objectId);
+        }
+
+        @Test
+        @DisplayName("메타데이터도 힌트도 없으면 예외를 던진다")
+        void should_Throw_when_NoMetadataAndNoHint() {
+            String objectId = "uploads/42/no-meta.png";
+            fileStorage.putWithoutMetadata(objectId);
+
+            assertThatThrownBy(() -> resolver.resolve(42L, objectId, null, null))
+                    .isInstanceOf(FileUploadException.class);
+        }
+    }
+
+    /**
+     * 테스트용 FileStorage 페이크. 메모리에 키→메타데이터를 보관한다.
+     */
+    private static final class FakeFileStorage implements FileStorage {
+
+        private final Map<String, StoredObjectMetadata> objects = new HashMap<>();
+        private final Map<String, Boolean> existsOnly = new HashMap<>();
+
+        void put(String key, String contentType, long size) {
+            objects.put(key, new StoredObjectMetadata(contentType, size));
+        }
+
+        void putWithoutMetadata(String key) {
+            existsOnly.put(key, true);
+        }
+
+        @Override
+        public String upload(InputStream inputStream, String fileName, String contentType, long fileSize) {
+            return resolveUrl(fileName);
+        }
+
+        @Override
+        public void delete(String fileName) {
+            objects.remove(fileName);
+            existsOnly.remove(fileName);
+        }
+
+        @Override
+        public boolean exists(String fileName) {
+            return objects.containsKey(fileName) || existsOnly.containsKey(fileName);
+        }
+
+        @Override
+        public String generatePresignedUrl(String fileName, int expirationMinutes) {
+            return resolveUrl(fileName);
+        }
+
+        @Override
+        public String resolveUrl(String objectKey) {
+            return "http://localhost:8080/files/" + objectKey;
+        }
+
+        @Override
+        public Optional<StoredObjectMetadata> getMetadata(String objectKey) {
+            return Optional.ofNullable(objects.get(objectKey));
+        }
+    }
+}


### PR DESCRIPTION
## 배경 / 목적
현재 파일 메시지 전송은 클라이언트가 `fileUrl/contentType/fileSize`를 직접 보낸다. #166에서 서버사이드 검증(host 화이트리스트·contentType·경로 소유)을 추가해 최소 방어는 됐지만, 근본 해결은 **클라이언트가 URL 대신 업로드가 발급한 불투명 식별자(object-id)만 전송하고, 서버가 그 id로 URL·메타를 재구성**하는 것이다. 이 PR은 그 서버 측을 **하위호환되게** 도입한다.

## 무엇을 했나
- **업로드 응답에 `objectId` 추가**: 업로드가 생성하는 저장 객체 키(`uploads/{userId}/{uuid}.ext`)가 곧 불투명 식별자다. 기존 `fileUrl`도 그대로 반환.
- **`FileObjectResolver`(도메인 서비스)** 신규: object-id가 오면
  1. 소유 검증 — `uploads/{senderId}/{file}` 구조에 정확히 속하는지(경로 탈출 `..`·타인 소유 거부)
  2. 존재 검증 — `FileStorage.exists`/메타 조회
  3. 메타 재구성 — 저장소가 기록한 contentType/size로 결정(부재 시 클라 힌트 폴백), `FileStorage.resolveUrl`로 URL 재구성, contentType 허용 목록 재검증
- **`FileStorage` 포트 확장**: `resolveUrl(objectKey)`, `getMetadata(objectKey)` (MinIO=headObject, InMemory=contentType 보관). 업로드 URL 생성 로직을 `resolveUrl`로 통합.
- **파일 메시지 전송(REST `/api/v1/chat/messages/file` + WebSocket `/chat/message/file`)**: `objectId`(+`thumbnailObjectId`)가 오면 resolver 경로, 없으면 기존 `fileUrl` 경로(#166 검증).
- DTO: `objectId`/`thumbnailObjectId` 옵셔널 추가. `SendFileMessageRequest`의 `fileUrl @NotBlank`를 완화하고 **"objectId 또는 fileUrl 중 하나 필수"**(`@AssertTrue`)로 대체.

## 하위호환 유지 방식 (중요)
- 서버는 **두 방식을 모두 수용**한다. `objectId`가 없으면 기존 클라이언트의 `fileUrl` 직접 전송이 그대로 #166 화이트리스트 검증을 거쳐 동작한다.
- 업로드 응답은 `fileUrl`을 계속 포함하므로 구버전 클라이언트 무영향.
- 이 PR은 **단독 머지해도 안전**(기존 동작 100% 유지). 새 필드는 모두 옵셔널.

## 배포 순서
- **이 서버 PR을 먼저 머지/배포**해야 한다. 그 후 클라이언트가 새 `objectId`를 보내도록 전환(별도 PR: co-talk-flutter `feat/file-message-opaque-id`).

## 보안 효과
- object-id 경로에서는 클라이언트가 임의 URL/contentType을 주입할 수 없다(서버가 저장 객체 키로만 재구성). 남의 object-id로 남의 파일을 붙이는 시도는 소유 검증으로 거부.

## TDD / 검증
- `FileObjectResolverTest`: object-id 메타 재구성, 타인 소유·uploads 밖·경로 탈출·미존재 거부, 저장 contentType 검증, 메타 부재 시 힌트 폴백.
- `SendMessageServiceTest`: object-id 전송 시 서버 재구성 저장, 타인 object-id 거부, 썸네일 object-id 재구성, **기존 fileUrl 회귀(외부/타인/경로탈출 거부)** 유지.
- 컨트롤러/스토리지 테스트 갱신.
- `./gradlew build` 그린 (전체 테스트 + ArchUnit + JaCoCo 통과).