### PR TITLE
feat(search): 암호화 메시지 검색 복구 — Blind Index (HMAC 트라이그램 토큰)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,6 +95,7 @@ dependencies {
     testImplementation(platform("org.testcontainers:testcontainers-bom:1.20.1"))
     testImplementation("org.testcontainers:testcontainers")
     testImplementation("org.testcontainers:junit-jupiter")
+    testImplementation("org.testcontainers:postgresql") // 암호화 ON 검색 통합테스트 (prod 동등 Flyway 검증)
     testImplementation("org.awaitility:awaitility:4.2.0") // 비동기 테스트 대기
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 

--- a/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageJpaRepository.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageJpaRepository.java
@@ -105,31 +105,64 @@ public interface MessageJpaRepository extends JpaRepository<Message, Long> {
             Pageable pageable);
 
     /**
-     * 특정 채팅방에서 키워드로 메시지를 검색한다.
+     * 특정 채팅방에서 블라인드 인덱스 토큰으로 메시지를 검색한다. (2단계 검색의 1단계)
+     *
+     * <p>키워드의 모든 트라이그램 토큰을 포함하는 메시지(= {@code COUNT(DISTINCT token) = :tokenCount})를
+     * 조회한다. 토큰 AND 매칭은 substring을 보장하지 않으므로, 호출 측에서 복호화 후
+     * {@code normalize(content).contains(normalize(keyword))} 최종 검증(2단계)을 수행해야 한다.</p>
      *
      * @param chatRoomId 채팅방 ID
-     * @param keyword 검색 키워드
-     * @param pageable 페이지 정보
-     * @return 검색된 메시지 목록
+     * @param tokens     키워드를 토큰화한 토큰 집합
+     * @param tokenCount 토큰 개수 (모든 토큰 포함 조건)
+     * @param pageable   페이지 정보 (over-fetch 권장)
+     * @return 토큰 조건을 만족하는 메시지 목록 (최신순)
      */
-    @Query("SELECT m FROM Message m WHERE m.chatRoomId = :chatRoomId AND m.deleted = false AND LOWER(m.content) LIKE LOWER(CONCAT('%', :keyword, '%')) ORDER BY m.createdAt DESC")
-    List<Message> searchByKeywordInChatRoom(
+    @Query("""
+        SELECT m FROM Message m
+        WHERE m.chatRoomId = :chatRoomId
+          AND m.deleted = false
+          AND m.id IN (
+            SELECT t.messageId FROM MessageSearchTokenJpaEntity t
+            WHERE t.token IN :tokens
+            GROUP BY t.messageId
+            HAVING COUNT(DISTINCT t.token) = :tokenCount
+          )
+        ORDER BY m.createdAt DESC
+        """)
+    List<Message> searchByTokensInChatRoom(
             @Param("chatRoomId") Long chatRoomId,
-            @Param("keyword") String keyword,
+            @Param("tokens") List<String> tokens,
+            @Param("tokenCount") long tokenCount,
             Pageable pageable);
 
     /**
-     * 사용자가 참여한 모든 채팅방에서 키워드로 메시지를 검색한다.
+     * 사용자가 참여한 모든 채팅방에서 블라인드 인덱스 토큰으로 메시지를 검색한다. (2단계 검색의 1단계)
      *
-     * @param userId 사용자 ID
-     * @param keyword 검색 키워드
-     * @param pageable 페이지 정보
-     * @return 검색된 메시지 목록
+     * <p>{@link #searchByTokensInChatRoom}과 동일한 토큰 AND 매칭에 멤버십(cm 서브쿼리) 한정을 결합한다.
+     * 복호화 substring 최종 검증(2단계)은 호출 측에서 수행한다.</p>
+     *
+     * @param userId     사용자 ID
+     * @param tokens     키워드를 토큰화한 토큰 집합
+     * @param tokenCount 토큰 개수 (모든 토큰 포함 조건)
+     * @param pageable   페이지 정보 (over-fetch 권장)
+     * @return 토큰 조건을 만족하는 메시지 목록 (최신순)
      */
-    @Query("SELECT m FROM Message m WHERE m.chatRoomId IN (SELECT cm.chatRoomId FROM ChatRoomMember cm WHERE cm.userId = :userId) AND m.deleted = false AND LOWER(m.content) LIKE LOWER(CONCAT('%', :keyword, '%')) ORDER BY m.createdAt DESC")
-    List<Message> searchByKeywordInUserChatRooms(
+    @Query("""
+        SELECT m FROM Message m
+        WHERE m.chatRoomId IN (SELECT cm.chatRoomId FROM ChatRoomMember cm WHERE cm.userId = :userId)
+          AND m.deleted = false
+          AND m.id IN (
+            SELECT t.messageId FROM MessageSearchTokenJpaEntity t
+            WHERE t.token IN :tokens
+            GROUP BY t.messageId
+            HAVING COUNT(DISTINCT t.token) = :tokenCount
+          )
+        ORDER BY m.createdAt DESC
+        """)
+    List<Message> searchByTokensInUserChatRooms(
             @Param("userId") Long userId,
-            @Param("keyword") String keyword,
+            @Param("tokens") List<String> tokens,
+            @Param("tokenCount") long tokenCount,
             Pageable pageable);
 
     /**

--- a/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageRepositoryAdapter.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageRepositoryAdapter.java
@@ -105,31 +105,39 @@ public class MessageRepositoryAdapter implements MessageRepository {
     }
 
     /**
-     * 특정 채팅방에서 키워드로 메시지를 검색한다.
+     * 특정 채팅방에서 블라인드 인덱스 토큰으로 메시지를 검색한다. (1단계)
      *
      * @param chatRoomId 채팅방 ID
-     * @param keyword 검색 키워드
+     * @param tokens 키워드 토큰 집합
+     * @param tokenCount 토큰 개수
      * @param page 페이지 번호
-     * @param size 페이지 크기
-     * @return 검색된 메시지 목록
+     * @param size 조회 크기 (over-fetch 한도)
+     * @return 토큰 조건을 만족하는 메시지 목록
      */
     @Override
-    public List<Message> searchByKeywordInChatRoom(Long chatRoomId, String keyword, int page, int size) {
-        return messageJpaRepository.searchByKeywordInChatRoom(chatRoomId, keyword, PageRequest.of(page, size));
+    public List<Message> searchByTokensInChatRoom(Long chatRoomId, List<String> tokens, long tokenCount, int page, int size) {
+        if (tokens == null || tokens.isEmpty()) {
+            return List.of();
+        }
+        return messageJpaRepository.searchByTokensInChatRoom(chatRoomId, tokens, tokenCount, PageRequest.of(page, size));
     }
 
     /**
-     * 사용자가 참여한 모든 채팅방에서 키워드로 메시지를 검색한다.
+     * 사용자가 참여한 모든 채팅방에서 블라인드 인덱스 토큰으로 메시지를 검색한다. (1단계)
      *
      * @param userId 사용자 ID
-     * @param keyword 검색 키워드
+     * @param tokens 키워드 토큰 집합
+     * @param tokenCount 토큰 개수
      * @param page 페이지 번호
-     * @param size 페이지 크기
-     * @return 검색된 메시지 목록
+     * @param size 조회 크기 (over-fetch 한도)
+     * @return 토큰 조건을 만족하는 메시지 목록
      */
     @Override
-    public List<Message> searchByKeywordInUserChatRooms(Long userId, String keyword, int page, int size) {
-        return messageJpaRepository.searchByKeywordInUserChatRooms(userId, keyword, PageRequest.of(page, size));
+    public List<Message> searchByTokensInUserChatRooms(Long userId, List<String> tokens, long tokenCount, int page, int size) {
+        if (tokens == null || tokens.isEmpty()) {
+            return List.of();
+        }
+        return messageJpaRepository.searchByTokensInUserChatRooms(userId, tokens, tokenCount, PageRequest.of(page, size));
     }
 
     /**

--- a/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageRepositoryAdapter.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageRepositoryAdapter.java
@@ -110,16 +110,16 @@ public class MessageRepositoryAdapter implements MessageRepository {
      * @param chatRoomId 채팅방 ID
      * @param tokens 키워드 토큰 집합
      * @param tokenCount 토큰 개수
-     * @param page 페이지 번호
-     * @param size 조회 크기 (over-fetch 한도)
+     * @param offset 조회 시작 오프셋 (사용자 page 기준)
+     * @param limit 조회 윈도우 크기 (over-fetch 한도)
      * @return 토큰 조건을 만족하는 메시지 목록
      */
     @Override
-    public List<Message> searchByTokensInChatRoom(Long chatRoomId, List<String> tokens, long tokenCount, int page, int size) {
+    public List<Message> searchByTokensInChatRoom(Long chatRoomId, List<String> tokens, long tokenCount, long offset, int limit) {
         if (tokens == null || tokens.isEmpty()) {
             return List.of();
         }
-        return messageJpaRepository.searchByTokensInChatRoom(chatRoomId, tokens, tokenCount, PageRequest.of(page, size));
+        return messageJpaRepository.searchByTokensInChatRoom(chatRoomId, tokens, tokenCount, OffsetLimitPageable.of(offset, limit));
     }
 
     /**
@@ -128,16 +128,16 @@ public class MessageRepositoryAdapter implements MessageRepository {
      * @param userId 사용자 ID
      * @param tokens 키워드 토큰 집합
      * @param tokenCount 토큰 개수
-     * @param page 페이지 번호
-     * @param size 조회 크기 (over-fetch 한도)
+     * @param offset 조회 시작 오프셋 (사용자 page 기준)
+     * @param limit 조회 윈도우 크기 (over-fetch 한도)
      * @return 토큰 조건을 만족하는 메시지 목록
      */
     @Override
-    public List<Message> searchByTokensInUserChatRooms(Long userId, List<String> tokens, long tokenCount, int page, int size) {
+    public List<Message> searchByTokensInUserChatRooms(Long userId, List<String> tokens, long tokenCount, long offset, int limit) {
         if (tokens == null || tokens.isEmpty()) {
             return List.of();
         }
-        return messageJpaRepository.searchByTokensInUserChatRooms(userId, tokens, tokenCount, PageRequest.of(page, size));
+        return messageJpaRepository.searchByTokensInUserChatRooms(userId, tokens, tokenCount, OffsetLimitPageable.of(offset, limit));
     }
 
     /**

--- a/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageSearchTokenJpaEntity.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageSearchTokenJpaEntity.java
@@ -5,10 +5,12 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Persistable;
 
 import java.io.Serializable;
 import java.util.Objects;
@@ -20,6 +22,12 @@ import java.util.Objects;
  * 무의미하여 {@link IdClass}로 복합 PK를 표현한다. 검색 조회는 {@link MessageJpaRepository}의
  * 토큰 조인 쿼리가 수행하며, 이 엔티티는 적재(write) 경로에서만 사용된다.</p>
  *
+ * <p><b>성능:</b> 복합 PK에 {@code @GeneratedValue}가 없어 Spring Data가 엔티티를 detached로
+ * 간주하면 {@code saveAll}이 행마다 {@code merge}(=SELECT 후 INSERT)를 실행한다. 긴 메시지는
+ * 토큰이 수천 개라 SELECT 폭증으로 이어진다. {@link Persistable#isNew()}를 항상 {@code true}로
+ * 반환해 {@code persist}(순수 INSERT) 경로를 강제하고, JDBC batch insert와 결합해 적재 부하를
+ * 낮춘다. 토큰은 항상 신규 적재만 하므로(수정 시 {@code deleteByMessageId} 후 재적재) 안전하다.</p>
+ *
  * @author seunggu.lee
  */
 @Entity
@@ -28,7 +36,7 @@ import java.util.Objects;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class MessageSearchTokenJpaEntity {
+public class MessageSearchTokenJpaEntity implements Persistable<MessageSearchTokenJpaEntity.MessageSearchTokenId> {
 
     @Id
     @Column(name = "message_id", nullable = false)
@@ -47,6 +55,33 @@ public class MessageSearchTokenJpaEntity {
      */
     public static MessageSearchTokenJpaEntity of(Long messageId, String token) {
         return new MessageSearchTokenJpaEntity(messageId, token);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>복합 식별자를 반환한다. (Spring Data {@link Persistable} 계약)</p>
+     */
+    @Override
+    @Transient
+    public MessageSearchTokenId getId() {
+        return new MessageSearchTokenId(messageId, token);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>항상 신규 엔티티로 취급한다. 토큰은 적재(INSERT) 경로에서만 생성되며, 수정 시에는
+     * {@code deleteByMessageId}로 전량 삭제 후 재적재하므로 {@code merge}의 사전 SELECT가
+     * 불필요하다. {@code true}를 반환해 {@code persist}(순수 INSERT)와 JDBC batch insert를
+     * 활성화한다.</p>
+     *
+     * @return 항상 {@code true}
+     */
+    @Override
+    @Transient
+    public boolean isNew() {
+        return true;
     }
 
     /**

--- a/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageSearchTokenJpaEntity.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageSearchTokenJpaEntity.java
@@ -1,0 +1,80 @@
+package com.cotalk.adapter.outbound.persistence.message;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * 메시지 검색 블라인드 인덱스 토큰 JPA 엔티티.
+ *
+ * <p>{@code (message_id, token)} 복합 키를 갖는 조인 테이블이다. 자체 surrogate key가
+ * 무의미하여 {@link IdClass}로 복합 PK를 표현한다. 검색 조회는 {@link MessageJpaRepository}의
+ * 토큰 조인 쿼리가 수행하며, 이 엔티티는 적재(write) 경로에서만 사용된다.</p>
+ *
+ * @author seunggu.lee
+ */
+@Entity
+@Table(name = "message_search_tokens")
+@IdClass(MessageSearchTokenJpaEntity.MessageSearchTokenId.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MessageSearchTokenJpaEntity {
+
+    @Id
+    @Column(name = "message_id", nullable = false)
+    private Long messageId;
+
+    @Id
+    @Column(name = "token", nullable = false, length = 24)
+    private String token;
+
+    /**
+     * 토큰 엔티티를 생성한다.
+     *
+     * @param messageId 메시지 ID
+     * @param token     블라인드 인덱스 토큰
+     * @return 생성된 엔티티
+     */
+    public static MessageSearchTokenJpaEntity of(Long messageId, String token) {
+        return new MessageSearchTokenJpaEntity(messageId, token);
+    }
+
+    /**
+     * {@link MessageSearchTokenJpaEntity}의 복합 식별자.
+     *
+     * @author seunggu.lee
+     */
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MessageSearchTokenId implements Serializable {
+
+        private Long messageId;
+        private String token;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof MessageSearchTokenId that)) {
+                return false;
+            }
+            return Objects.equals(messageId, that.messageId) && Objects.equals(token, that.token);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(messageId, token);
+        }
+    }
+}

--- a/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageSearchTokenJpaRepository.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageSearchTokenJpaRepository.java
@@ -1,0 +1,24 @@
+package com.cotalk.adapter.outbound.persistence.message;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * 메시지 검색 토큰 JPA 리포지토리.
+ *
+ * @author seunggu.lee
+ */
+public interface MessageSearchTokenJpaRepository
+        extends JpaRepository<MessageSearchTokenJpaEntity, MessageSearchTokenJpaEntity.MessageSearchTokenId> {
+
+    /**
+     * 특정 메시지의 모든 검색 토큰을 삭제한다. (메시지 수정 시 재토큰화용)
+     *
+     * @param messageId 메시지 ID
+     */
+    @Modifying
+    @Query("DELETE FROM MessageSearchTokenJpaEntity t WHERE t.messageId = :messageId")
+    void deleteByMessageId(@Param("messageId") Long messageId);
+}

--- a/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageSearchTokenRepositoryAdapter.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageSearchTokenRepositoryAdapter.java
@@ -1,0 +1,50 @@
+package com.cotalk.adapter.outbound.persistence.message;
+
+import com.cotalk.domain.port.outbound.MessageSearchTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 메시지 검색 토큰 영속성 어댑터.
+ *
+ * <p>{@link MessageSearchTokenRepository} 포트를 JPA로 구현한다. 토큰 적재/삭제만 담당하며,
+ * 검색 조회는 {@code MessageRepository}의 토큰 조인 메서드가 수행한다.</p>
+ *
+ * @author seunggu.lee
+ */
+@Repository
+@RequiredArgsConstructor
+public class MessageSearchTokenRepositoryAdapter implements MessageSearchTokenRepository {
+
+    private final MessageSearchTokenJpaRepository jpaRepository;
+
+    /**
+     * 메시지의 검색 토큰들을 저장한다.
+     *
+     * @param messageId 토큰이 속한 메시지 ID
+     * @param tokens    저장할 토큰 집합
+     */
+    @Override
+    public void saveTokens(Long messageId, Set<String> tokens) {
+        if (tokens == null || tokens.isEmpty()) {
+            return;
+        }
+        List<MessageSearchTokenJpaEntity> entities = tokens.stream()
+                .map(token -> MessageSearchTokenJpaEntity.of(messageId, token))
+                .toList();
+        jpaRepository.saveAll(entities);
+    }
+
+    /**
+     * 특정 메시지의 모든 검색 토큰을 삭제한다.
+     *
+     * @param messageId 토큰을 삭제할 메시지 ID
+     */
+    @Override
+    public void deleteByMessageId(Long messageId) {
+        jpaRepository.deleteByMessageId(messageId);
+    }
+}

--- a/src/main/java/com/cotalk/adapter/outbound/persistence/message/OffsetLimitPageable.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/message/OffsetLimitPageable.java
@@ -1,0 +1,91 @@
+package com.cotalk.adapter.outbound.persistence.message;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+/**
+ * 임의의 (offset, limit) 윈도우를 표현하는 {@link Pageable} 구현체.
+ *
+ * <p>표준 {@link org.springframework.data.domain.PageRequest}는 offset이
+ * {@code pageNumber * pageSize}로 고정되어, over-fetch(limit을 page 크기보다 크게)와
+ * page 기반 오프셋을 동시에 만족시킬 수 없다. 블라인드 인덱스 검색 1단계는
+ * "사용자 page 기준 오프셋(page * size)"은 유지하면서 "윈도우만 넉넉히(over-fetch)"
+ * 가져와야 page&gt;0에서도 결과 누락/중복이 발생하지 않는다. 이를 위해 offset과 limit을
+ * 독립적으로 지정할 수 있는 Pageable을 제공한다.</p>
+ *
+ * <p>정렬은 쿼리({@code ORDER BY m.createdAt DESC})에 내장되어 있으므로 unsorted로 둔다.</p>
+ *
+ * @author seunggu.lee
+ */
+final class OffsetLimitPageable implements Pageable {
+
+    private final long offset;
+    private final int limit;
+
+    private OffsetLimitPageable(long offset, int limit) {
+        if (offset < 0) {
+            throw new IllegalArgumentException("offset은 0 이상이어야 합니다: " + offset);
+        }
+        if (limit < 1) {
+            throw new IllegalArgumentException("limit은 1 이상이어야 합니다: " + limit);
+        }
+        this.offset = offset;
+        this.limit = limit;
+    }
+
+    /**
+     * (offset, limit) Pageable을 생성한다.
+     *
+     * @param offset 조회 시작 오프셋 (0 이상)
+     * @param limit  조회 윈도우 크기 (1 이상)
+     * @return Pageable
+     */
+    static OffsetLimitPageable of(long offset, int limit) {
+        return new OffsetLimitPageable(offset, limit);
+    }
+
+    @Override
+    public int getPageNumber() {
+        return (int) (offset / limit);
+    }
+
+    @Override
+    public int getPageSize() {
+        return limit;
+    }
+
+    @Override
+    public long getOffset() {
+        return offset;
+    }
+
+    @Override
+    public Sort getSort() {
+        return Sort.unsorted();
+    }
+
+    @Override
+    public Pageable next() {
+        return new OffsetLimitPageable(offset + limit, limit);
+    }
+
+    @Override
+    public Pageable previousOrFirst() {
+        return hasPrevious() ? new OffsetLimitPageable(offset - limit, limit) : first();
+    }
+
+    @Override
+    public Pageable first() {
+        return new OffsetLimitPageable(0, limit);
+    }
+
+    @Override
+    public Pageable withPage(int pageNumber) {
+        return new OffsetLimitPageable((long) pageNumber * limit, limit);
+    }
+
+    @Override
+    public boolean hasPrevious() {
+        return offset >= limit;
+    }
+}

--- a/src/main/java/com/cotalk/application/service/message/SearchMessageService.java
+++ b/src/main/java/com/cotalk/application/service/message/SearchMessageService.java
@@ -2,6 +2,7 @@ package com.cotalk.application.service.message;
 
 import com.cotalk.domain.entity.Message;
 import com.cotalk.domain.port.inbound.message.SearchMessageUseCase;
+import com.cotalk.domain.port.outbound.BlindIndexTokenizer;
 import com.cotalk.domain.port.outbound.ChatRoomMemberRepository;
 import com.cotalk.domain.port.outbound.MessageRepository;
 import lombok.RequiredArgsConstructor;
@@ -10,10 +11,23 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 /**
  * 메시지 검색 유스케이스 구현체.
- * 채팅방 내 또는 전체 채팅방에서 메시지를 검색한다.
+ *
+ * <p>메시지 본문이 AES-GCM(랜덤 IV)으로 암호화되어 DB LIKE 검색이 불가능하므로,
+ * 블라인드 인덱스(HMAC 트라이그램 토큰) 기반 2단계 검색을 수행한다.</p>
+ *
+ * <ol>
+ *   <li><b>1단계(DB)</b>: 키워드를 동일 파이프라인으로 토큰화 → "모든 토큰을 포함하는 메시지"를
+ *       토큰 조인 쿼리로 조회. 토큰 AND 매칭은 substring을 보장하지 않으므로 over-fetch한다.</li>
+ *   <li><b>2단계(애플리케이션)</b>: JPA가 {@code @Convert}로 이미 복호화한 본문을 동일 규칙으로
+ *       정규화하여 {@code contains}로 substring을 최종 검증한다(false positive 제거 — 정확도의 진실).</li>
+ * </ol>
+ *
+ * <p>1~2글자 키워드는 트라이그램이 나오지 않아 블라인드 인덱스로 검색할 수 없으므로
+ * 명시적으로 거부한다(3글자 이상 안내).</p>
  *
  * @author seunggu.lee
  */
@@ -22,20 +36,30 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class SearchMessageService implements SearchMessageUseCase {
 
-    private final MessageRepository messageRepository;
-    private final ChatRoomMemberRepository chatRoomMemberRepository;
+    /** 블라인드 인덱스 트라이그램에 필요한 최소 키워드 길이(코드포인트). */
+    private static final int MIN_KEYWORD_LENGTH = 3;
 
     /**
-     * 특정 채팅방 내에서 메시지를 검색한다.
-     * 채팅방 멤버만 검색할 수 있다.
+     * over-fetch 배수.
+     * 2단계 복호화 substring 검증에서 행이 줄어들 수 있으므로 1단계에서 size보다 넉넉히 조회한다.
+     * 정확 페이지 크기는 보장하지 않는다(approximate; PR 본문에 명시).
+     */
+    private static final int OVER_FETCH_MULTIPLIER = 3;
+
+    private final MessageRepository messageRepository;
+    private final ChatRoomMemberRepository chatRoomMemberRepository;
+    private final BlindIndexTokenizer blindIndexTokenizer;
+
+    /**
+     * 특정 채팅방 내에서 메시지를 검색한다. 채팅방 멤버만 검색할 수 있다.
      *
      * @param chatRoomId 채팅방 ID
      * @param userId 요청 사용자 ID
      * @param keyword 검색 키워드
      * @param page 페이지 번호
      * @param size 페이지 크기
-     * @return 검색된 메시지 목록
-     * @throws IllegalArgumentException 채팅방 멤버가 아닌 경우
+     * @return 검색된 메시지 목록 (최신순)
+     * @throws IllegalArgumentException 채팅방 멤버가 아니거나 키워드가 3글자 미만인 경우
      */
     @Override
     public List<Message> searchInChatRoom(Long chatRoomId, Long userId, String keyword, int page, int size) {
@@ -43,13 +67,22 @@ public class SearchMessageService implements SearchMessageUseCase {
             throw new IllegalArgumentException("채팅방 멤버만 메시지를 검색할 수 있습니다.");
         }
 
-        if (keyword == null || keyword.trim().isEmpty()) {
+        if (isBlank(keyword)) {
             return Collections.emptyList();
         }
 
-        int clampedSize = Math.min(Math.max(size, 1), 100);
-        return messageRepository.searchByKeywordInChatRoom(chatRoomId, keyword.trim(), page, clampedSize)
-                .stream().filter(m -> !m.isDeleted()).toList();
+        String trimmed = keyword.trim();
+        validateKeywordLength(trimmed);
+
+        int clampedSize = clampSize(size);
+        Set<String> tokens = blindIndexTokenizer.tokenizeQuery(trimmed);
+        if (tokens.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<Message> candidates = messageRepository.searchByTokensInChatRoom(
+                chatRoomId, List.copyOf(tokens), tokens.size(), page, fetchSize(clampedSize));
+        return finalFilter(candidates, trimmed, clampedSize);
     }
 
     /**
@@ -59,16 +92,62 @@ public class SearchMessageService implements SearchMessageUseCase {
      * @param keyword 검색 키워드
      * @param page 페이지 번호
      * @param size 페이지 크기
-     * @return 검색된 메시지 목록
+     * @return 검색된 메시지 목록 (최신순)
+     * @throws IllegalArgumentException 키워드가 3글자 미만인 경우
      */
     @Override
     public List<Message> searchAcrossAllChatRooms(Long userId, String keyword, int page, int size) {
-        if (keyword == null || keyword.trim().isEmpty()) {
+        if (isBlank(keyword)) {
             return Collections.emptyList();
         }
 
-        int clampedSize = Math.min(Math.max(size, 1), 100);
-        return messageRepository.searchByKeywordInUserChatRooms(userId, keyword.trim(), page, clampedSize)
-                .stream().filter(m -> !m.isDeleted()).toList();
+        String trimmed = keyword.trim();
+        validateKeywordLength(trimmed);
+
+        int clampedSize = clampSize(size);
+        Set<String> tokens = blindIndexTokenizer.tokenizeQuery(trimmed);
+        if (tokens.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<Message> candidates = messageRepository.searchByTokensInUserChatRooms(
+                userId, List.copyOf(tokens), tokens.size(), page, fetchSize(clampedSize));
+        return finalFilter(candidates, trimmed, clampedSize);
+    }
+
+    /**
+     * 2단계 최종 필터: 삭제 제외 + 복호화 본문 substring 검증 + size 컷.
+     * 토큰화와 동일한 정규화를 키워드/본문에 적용해 트라이그램 흩어짐 오탐을 제거한다.
+     *
+     * @param candidates 1단계 토큰 조인 결과 (복호화된 본문 보유)
+     * @param keyword 검색 키워드(trim됨)
+     * @param size 최종 반환 크기
+     * @return substring을 실제로 포함하는 메시지 목록 (최대 size개)
+     */
+    private List<Message> finalFilter(List<Message> candidates, String keyword, int size) {
+        String normalizedKeyword = blindIndexTokenizer.normalize(keyword);
+        return candidates.stream()
+                .filter(m -> !m.isDeleted())
+                .filter(m -> blindIndexTokenizer.normalize(m.getContent()).contains(normalizedKeyword))
+                .limit(size)
+                .toList();
+    }
+
+    private boolean isBlank(String keyword) {
+        return keyword == null || keyword.trim().isEmpty();
+    }
+
+    private void validateKeywordLength(String trimmed) {
+        if (trimmed.codePointCount(0, trimmed.length()) < MIN_KEYWORD_LENGTH) {
+            throw new IllegalArgumentException("검색어는 3글자 이상 입력해야 합니다.");
+        }
+    }
+
+    private int clampSize(int size) {
+        return Math.min(Math.max(size, 1), 100);
+    }
+
+    private int fetchSize(int clampedSize) {
+        return Math.min(clampedSize * OVER_FETCH_MULTIPLIER, 300);
     }
 }

--- a/src/main/java/com/cotalk/application/service/message/SearchMessageService.java
+++ b/src/main/java/com/cotalk/application/service/message/SearchMessageService.java
@@ -81,7 +81,8 @@ public class SearchMessageService implements SearchMessageUseCase {
         }
 
         List<Message> candidates = messageRepository.searchByTokensInChatRoom(
-                chatRoomId, List.copyOf(tokens), tokens.size(), page, fetchSize(clampedSize));
+                chatRoomId, List.copyOf(tokens), tokens.size(),
+                fetchOffset(page, clampedSize), fetchLimit(clampedSize));
         return finalFilter(candidates, trimmed, clampedSize);
     }
 
@@ -111,7 +112,8 @@ public class SearchMessageService implements SearchMessageUseCase {
         }
 
         List<Message> candidates = messageRepository.searchByTokensInUserChatRooms(
-                userId, List.copyOf(tokens), tokens.size(), page, fetchSize(clampedSize));
+                userId, List.copyOf(tokens), tokens.size(),
+                fetchOffset(page, clampedSize), fetchLimit(clampedSize));
         return finalFilter(candidates, trimmed, clampedSize);
     }
 
@@ -137,8 +139,20 @@ public class SearchMessageService implements SearchMessageUseCase {
         return keyword == null || keyword.trim().isEmpty();
     }
 
+    /**
+     * 키워드 길이를 검증한다.
+     *
+     * <p>토큰화 파이프라인({@code normalize})은 내부 공백/제어문자까지 제거하므로,
+     * 동일한 정규화를 적용한 뒤 코드포인트 수로 3글자 미만을 판정한다.
+     * (예: "a b"는 trim만으로는 3글자지만 normalize 후 "ab"=2글자라 트라이그램이 0개가 되어
+     * 조용한 빈 결과가 된다 — 이를 명시적 거부로 전환한다.)</p>
+     *
+     * @param trimmed 앞뒤 공백을 제거한 키워드
+     * @throws IllegalArgumentException 정규화 후 3글자 미만인 경우
+     */
     private void validateKeywordLength(String trimmed) {
-        if (trimmed.codePointCount(0, trimmed.length()) < MIN_KEYWORD_LENGTH) {
+        String normalized = blindIndexTokenizer.normalize(trimmed);
+        if (normalized.codePointCount(0, normalized.length()) < MIN_KEYWORD_LENGTH) {
             throw new IllegalArgumentException("검색어는 3글자 이상 입력해야 합니다.");
         }
     }
@@ -147,7 +161,26 @@ public class SearchMessageService implements SearchMessageUseCase {
         return Math.min(Math.max(size, 1), 100);
     }
 
-    private int fetchSize(int clampedSize) {
+    /**
+     * 1단계 조회의 시작 오프셋. 사용자 page 기준(page * clampedSize)이어야 over-fetch가
+     * 윈도우 크기만 키우고 오프셋은 어긋나지 않는다.
+     *
+     * @param page        사용자 페이지 번호
+     * @param clampedSize 클램프된 페이지 크기
+     * @return 조회 시작 오프셋
+     */
+    private long fetchOffset(int page, int clampedSize) {
+        return (long) page * clampedSize;
+    }
+
+    /**
+     * 1단계 조회의 윈도우 크기(limit). 2단계 복호화 substring 검증에서 행이 줄어들 수 있어
+     * size보다 넉넉히(over-fetch) 가져온다.
+     *
+     * @param clampedSize 클램프된 페이지 크기
+     * @return over-fetch limit
+     */
+    private int fetchLimit(int clampedSize) {
         return Math.min(clampedSize * OVER_FETCH_MULTIPLIER, 300);
     }
 }

--- a/src/main/java/com/cotalk/application/service/message/SendMessageService.java
+++ b/src/main/java/com/cotalk/application/service/message/SendMessageService.java
@@ -7,11 +7,13 @@ import com.cotalk.domain.entity.Message;
 import com.cotalk.domain.entity.Message.MessageType;
 import com.cotalk.domain.entity.User;
 import com.cotalk.domain.port.inbound.message.SendMessageUseCase;
+import com.cotalk.domain.port.outbound.BlindIndexTokenizer;
 import com.cotalk.domain.port.outbound.ChatRoomMemberRepository;
 import com.cotalk.domain.port.outbound.ChatRoomRepository;
 import com.cotalk.domain.port.outbound.ChatRoomPresenceTracker;
 import com.cotalk.domain.port.outbound.IdGenerator;
 import com.cotalk.domain.port.outbound.MessageRepository;
+import com.cotalk.domain.port.outbound.MessageSearchTokenRepository;
 import com.cotalk.domain.port.outbound.MetricsPort;
 import com.cotalk.domain.port.outbound.NotificationCommandPort;
 import com.cotalk.domain.port.outbound.TimeProvider;
@@ -44,6 +46,8 @@ import java.util.Set;
 public class SendMessageService implements SendMessageUseCase {
 
     private final MessageRepository messageRepository;
+    private final MessageSearchTokenRepository messageSearchTokenRepository;
+    private final BlindIndexTokenizer blindIndexTokenizer;
     private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final UserRepository userRepository;
@@ -253,6 +257,10 @@ public class SendMessageService implements SendMessageUseCase {
             Message savedMessage = messageRepository.save(message);
             customMetrics.incrementMessagesSent();
 
+            // 블라인드 인덱스 검색 토큰 적재 (같은 트랜잭션 — 부분 저장 방지)
+            // TEXT 메시지만 토큰화한다(FILE/IMAGE/SYSTEM 제외). 입력은 암호화 전 평문(sanitizedContent).
+            indexSearchTokens(savedMessage);
+
             // 발신자는 자신이 보낸 메시지를 읽은 것으로 간주하여 lastReadMessageId 업데이트
             LocalDateTime now = timeProvider.now();
             int updated = chatRoomMemberRepository.updateLastReadMessageIdIfNewer(
@@ -276,6 +284,22 @@ public class SendMessageService implements SendMessageUseCase {
 
         customMetrics.stopMessageProcessingTimer(timerSample);
         return result;
+    }
+
+    /**
+     * 메시지의 검색 토큰을 적재한다. TEXT 메시지만 대상으로 한다.
+     *
+     * <p>호출 시점은 메시지 저장 직후, 같은 트랜잭션 경계 안이어야 한다(부분 저장 방지).
+     * 토큰화 입력은 암호화 전 평문 본문이며, 토큰화 결과가 비어있으면(3글자 미만 등) 적재하지 않는다.</p>
+     *
+     * @param savedMessage 저장된 메시지
+     */
+    private void indexSearchTokens(Message savedMessage) {
+        if (!savedMessage.isText()) {
+            return;
+        }
+        Set<String> tokens = blindIndexTokenizer.tokenize(savedMessage.getContent());
+        messageSearchTokenRepository.saveTokens(savedMessage.getId(), tokens);
     }
 
     /**

--- a/src/main/java/com/cotalk/application/service/message/UpdateMessageService.java
+++ b/src/main/java/com/cotalk/application/service/message/UpdateMessageService.java
@@ -4,8 +4,10 @@ import com.cotalk.domain.entity.Message;
 import com.cotalk.domain.exception.MessageNotFoundException;
 import com.cotalk.domain.exception.ResourceAccessDeniedException;
 import com.cotalk.domain.port.inbound.message.UpdateMessageUseCase;
+import com.cotalk.domain.port.outbound.BlindIndexTokenizer;
 import com.cotalk.domain.port.outbound.ChatMessageBroker;
 import com.cotalk.domain.port.outbound.MessageRepository;
+import com.cotalk.domain.port.outbound.MessageSearchTokenRepository;
 import com.cotalk.domain.port.outbound.TimeProvider;
 import com.cotalk.domain.util.HtmlSanitizer;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +30,8 @@ import java.time.ZoneOffset;
 public class UpdateMessageService implements UpdateMessageUseCase {
 
     private final MessageRepository messageRepository;
+    private final MessageSearchTokenRepository messageSearchTokenRepository;
+    private final BlindIndexTokenizer blindIndexTokenizer;
     private final ChatMessageBroker chatMessageBroker;
     private final TimeProvider timeProvider;
 
@@ -65,6 +69,11 @@ public class UpdateMessageService implements UpdateMessageUseCase {
         // XSS 방지 + 메시지 수정
         message.updateContent(HtmlSanitizer.stripAllTags(newContent));
         Message updated = messageRepository.save(message);
+
+        // 블라인드 인덱스 재토큰화 (delete-then-insert) — 수정된 본문 기준으로 검색 토큰 갱신.
+        // @Transactional 경계 안에서 수행되어 본문/토큰이 일관되게 커밋된다. TEXT만 수정 가능하므로 항상 토큰화 대상.
+        messageSearchTokenRepository.deleteByMessageId(updated.getId());
+        messageSearchTokenRepository.saveTokens(updated.getId(), blindIndexTokenizer.tokenize(updated.getContent()));
 
         log.info("Message updated: messageId={}, userId={}", messageId, userId);
 

--- a/src/main/java/com/cotalk/domain/port/outbound/BlindIndexTokenizer.java
+++ b/src/main/java/com/cotalk/domain/port/outbound/BlindIndexTokenizer.java
@@ -1,0 +1,57 @@
+package com.cotalk.domain.port.outbound;
+
+import java.util.Set;
+
+/**
+ * 블라인드 인덱스 토큰화 포트.
+ *
+ * <p>암호화되어 저장되는 메시지 본문을 검색하기 위한 결정적(deterministic) 토큰을 생성한다.
+ * 평문은 AES-GCM 랜덤 IV로 암호화되어 DB LIKE 검색이 불가능하므로, 평문의 글자 단위
+ * 트라이그램(3-gram)을 HMAC-SHA256으로 변환한 고정 길이 토큰을 별도 테이블에 적재해
+ * 등가매칭(exact match) 조인으로 검색을 복구한다.</p>
+ *
+ * <p>저장 토큰화와 검색 키워드 토큰화는 반드시 동일한 정규화/트라이그램 규칙을 사용해야
+ * 일치가 보장된다. 토큰은 "후보 좁히기"일 뿐이며, 최종 정확도는 복호화 후 substring 검증
+ * (2단계)에서 보증한다.</p>
+ *
+ * <p>HMAC 시크릿 주입이 필요하므로 구현은 infrastructure 레이어에 둔다
+ * ({@code EncryptionPort}와 동일한 패턴).</p>
+ *
+ * @author seunggu.lee
+ */
+public interface BlindIndexTokenizer {
+
+    /**
+     * 저장 대상 평문 텍스트를 토큰 집합으로 변환한다.
+     *
+     * <p>정규화(NFC, 소문자, 공백/제어문자 제거) 후 글자(유니코드 코드포인트) 단위
+     * 슬라이딩 윈도우로 트라이그램을 추출하고, 각 트라이그램을 HMAC-SHA256으로 변환해
+     * 잘라낸(truncated) Base64url 토큰을 만든다. 중복은 제거한다.</p>
+     *
+     * @param text 토큰화할 평문 (보통 sanitized content)
+     * @return 토큰 집합 (3글자 미만이거나 비어있으면 빈 집합)
+     */
+    Set<String> tokenize(String text);
+
+    /**
+     * 검색 키워드를 토큰 집합으로 변환한다.
+     *
+     * <p>{@link #tokenize(String)}와 동일한 파이프라인을 사용한다. 키워드와 본문이 같은
+     * 규칙으로 토큰화되어야 토큰 AND 매칭이 성립한다.</p>
+     *
+     * @param keyword 검색 키워드
+     * @return 토큰 집합 (3글자 미만이거나 비어있으면 빈 집합)
+     */
+    Set<String> tokenizeQuery(String keyword);
+
+    /**
+     * 토큰화/검색에 사용하는 것과 동일한 정규화를 적용한다.
+     *
+     * <p>2단계 복호화 substring 검증에서 본문과 키워드를 동일 규칙으로 정규화한 뒤
+     * {@code contains} 비교를 하기 위해 노출한다. (NFC + 소문자 + 공백/제어문자 제거)</p>
+     *
+     * @param text 정규화할 문자열 (null이면 빈 문자열 반환)
+     * @return 정규화된 문자열
+     */
+    String normalize(String text);
+}

--- a/src/main/java/com/cotalk/domain/port/outbound/MessageRepository.java
+++ b/src/main/java/com/cotalk/domain/port/outbound/MessageRepository.java
@@ -84,26 +84,33 @@ public interface MessageRepository {
     List<Message> findByChatRoomIdBeforeMessageId(Long chatRoomId, Long beforeMessageId, int size);
 
     /**
-     * 특정 채팅방 내에서 키워드로 메시지를 검색한다.
+     * 특정 채팅방 내에서 블라인드 인덱스 토큰으로 메시지를 검색한다. (2단계 검색의 1단계)
+     *
+     * <p>키워드의 모든 트라이그램 토큰을 포함하는 메시지를 조회한다. 토큰 AND 매칭은
+     * substring을 보장하지 않으므로, 호출 측(서비스)에서 복호화 후 substring 최종 검증을 수행한다.</p>
      *
      * @param chatRoomId 채팅방 ID
-     * @param keyword    검색 키워드
+     * @param tokens     키워드를 토큰화한 토큰 집합
+     * @param tokenCount 토큰 개수 (모든 토큰 포함 조건)
      * @param page       페이지 번호 (0부터 시작)
-     * @param size       페이지 크기
-     * @return 검색된 메시지 목록 (최신순)
+     * @param size       조회 크기 (over-fetch 한도)
+     * @return 토큰 조건을 만족하는 메시지 목록 (최신순)
      */
-    List<Message> searchByKeywordInChatRoom(Long chatRoomId, String keyword, int page, int size);
+    List<Message> searchByTokensInChatRoom(Long chatRoomId, List<String> tokens, long tokenCount, int page, int size);
 
     /**
-     * 사용자가 속한 모든 채팅방에서 키워드로 메시지를 검색한다.
+     * 사용자가 속한 모든 채팅방에서 블라인드 인덱스 토큰으로 메시지를 검색한다. (2단계 검색의 1단계)
      *
-     * @param userId  사용자 ID
-     * @param keyword 검색 키워드
-     * @param page    페이지 번호 (0부터 시작)
-     * @param size    페이지 크기
-     * @return 검색된 메시지 목록 (최신순)
+     * <p>멤버십 한정 + 토큰 AND 매칭. 복호화 substring 최종 검증은 호출 측에서 수행한다.</p>
+     *
+     * @param userId     사용자 ID
+     * @param tokens     키워드를 토큰화한 토큰 집합
+     * @param tokenCount 토큰 개수 (모든 토큰 포함 조건)
+     * @param page       페이지 번호 (0부터 시작)
+     * @param size       조회 크기 (over-fetch 한도)
+     * @return 토큰 조건을 만족하는 메시지 목록 (최신순)
      */
-    List<Message> searchByKeywordInUserChatRooms(Long userId, String keyword, int page, int size);
+    List<Message> searchByTokensInUserChatRooms(Long userId, List<String> tokens, long tokenCount, int page, int size);
 
     /**
      * 전체 메시지 수를 조회한다.

--- a/src/main/java/com/cotalk/domain/port/outbound/MessageRepository.java
+++ b/src/main/java/com/cotalk/domain/port/outbound/MessageRepository.java
@@ -92,11 +92,11 @@ public interface MessageRepository {
      * @param chatRoomId 채팅방 ID
      * @param tokens     키워드를 토큰화한 토큰 집합
      * @param tokenCount 토큰 개수 (모든 토큰 포함 조건)
-     * @param page       페이지 번호 (0부터 시작)
-     * @param size       조회 크기 (over-fetch 한도)
+     * @param offset     조회 시작 오프셋 (사용자 page 기준: page * size)
+     * @param limit      조회 윈도우 크기 (over-fetch 한도)
      * @return 토큰 조건을 만족하는 메시지 목록 (최신순)
      */
-    List<Message> searchByTokensInChatRoom(Long chatRoomId, List<String> tokens, long tokenCount, int page, int size);
+    List<Message> searchByTokensInChatRoom(Long chatRoomId, List<String> tokens, long tokenCount, long offset, int limit);
 
     /**
      * 사용자가 속한 모든 채팅방에서 블라인드 인덱스 토큰으로 메시지를 검색한다. (2단계 검색의 1단계)
@@ -106,11 +106,11 @@ public interface MessageRepository {
      * @param userId     사용자 ID
      * @param tokens     키워드를 토큰화한 토큰 집합
      * @param tokenCount 토큰 개수 (모든 토큰 포함 조건)
-     * @param page       페이지 번호 (0부터 시작)
-     * @param size       조회 크기 (over-fetch 한도)
+     * @param offset     조회 시작 오프셋 (사용자 page 기준: page * size)
+     * @param limit      조회 윈도우 크기 (over-fetch 한도)
      * @return 토큰 조건을 만족하는 메시지 목록 (최신순)
      */
-    List<Message> searchByTokensInUserChatRooms(Long userId, List<String> tokens, long tokenCount, int page, int size);
+    List<Message> searchByTokensInUserChatRooms(Long userId, List<String> tokens, long tokenCount, long offset, int limit);
 
     /**
      * 전체 메시지 수를 조회한다.

--- a/src/main/java/com/cotalk/domain/port/outbound/MessageSearchTokenRepository.java
+++ b/src/main/java/com/cotalk/domain/port/outbound/MessageSearchTokenRepository.java
@@ -1,0 +1,35 @@
+package com.cotalk.domain.port.outbound;
+
+import java.util.Set;
+
+/**
+ * 메시지 검색 토큰 레포지토리 포트.
+ *
+ * <p>블라인드 인덱스 토큰({@code message_search_tokens})의 저장/삭제를 담당한다.
+ * 검색 조회 자체는 {@link MessageRepository}의 토큰 조인 검색 메서드가 수행하며,
+ * 이 포트는 적재(write) 경로만 책임진다.</p>
+ *
+ * @author seunggu.lee
+ */
+public interface MessageSearchTokenRepository {
+
+    /**
+     * 메시지의 검색 토큰들을 저장한다.
+     *
+     * <p>같은 트랜잭션 내에서 메시지 저장 직후 호출되어 부분 저장을 방지한다.
+     * 빈 토큰 집합이면 아무 것도 하지 않는다.</p>
+     *
+     * @param messageId 토큰이 속한 메시지 ID
+     * @param tokens    저장할 토큰 집합
+     */
+    void saveTokens(Long messageId, Set<String> tokens);
+
+    /**
+     * 특정 메시지의 모든 검색 토큰을 삭제한다.
+     *
+     * <p>메시지 수정 시 재토큰화(delete-then-insert)에 사용한다.</p>
+     *
+     * @param messageId 토큰을 삭제할 메시지 ID
+     */
+    void deleteByMessageId(Long messageId);
+}

--- a/src/main/java/com/cotalk/infrastructure/config/properties/AppProperties.java
+++ b/src/main/java/com/cotalk/infrastructure/config/properties/AppProperties.java
@@ -14,6 +14,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @param terms         약관 버전 설정
  * @param encryption    암호화 설정
  * @param swagger       Swagger UI 설정
+ * @param search        메시지 검색(블라인드 인덱스) 설정
  * @author seunggu.lee
  */
 @ConfigurationProperties(prefix = "app")
@@ -24,7 +25,8 @@ public record AppProperties(
         PasswordReset passwordReset,
         Terms terms,
         Encryption encryption,
-        Swagger swagger
+        Swagger swagger,
+        Search search
 ) {
     private static final Logger log = LoggerFactory.getLogger(AppProperties.class);
     /**
@@ -105,6 +107,23 @@ public record AppProperties(
     }
 
     /**
+     * 메시지 검색(블라인드 인덱스) 설정.
+     *
+     * <p>{@code blindIndexSecret}은 HMAC-SHA256 트라이그램 토큰 생성용 시크릿(Base64)이며,
+     * AES 암호화 키({@link Encryption#key()})와 완전히 분리된 별도 시크릿이다.
+     * 프로덕션에서는 반드시 환경변수로 주입해야 하며 기본값이 없다(보안).</p>
+     *
+     * @param blindIndexSecret 블라인드 인덱스 HMAC 시크릿 (Base64, 기본값 없음)
+     */
+    public record Search(String blindIndexSecret) {
+        public Search {
+            if (blindIndexSecret == null) {
+                blindIndexSecret = "";
+            }
+        }
+    }
+
+    /**
      * Swagger UI 설정.
      *
      * @param serverUrl         서버 URL
@@ -148,6 +167,9 @@ public record AppProperties(
         }
         if (swagger == null) {
             swagger = new Swagger("http://localhost:8080", "API 서버");
+        }
+        if (search == null) {
+            search = new Search("");
         }
     }
 }

--- a/src/main/java/com/cotalk/infrastructure/crypto/HmacBlindIndexTokenizer.java
+++ b/src/main/java/com/cotalk/infrastructure/crypto/HmacBlindIndexTokenizer.java
@@ -1,0 +1,134 @@
+package com.cotalk.infrastructure.crypto;
+
+import com.cotalk.domain.port.outbound.BlindIndexTokenizer;
+import com.cotalk.infrastructure.config.properties.AppProperties;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.text.Normalizer;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * HMAC-SHA256 기반 블라인드 인덱스 토큰화 구현체.
+ *
+ * <p>파이프라인: NFC 정규화 → 소문자(Locale.ROOT) → 공백/제어문자 제거 →
+ * 글자(유니코드 코드포인트) 단위 슬라이딩 3-gram → 각 트라이그램을 HMAC-SHA256으로 변환 →
+ * 앞 12바이트로 truncate → Base64url(no padding) 인코딩 → distinct 집합.</p>
+ *
+ * <p>HMAC 시크릿은 {@code app.search.blind-index-secret}(Base64)에서 로드하며,
+ * AES 암호화 키와 완전히 분리된다. 시크릿이 없으면 빈 토큰만 만들어 검색이 조용히 깨지는 것을
+ * 방지하기 위해 생성 시점에 예외를 던진다(fail-fast).</p>
+ *
+ * <p>트라이그램은 엔트로피가 낮아 일반 해시(SHA-256)였다면 사전공격으로 즉시 역산되지만,
+ * HMAC + 비밀키가 이를 막는다(시크릿 보안이 전체 안전성의 단일 의존점).</p>
+ *
+ * @author seunggu.lee
+ */
+@Component
+public class HmacBlindIndexTokenizer implements BlindIndexTokenizer {
+
+    private static final String HMAC_ALGORITHM = "HmacSHA256";
+    /** 토큰화 최소 글자 수 (트라이그램). */
+    private static final int TRIGRAM_SIZE = 3;
+    /** HMAC 결과에서 토큰으로 취할 바이트 수 (truncation). 12B → base64url 16자. */
+    private static final int TOKEN_BYTE_LENGTH = 12;
+
+    private final SecretKeySpec secretKey;
+    private final Base64.Encoder urlEncoder = Base64.getUrlEncoder().withoutPadding();
+
+    /**
+     * 토큰화 구현체 생성자.
+     *
+     * @param appProperties 앱 설정 (블라인드 인덱스 시크릿 포함)
+     * @throws IllegalStateException 블라인드 인덱스 시크릿이 비어있는 경우
+     */
+    public HmacBlindIndexTokenizer(AppProperties appProperties) {
+        String secret = appProperties.search().blindIndexSecret();
+        if (secret == null || secret.isBlank()) {
+            throw new IllegalStateException(
+                    "app.search.blind-index-secret이 설정되지 않았습니다. 메시지 검색 블라인드 인덱스에 필수입니다.");
+        }
+        byte[] keyBytes = Base64.getDecoder().decode(secret);
+        this.secretKey = new SecretKeySpec(keyBytes, HMAC_ALGORITHM);
+    }
+
+    /**
+     * 평문 텍스트를 토큰 집합으로 변환한다.
+     *
+     * @param text 토큰화할 평문
+     * @return 토큰 집합 (3글자 미만/빈 입력은 빈 집합)
+     */
+    @Override
+    public Set<String> tokenize(String text) {
+        return tokenizeInternal(text);
+    }
+
+    /**
+     * 검색 키워드를 토큰 집합으로 변환한다.
+     *
+     * @param keyword 검색 키워드
+     * @return 토큰 집합 (3글자 미만/빈 입력은 빈 집합)
+     */
+    @Override
+    public Set<String> tokenizeQuery(String keyword) {
+        return tokenizeInternal(keyword);
+    }
+
+    /**
+     * 토큰화/검색에 사용하는 것과 동일한 정규화를 적용한다.
+     *
+     * @param text 정규화할 문자열
+     * @return 정규화된 문자열 (null이면 빈 문자열)
+     */
+    @Override
+    public String normalize(String text) {
+        if (text == null) {
+            return "";
+        }
+        String nfc = Normalizer.normalize(text, Normalizer.Form.NFC);
+        String lowered = nfc.toLowerCase(Locale.ROOT);
+        // 모든 공백/제어문자 제거 (한국어 띄어쓰기 불규칙성 → 부분일치 UX 우선)
+        StringBuilder sb = new StringBuilder(lowered.length());
+        lowered.codePoints().forEach(cp -> {
+            if (!Character.isWhitespace(cp) && !Character.isISOControl(cp)) {
+                sb.appendCodePoint(cp);
+            }
+        });
+        return sb.toString();
+    }
+
+    private Set<String> tokenizeInternal(String text) {
+        String normalized = normalize(text);
+        // 코드포인트 배열로 변환하여 서로게이트 페어(이모지)를 한 글자로 취급
+        int[] codePoints = normalized.codePoints().toArray();
+        if (codePoints.length < TRIGRAM_SIZE) {
+            return Set.of();
+        }
+
+        Set<String> tokens = new LinkedHashSet<>();
+        for (int i = 0; i + TRIGRAM_SIZE <= codePoints.length; i++) {
+            int[] window = Arrays.copyOfRange(codePoints, i, i + TRIGRAM_SIZE);
+            String trigram = new String(window, 0, window.length);
+            tokens.add(hmacToken(trigram));
+        }
+        return tokens;
+    }
+
+    private String hmacToken(String trigram) {
+        try {
+            Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+            mac.init(secretKey);
+            byte[] full = mac.doFinal(trigram.getBytes(StandardCharsets.UTF_8));
+            byte[] truncated = Arrays.copyOf(full, TOKEN_BYTE_LENGTH);
+            return urlEncoder.encodeToString(truncated);
+        } catch (Exception e) {
+            throw new IllegalStateException("블라인드 인덱스 토큰 생성 실패", e);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -146,6 +146,11 @@ app:
     # 키 생성: openssl rand -base64 32
     key: ${ENCRYPTION_KEY}  # 필수 환경변수 - 기본값 없음 (보안)
     enabled: ${ENCRYPTION_ENABLED:true}
+  search:
+    # 블라인드 인덱스(HMAC 트라이그램 토큰) 시크릿 (Base64, 32바이트 권장)
+    # AES 암호화 키와 완전히 분리된 별도 시크릿. 프로덕션: 반드시 환경변수로 설정 (기본값 없음)
+    # 키 생성: openssl rand -base64 32
+    blind-index-secret: ${BLIND_INDEX_SECRET}  # 필수 환경변수 - 기본값 없음 (보안)
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000}
   redis:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,6 +44,11 @@ spring:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         format_sql: true
         use_sql_comments: true
+        # 대량 INSERT(메시지 검색 토큰 등)를 JDBC batch로 묶어 round-trip 절감
+        jdbc:
+          batch_size: 50
+        order_inserts: true
+        order_updates: true
     open-in-view: false
 
   # Flyway 설정 (데이터베이스 마이그레이션)

--- a/src/main/resources/db/migration/V17__add_message_search_token.sql
+++ b/src/main/resources/db/migration/V17__add_message_search_token.sql
@@ -15,4 +15,8 @@ CREATE TABLE IF NOT EXISTS message_search_tokens (
 );
 
 -- 토큰 → message 역방향 조회용 (검색 쿼리의 워크호스). 신규 테이블이라 CONCURRENTLY 불필요.
-CREATE INDEX IF NOT EXISTS idx_mst_token ON message_search_tokens(token);
+-- 1단계 쿼리는 `WHERE token IN (...) GROUP BY message_id HAVING COUNT(DISTINCT token)=:n` 형태라,
+-- (token) 단일 인덱스만으로는 매칭 행마다 message_id를 위해 힙(PK)을 다시 들춰야 한다.
+-- (token, message_id) 복합 인덱스는 두 컬럼이 모두 인덱스에 있어 인덱스-온리 스캔(커버링)으로
+-- 그룹/집계를 끝낼 수 있다(PK가 (message_id, token)이라 이 정렬 순서를 별도로 제공).
+CREATE INDEX IF NOT EXISTS idx_mst_token_message ON message_search_tokens(token, message_id);

--- a/src/main/resources/db/migration/V17__add_message_search_token.sql
+++ b/src/main/resources/db/migration/V17__add_message_search_token.sql
@@ -1,0 +1,18 @@
+-- V17: 메시지 검색 블라인드 인덱스 토큰 테이블
+-- 배경: messages.content는 AES-256-GCM(랜덤 IV) 애플리케이션 암호화로 저장되어
+--       평문 LIKE 검색이 운영에서 0건이 된다(기능 정지). 평문 글자 단위 트라이그램을
+--       HMAC-SHA256으로 변환한 결정적 토큰을 별도 테이블에 적재해 등가매칭 조인으로 검색을 복구한다.
+-- 전략: token IN (...) AND COUNT(DISTINCT token)=:n 으로 "키워드의 모든 트라이그램을 포함하는 메시지"를
+--       조회(1단계) 후, 애플리케이션에서 복호화 substring 검증(2단계)으로 false positive를 제거한다.
+-- 인덱스: 토큰은 substring이 아니라 exact match라 trgm/GIN이 불필요하며 일반 B-Tree 하나로 충분하다.
+
+CREATE TABLE IF NOT EXISTS message_search_tokens (
+    message_id  BIGINT       NOT NULL,
+    token       VARCHAR(24)  NOT NULL,   -- HMAC-SHA256 truncated(12B) → base64url 16자, 여유 24
+    PRIMARY KEY (message_id, token),
+    CONSTRAINT fk_mst_message FOREIGN KEY (message_id)
+        REFERENCES messages(id) ON DELETE CASCADE
+);
+
+-- 토큰 → message 역방향 조회용 (검색 쿼리의 워크호스). 신규 테이블이라 CONCURRENTLY 불필요.
+CREATE INDEX IF NOT EXISTS idx_mst_token ON message_search_tokens(token);

--- a/src/test/java/com/cotalk/adapter/outbound/persistence/MessageJpaRepositoryTest.java
+++ b/src/test/java/com/cotalk/adapter/outbound/persistence/MessageJpaRepositoryTest.java
@@ -1,6 +1,9 @@
 package com.cotalk.adapter.outbound.persistence;
 
 import com.cotalk.adapter.outbound.persistence.message.MessageRepositoryAdapter;
+import com.cotalk.adapter.outbound.persistence.message.MessageSearchTokenJpaEntity;
+import com.cotalk.adapter.outbound.persistence.message.MessageSearchTokenJpaRepository;
+import com.cotalk.adapter.outbound.persistence.message.MessageSearchTokenRepositoryAdapter;
 import com.cotalk.domain.entity.Message;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -17,86 +20,109 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * 메시지 키워드 검색 동작 회귀 테스트.
+ * 블라인드 인덱스 토큰 조인 검색 쿼리 회귀 테스트 (@DataJpaTest, H2).
  *
- * <p>이 테스트는 메시지 검색이 부분 일치(substring) LIKE 방식으로 동작함을 고정한다.
- * 전문 검색(단어 단위)으로 전환하면 깨졌을 케이스(단어 중간 부분 매칭 등)를 명시적으로
- * 검증하여 검색 UX 계약을 보장한다.</p>
+ * <p>암호화/HMAC와 무관하게 토큰 조인 SQL의 AND 매칭 정합성만 검증한다. 평문 토큰을
+ * 직접 {@code message_search_tokens}에 적재하고, "키워드의 모든 토큰을 포함하는 메시지"
+ * ({@code COUNT(DISTINCT token) = :tokenCount})만 조회되는지 본다.</p>
  *
- * <p>참고: 테스트 환경은 H2(ddl-auto)로 스키마를 만들고 Flyway는 비활성이므로
- * GIN 인덱스가 애초에 존재하지 않는다. 따라서 'V15의 GIN 제거 무회귀'를 직접 보장하는
- * 것은 이 테스트가 아니다. 회귀 안전성의 근거는 '검색 쿼리가 선행 와일드카드 LIKE라
- * 어떤 GIN도 사용하지 않는다'는 정적 사실이며(V15 마이그레이션 주석 참조), 이 테스트는
- * 그 LIKE substring 동작 자체를 고정하는 역할로 한정된다.</p>
+ * <p>참고: H2(ddl-auto)로 스키마를 만들고 Flyway는 비활성이다. prod 동등(실제 Flyway +
+ * 암호화 ON) 검증은 testcontainers 통합테스트가 담당한다.</p>
  *
  * @author seunggu.lee
  */
 @DataJpaTest
 @ActiveProfiles("test")
-@Import({MessageRepositoryAdapter.class, JpaAuditingConfig.class})
-@DisplayName("MessageJpaRepository 키워드 검색")
+@Import({MessageRepositoryAdapter.class, MessageSearchTokenRepositoryAdapter.class, JpaAuditingConfig.class})
+@DisplayName("MessageJpaRepository 토큰 조인 검색")
 class MessageJpaRepositoryTest {
 
     @Autowired
     private MessageRepositoryAdapter messageRepository;
 
+    @Autowired
+    private MessageSearchTokenRepositoryAdapter tokenRepository;
+
+    @Autowired
+    private MessageSearchTokenJpaRepository tokenJpaRepository;
+
     private long nextId = 1L;
 
-    private Message text(Long chatRoomId, Long senderId, String content) {
-        return Message.builder()
+    private Message saveText(Long chatRoomId, Long senderId, String content, String... tokens) {
+        Message saved = messageRepository.save(Message.builder()
                 .id(nextId++)
                 .chatRoomId(chatRoomId)
                 .senderId(senderId)
                 .content(content)
                 .type(Message.MessageType.TEXT)
-                .build();
+                .build());
+        for (String t : tokens) {
+            tokenJpaRepository.save(MessageSearchTokenJpaEntity.of(saved.getId(), t));
+        }
+        return saved;
     }
 
     @Nested
-    @DisplayName("채팅방 내 검색 시")
+    @DisplayName("채팅방 내 토큰 검색 시")
     class SearchInChatRoom {
 
         @Test
-        @DisplayName("단어 중간의 부분 문자열도 매칭한다 (substring UX 유지)")
-        void should_matchSubstring_when_keywordInsideWord() {
-            // given
-            messageRepository.save(text(1L, 10L, "안녕하세요 반갑습니다"));
-            messageRepository.save(text(1L, 11L, "오늘 점심 뭐 먹지"));
+        @DisplayName("키워드의 모든 토큰을 포함하는 메시지만 매칭한다 (AND 매칭)")
+        void should_matchOnlyWhenAllTokensPresent() {
+            // given: 메시지 A는 두 토큰 모두, 메시지 B는 한 토큰만 보유
+            Message a = saveText(1L, 10L, "안녕하세요 반갑습니다", "t-an", "t-ny");
+            saveText(1L, 11L, "안녕 친구", "t-an");
 
-            // when: "녕하"는 "안녕하세요" 단어의 중간 부분 문자열 → FTS였다면 매칭 실패
-            List<Message> results = messageRepository.searchByKeywordInChatRoom(1L, "녕하", 0, 20);
+            // when: 두 토큰을 모두 포함하는 메시지 검색 (tokenCount=2)
+            List<Message> results = messageRepository.searchByTokensInChatRoom(
+                    1L, List.of("t-an", "t-ny"), 2, 0, 20);
 
-            // then
-            assertThat(results).hasSize(1);
-            assertThat(results.get(0).getContent()).isEqualTo("안녕하세요 반갑습니다");
-        }
-
-        @Test
-        @DisplayName("대소문자를 구분하지 않는다")
-        void should_matchCaseInsensitively() {
-            // given
-            messageRepository.save(text(1L, 10L, "Hello World"));
-
-            // when
-            List<Message> results = messageRepository.searchByKeywordInChatRoom(1L, "hello", 0, 20);
-
-            // then
-            assertThat(results).hasSize(1);
+            // then: A만 매칭
+            assertThat(results).extracting(Message::getId).containsExactly(a.getId());
         }
 
         @Test
         @DisplayName("다른 채팅방의 메시지는 검색되지 않는다")
         void should_notMatch_when_differentChatRoom() {
-            // given
-            messageRepository.save(text(1L, 10L, "공통키워드 방1"));
-            messageRepository.save(text(2L, 11L, "공통키워드 방2"));
+            Message room1 = saveText(1L, 10L, "공통키워드 방1", "t-com");
+            saveText(2L, 11L, "공통키워드 방2", "t-com");
 
-            // when
-            List<Message> results = messageRepository.searchByKeywordInChatRoom(1L, "공통키워드", 0, 20);
+            List<Message> results = messageRepository.searchByTokensInChatRoom(
+                    1L, List.of("t-com"), 1, 0, 20);
 
-            // then
-            assertThat(results).hasSize(1);
-            assertThat(results.get(0).getChatRoomId()).isEqualTo(1L);
+            assertThat(results).extracting(Message::getChatRoomId).containsExactly(1L);
+            assertThat(results).extracting(Message::getId).containsExactly(room1.getId());
+        }
+
+        @Test
+        @DisplayName("소프트 삭제된 메시지는 토큰이 남아 있어도 제외된다")
+        void should_excludeSoftDeleted() {
+            Message alive = saveText(1L, 10L, "살아있는 메시지", "t-x", "t-y");
+            Message deleted = Message.builder()
+                    .id(nextId++).chatRoomId(1L).senderId(11L).content("삭제됨")
+                    .type(Message.MessageType.TEXT).deleted(true).build();
+            messageRepository.save(deleted);
+            tokenJpaRepository.save(MessageSearchTokenJpaEntity.of(deleted.getId(), "t-x"));
+            tokenJpaRepository.save(MessageSearchTokenJpaEntity.of(deleted.getId(), "t-y"));
+
+            List<Message> results = messageRepository.searchByTokensInChatRoom(
+                    1L, List.of("t-x", "t-y"), 2, 0, 20);
+
+            assertThat(results).extracting(Message::getId).containsExactly(alive.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("전체 채팅방 토큰 검색 시")
+    class SearchAcrossChatRooms {
+
+        @Test
+        @DisplayName("빈 토큰 집합이면 빈 결과를 반환한다")
+        void should_returnEmpty_when_noTokens() {
+            saveText(1L, 10L, "내용", "t-a");
+            List<Message> results = messageRepository.searchByTokensInUserChatRooms(
+                    10L, List.of(), 0, 0, 20);
+            assertThat(results).isEmpty();
         }
     }
 }

--- a/src/test/java/com/cotalk/adapter/outbound/persistence/MessageRepositoryAdapterTest.java
+++ b/src/test/java/com/cotalk/adapter/outbound/persistence/MessageRepositoryAdapterTest.java
@@ -4,6 +4,9 @@ import com.cotalk.adapter.outbound.persistence.chatroom.ChatRoomMemberRepository
 import com.cotalk.adapter.outbound.persistence.chatroom.ChatRoomRepositoryAdapter;
 import com.cotalk.adapter.outbound.persistence.mapper.UserMapper;
 import com.cotalk.adapter.outbound.persistence.message.MessageRepositoryAdapter;
+import com.cotalk.adapter.outbound.persistence.message.MessageSearchTokenJpaEntity;
+import com.cotalk.adapter.outbound.persistence.message.MessageSearchTokenJpaRepository;
+import com.cotalk.adapter.outbound.persistence.message.MessageSearchTokenRepositoryAdapter;
 import com.cotalk.adapter.outbound.persistence.user.UserRepositoryAdapter;
 import com.cotalk.domain.entity.ChatRoom;
 import com.cotalk.domain.entity.ChatRoom.ChatRoomType;
@@ -35,13 +38,16 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @DataJpaTest
 @ActiveProfiles("test")
-@Import({MessageRepositoryAdapter.class, ChatRoomRepositoryAdapter.class,
+@Import({MessageRepositoryAdapter.class, MessageSearchTokenRepositoryAdapter.class, ChatRoomRepositoryAdapter.class,
         ChatRoomMemberRepositoryAdapter.class, UserRepositoryAdapter.class, UserMapper.class, JpaAuditingConfig.class})
 @DisplayName("MessageRepositoryAdapter")
 class MessageRepositoryAdapterTest {
 
     @Autowired
     private MessageRepositoryAdapter messageRepository;
+
+    @Autowired
+    private MessageSearchTokenJpaRepository tokenJpaRepository;
 
     @Autowired
     private ChatRoomRepositoryAdapter chatRoomRepository;
@@ -420,82 +426,70 @@ class MessageRepositoryAdapterTest {
     @DisplayName("메시지 검색 시")
     class Search {
 
-        @Test
-        @DisplayName("특정 채팅방에서 키워드로 메시지를 검색한다")
-        void should_searchMessages_when_keywordProvided() {
-            // given
-            messageRepository.save(Message.builder()
-                    .id(10001L)
-                    .chatRoomId(chatRoom.getId())
-                    .senderId(user1.getId())
-                    .content("안녕하세요 반갑습니다")
-                    .type(MessageType.TEXT)
-                    .build());
-            messageRepository.save(Message.builder()
-                    .id(10002L)
-                    .chatRoomId(chatRoom.getId())
-                    .senderId(user2.getId())
-                    .content("네 안녕하세요")
-                    .type(MessageType.TEXT)
-                    .build());
-            messageRepository.save(Message.builder()
-                    .id(10003L)
-                    .chatRoomId(chatRoom.getId())
-                    .senderId(user1.getId())
-                    .content("오늘 날씨 좋네요")
-                    .type(MessageType.TEXT)
-                    .build());
-
-            // when
-            List<Message> results = messageRepository.searchByKeywordInChatRoom(
-                    chatRoom.getId(), "안녕", 0, 10);
-
-            // then
-            assertThat(results).hasSize(2);
+        private void token(Long messageId, String... tokens) {
+            for (String t : tokens) {
+                tokenJpaRepository.save(MessageSearchTokenJpaEntity.of(messageId, t));
+            }
         }
 
         @Test
-        @DisplayName("사용자가 참여한 모든 채팅방에서 키워드로 검색한다")
+        @DisplayName("특정 채팅방에서 토큰으로 메시지를 검색한다 (모든 토큰 포함)")
+        void should_searchMessages_when_tokensProvided() {
+            // given: 두 메시지는 "안녕"의 토큰을 모두 보유, 세 번째는 무관
+            messageRepository.save(Message.builder()
+                    .id(10001L).chatRoomId(chatRoom.getId()).senderId(user1.getId())
+                    .content("안녕하세요 반갑습니다").type(MessageType.TEXT).build());
+            token(10001L, "t-an");
+            messageRepository.save(Message.builder()
+                    .id(10002L).chatRoomId(chatRoom.getId()).senderId(user2.getId())
+                    .content("네 안녕하세요").type(MessageType.TEXT).build());
+            token(10002L, "t-an");
+            messageRepository.save(Message.builder()
+                    .id(10003L).chatRoomId(chatRoom.getId()).senderId(user1.getId())
+                    .content("오늘 날씨 좋네요").type(MessageType.TEXT).build());
+            token(10003L, "t-weather");
+
+            // when
+            List<Message> results = messageRepository.searchByTokensInChatRoom(
+                    chatRoom.getId(), List.of("t-an"), 1, 0, 10);
+
+            // then
+            assertThat(results).extracting(Message::getId).containsExactlyInAnyOrder(10001L, 10002L);
+        }
+
+        @Test
+        @DisplayName("사용자가 참여한 모든 채팅방에서 토큰으로 검색한다")
         void should_searchAcrossChatRooms_when_userIdProvided() {
             // given
             messageRepository.save(Message.builder()
-                    .id(10001L)
-                    .chatRoomId(chatRoom.getId())
-                    .senderId(user1.getId())
-                    .content("프로젝트 관련 내용입니다")
-                    .type(MessageType.TEXT)
-                    .build());
+                    .id(10001L).chatRoomId(chatRoom.getId()).senderId(user1.getId())
+                    .content("프로젝트 관련 내용입니다").type(MessageType.TEXT).build());
+            token(10001L, "t-proj");
             messageRepository.save(Message.builder()
-                    .id(10002L)
-                    .chatRoomId(chatRoom2.getId())
-                    .senderId(user1.getId())
-                    .content("프로젝트 일정 공유드립니다")
-                    .type(MessageType.TEXT)
-                    .build());
+                    .id(10002L).chatRoomId(chatRoom2.getId()).senderId(user1.getId())
+                    .content("프로젝트 일정 공유드립니다").type(MessageType.TEXT).build());
+            token(10002L, "t-proj");
 
             // when
-            List<Message> results = messageRepository.searchByKeywordInUserChatRooms(
-                    user1.getId(), "프로젝트", 0, 10);
+            List<Message> results = messageRepository.searchByTokensInUserChatRooms(
+                    user1.getId(), List.of("t-proj"), 1, 0, 10);
 
             // then
             assertThat(results).hasSize(2);
         }
 
         @Test
-        @DisplayName("검색 결과가 없으면 빈 목록을 반환한다")
+        @DisplayName("토큰 조건을 만족하는 메시지가 없으면 빈 목록을 반환한다")
         void should_returnEmptyList_when_noResults() {
             // given
             messageRepository.save(Message.builder()
-                    .id(10001L)
-                    .chatRoomId(chatRoom.getId())
-                    .senderId(user1.getId())
-                    .content("테스트 메시지")
-                    .type(MessageType.TEXT)
-                    .build());
+                    .id(10001L).chatRoomId(chatRoom.getId()).senderId(user1.getId())
+                    .content("테스트 메시지").type(MessageType.TEXT).build());
+            token(10001L, "t-test");
 
             // when
-            List<Message> results = messageRepository.searchByKeywordInChatRoom(
-                    chatRoom.getId(), "존재하지않는키워드", 0, 10);
+            List<Message> results = messageRepository.searchByTokensInChatRoom(
+                    chatRoom.getId(), List.of("t-nonexistent"), 1, 0, 10);
 
             // then
             assertThat(results).isEmpty();

--- a/src/test/java/com/cotalk/application/service/message/SearchMessageServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/message/SearchMessageServiceTest.java
@@ -18,6 +18,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import org.mockito.ArgumentCaptor;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -26,6 +28,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
 
 /**
  * {@link SearchMessageService} 단위 테스트.
@@ -54,11 +57,19 @@ class SearchMessageServiceTest {
      * normalize는 소문자+공백제거, tokenizeQuery는 비어있지 않은 토큰을 돌려준다.
      */
     private void stubTokenizer(String keyword) {
+        stubNormalize();
+        lenient().when(tokenizer.tokenizeQuery(keyword)).thenReturn(Set.of("tok1", "tok2"));
+    }
+
+    /**
+     * normalize 스텁: 실제 구현과 동일하게 소문자+공백제거, null→"".
+     * 길이 가드가 normalize 결과를 사용하므로(조용한 빈 결과 방지) 거부 경로 테스트에도 필요하다.
+     */
+    private void stubNormalize() {
         lenient().when(tokenizer.normalize(any())).thenAnswer(inv -> {
             String s = inv.getArgument(0);
             return s == null ? "" : s.toLowerCase().replaceAll("\\s+", "");
         });
-        lenient().when(tokenizer.tokenizeQuery(keyword)).thenReturn(Set.of("tok1", "tok2"));
     }
 
     @Test
@@ -73,7 +84,7 @@ class SearchMessageServiceTest {
         Message m2 = Message.builder().id(2L).chatRoomId(chatRoomId).senderId(200L).content("안녕하세요 반가워요").build();
 
         given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, userId)).willReturn(true);
-        given(messageRepository.searchByTokensInChatRoom(eq(chatRoomId), any(), anyLong(), anyInt(), anyInt()))
+        given(messageRepository.searchByTokensInChatRoom(eq(chatRoomId), any(), anyLong(), anyLong(), anyInt()))
                 .willReturn(List.of(m1, m2));
 
         List<Message> result = searchMessageService.searchInChatRoom(chatRoomId, userId, keyword, 0, 20);
@@ -96,7 +107,7 @@ class SearchMessageServiceTest {
                 .content("비밀 얘기, 전화번호 알려줘").build(); // '비밀번호' 연속 아님
 
         given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, userId)).willReturn(true);
-        given(messageRepository.searchByTokensInChatRoom(eq(chatRoomId), any(), anyLong(), anyInt(), anyInt()))
+        given(messageRepository.searchByTokensInChatRoom(eq(chatRoomId), any(), anyLong(), anyLong(), anyInt()))
                 .willReturn(List.of(hit, falsePositive));
 
         List<Message> result = searchMessageService.searchInChatRoom(chatRoomId, userId, keyword, 0, 20);
@@ -145,6 +156,7 @@ class SearchMessageServiceTest {
     void should_rejectKeyword_when_shorterThanThreeChars(int len, String keyword) {
         Long chatRoomId = 1L;
         Long userId = 100L;
+        stubNormalize();
 
         given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, userId)).willReturn(true);
 
@@ -156,6 +168,7 @@ class SearchMessageServiceTest {
     @Test
     @DisplayName("전체 채팅방 검색에서도 3글자 미만 키워드는 거부한다")
     void should_rejectKeyword_when_shortInAllChatRooms() {
+        stubNormalize();
         assertThatThrownBy(() -> searchMessageService.searchAcrossAllChatRooms(100L, "가나", 0, 20))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("3글자");
@@ -179,7 +192,7 @@ class SearchMessageServiceTest {
         Message m1 = Message.builder().id(1L).chatRoomId(1L).senderId(100L).content("회의시간 알려주세요").build();
         Message m2 = Message.builder().id(2L).chatRoomId(2L).senderId(200L).content("회의시간 정했어요").build();
 
-        given(messageRepository.searchByTokensInUserChatRooms(eq(userId), any(), anyLong(), anyInt(), anyInt()))
+        given(messageRepository.searchByTokensInUserChatRooms(eq(userId), any(), anyLong(), anyLong(), anyInt()))
                 .willReturn(List.of(m1, m2));
 
         List<Message> result = searchMessageService.searchAcrossAllChatRooms(userId, keyword, 0, 20);
@@ -199,7 +212,7 @@ class SearchMessageServiceTest {
         Message deleted = Message.builder().id(2L).chatRoomId(chatRoomId).senderId(200L).content("회의시간 변경").deleted(true).build();
 
         given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, userId)).willReturn(true);
-        given(messageRepository.searchByTokensInChatRoom(eq(chatRoomId), any(), anyLong(), anyInt(), anyInt()))
+        given(messageRepository.searchByTokensInChatRoom(eq(chatRoomId), any(), anyLong(), anyLong(), anyInt()))
                 .willReturn(List.of(alive, deleted));
 
         List<Message> result = searchMessageService.searchInChatRoom(chatRoomId, userId, keyword, 0, 20);
@@ -221,11 +234,69 @@ class SearchMessageServiceTest {
         Message c = Message.builder().id(3L).chatRoomId(chatRoomId).senderId(100L).content("회의시간 3").build();
 
         given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, userId)).willReturn(true);
-        given(messageRepository.searchByTokensInChatRoom(eq(chatRoomId), any(), anyLong(), anyInt(), anyInt()))
+        given(messageRepository.searchByTokensInChatRoom(eq(chatRoomId), any(), anyLong(), anyLong(), anyInt()))
                 .willReturn(List.of(a, b, c));
 
         List<Message> result = searchMessageService.searchInChatRoom(chatRoomId, userId, keyword, 0, 2);
 
         assertThat(result).hasSize(2).extracting(Message::getId).containsExactly(1L, 2L);
+    }
+
+    @Test
+    @DisplayName("page>0이면 오프셋이 page*size(=윈도우 크기가 아니라 사용자 페이지 기준)로 전달된다")
+    void should_useUserPageOffset_when_pageGreaterThanZero() {
+        Long chatRoomId = 1L;
+        Long userId = 100L;
+        String keyword = "회의시간";
+        stubTokenizer(keyword);
+
+        given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, userId)).willReturn(true);
+        given(messageRepository.searchByTokensInChatRoom(eq(chatRoomId), any(), anyLong(), anyLong(), anyInt()))
+                .willReturn(List.of());
+
+        // page=2, size=20 → offset은 2*20=40 이어야 한다 (over-fetch 윈도우 60이 아니라).
+        searchMessageService.searchInChatRoom(chatRoomId, userId, keyword, 2, 20);
+
+        ArgumentCaptor<Long> offsetCaptor = ArgumentCaptor.forClass(Long.class);
+        ArgumentCaptor<Integer> limitCaptor = ArgumentCaptor.forClass(Integer.class);
+        verify(messageRepository).searchByTokensInChatRoom(
+                eq(chatRoomId), any(), anyLong(), offsetCaptor.capture(), limitCaptor.capture());
+
+        assertThat(offsetCaptor.getValue()).isEqualTo(40L);
+        assertThat(limitCaptor.getValue()).isEqualTo(60); // over-fetch = size * 3
+    }
+
+    @Test
+    @DisplayName("전체 채팅방 검색도 page>0에서 사용자 페이지 기준 오프셋을 사용한다")
+    void should_useUserPageOffset_inAllChatRooms_when_pageGreaterThanZero() {
+        Long userId = 100L;
+        String keyword = "회의시간";
+        stubTokenizer(keyword);
+
+        given(messageRepository.searchByTokensInUserChatRooms(eq(userId), any(), anyLong(), anyLong(), anyInt()))
+                .willReturn(List.of());
+
+        searchMessageService.searchAcrossAllChatRooms(userId, keyword, 3, 10);
+
+        ArgumentCaptor<Long> offsetCaptor = ArgumentCaptor.forClass(Long.class);
+        verify(messageRepository).searchByTokensInUserChatRooms(
+                eq(userId), any(), anyLong(), offsetCaptor.capture(), anyInt());
+
+        assertThat(offsetCaptor.getValue()).isEqualTo(30L); // 3 * 10
+    }
+
+    @Test
+    @DisplayName("내부 공백 제거(normalize) 후 3글자 미만이면 거부한다 (\"a b\"=2글자) — 조용한 빈 결과 방지")
+    void should_rejectKeyword_when_normalizedLengthBelowThree() {
+        Long chatRoomId = 1L;
+        Long userId = 100L;
+        // normalize는 공백을 제거하므로 "a b" → "ab"(2글자) → 트라이그램 0개가 되어야 한다.
+        stubNormalize();
+
+        given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, userId)).willReturn(true);
+
+        assertThatThrownBy(() -> searchMessageService.searchInChatRoom(chatRoomId, userId, "a b", 0, 20))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("3글자");
     }
 }

--- a/src/test/java/com/cotalk/application/service/message/SearchMessageServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/message/SearchMessageServiceTest.java
@@ -1,6 +1,7 @@
 package com.cotalk.application.service.message;
 
 import com.cotalk.domain.entity.Message;
+import com.cotalk.domain.port.outbound.BlindIndexTokenizer;
 import com.cotalk.domain.port.outbound.ChatRoomMemberRepository;
 import com.cotalk.domain.port.outbound.MessageRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -14,12 +15,25 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
 
+/**
+ * {@link SearchMessageService} 단위 테스트.
+ *
+ * <p>블라인드 인덱스 토큰화 호출 + 복호화 substring 최종 필터 + 길이 가드(3글자 미만 거부)를 검증한다.
+ * 토큰화는 Mock으로 대체하되, "키워드를 포함하지 않는" 메시지가 2단계 substring 필터에서
+ * 제거되는지(false positive 제거)를 핵심으로 본다.</p>
+ */
 @ExtendWith(MockitoExtension.class)
 class SearchMessageServiceTest {
 
@@ -29,55 +43,76 @@ class SearchMessageServiceTest {
     @Mock
     private ChatRoomMemberRepository chatRoomMemberRepository;
 
+    @Mock
+    private BlindIndexTokenizer tokenizer;
+
     @InjectMocks
     private SearchMessageService searchMessageService;
 
+    /**
+     * 테스트용 토큰화/정규화 동작을 설정한다.
+     * normalize는 소문자+공백제거, tokenizeQuery는 비어있지 않은 토큰을 돌려준다.
+     */
+    private void stubTokenizer(String keyword) {
+        lenient().when(tokenizer.normalize(any())).thenAnswer(inv -> {
+            String s = inv.getArgument(0);
+            return s == null ? "" : s.toLowerCase().replaceAll("\\s+", "");
+        });
+        lenient().when(tokenizer.tokenizeQuery(keyword)).thenReturn(Set.of("tok1", "tok2"));
+    }
+
     @Test
-    @DisplayName("채팅방 내 메시지 검색 성공")
+    @DisplayName("채팅방 내 메시지 검색 성공 — 토큰 조회 후 복호화 substring 필터 통과분 반환")
     void should_returnMessages_when_searchInChatRoom() {
-        // given
         Long chatRoomId = 1L;
         Long userId = 100L;
-        String keyword = "안녕";
+        String keyword = "안녕하세요";
+        stubTokenizer(keyword);
 
-        Message message1 = Message.builder()
-                .id(1L)
-                .chatRoomId(chatRoomId)
-                .senderId(100L)
-                .content("안녕하세요!")
-                .build();
-
-        Message message2 = Message.builder()
-                .id(2L)
-                .chatRoomId(chatRoomId)
-                .senderId(200L)
-                .content("안녕, 반가워요")
-                .build();
+        Message m1 = Message.builder().id(1L).chatRoomId(chatRoomId).senderId(100L).content("안녕하세요!").build();
+        Message m2 = Message.builder().id(2L).chatRoomId(chatRoomId).senderId(200L).content("안녕하세요 반가워요").build();
 
         given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, userId)).willReturn(true);
-        given(messageRepository.searchByKeywordInChatRoom(chatRoomId, keyword, 0, 20))
-                .willReturn(List.of(message1, message2));
+        given(messageRepository.searchByTokensInChatRoom(eq(chatRoomId), any(), anyLong(), anyInt(), anyInt()))
+                .willReturn(List.of(m1, m2));
 
-        // when
         List<Message> result = searchMessageService.searchInChatRoom(chatRoomId, userId, keyword, 0, 20);
 
-        // then
         assertThat(result).hasSize(2)
-                        .allSatisfy(m -> assertThat(m.getContent()).contains("안녕"));
+                .allSatisfy(m -> assertThat(m.getContent()).contains("안녕하세요"));
+    }
+
+    @Test
+    @DisplayName("토큰은 맞지만 substring이 아닌 false positive는 2단계 필터에서 제거된다")
+    void should_removeFalsePositive_when_substringNotPresent() {
+        Long chatRoomId = 1L;
+        Long userId = 100L;
+        String keyword = "비밀번호";
+        stubTokenizer(keyword);
+
+        // "비밀번호"의 트라이그램은 흩어져 포함되지만 연속 substring은 아닌 메시지 (false positive)
+        Message hit = Message.builder().id(1L).chatRoomId(chatRoomId).senderId(100L).content("새 비밀번호로 변경했어요").build();
+        Message falsePositive = Message.builder().id(2L).chatRoomId(chatRoomId).senderId(200L)
+                .content("비밀 얘기, 전화번호 알려줘").build(); // '비밀번호' 연속 아님
+
+        given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, userId)).willReturn(true);
+        given(messageRepository.searchByTokensInChatRoom(eq(chatRoomId), any(), anyLong(), anyInt(), anyInt()))
+                .willReturn(List.of(hit, falsePositive));
+
+        List<Message> result = searchMessageService.searchInChatRoom(chatRoomId, userId, keyword, 0, 20);
+
+        assertThat(result).extracting(Message::getId).containsExactly(1L);
     }
 
     @Test
     @DisplayName("채팅방 멤버가 아닌 경우 검색 실패")
     void should_throwException_when_notChatRoomMember() {
-        // given
         Long chatRoomId = 1L;
         Long userId = 100L;
-        String keyword = "안녕";
 
         given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, userId)).willReturn(false);
 
-        // when & then
-        assertThatThrownBy(() -> searchMessageService.searchInChatRoom(chatRoomId, userId, keyword, 0, 20))
+        assertThatThrownBy(() -> searchMessageService.searchInChatRoom(chatRoomId, userId, "안녕하세요", 0, 20))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("채팅방 멤버만 메시지를 검색할 수 있습니다.");
     }
@@ -86,16 +121,13 @@ class SearchMessageServiceTest {
     @MethodSource("blankKeywordSource")
     @DisplayName("검색어가 비어있거나 공백인 경우 빈 결과 반환")
     void should_returnEmpty_when_keywordIsEmptyOrBlank(String displayValue, String keyword) {
-        // given
         Long chatRoomId = 1L;
         Long userId = 100L;
 
         given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, userId)).willReturn(true);
 
-        // when
         List<Message> result = searchMessageService.searchInChatRoom(chatRoomId, userId, keyword, 0, 20);
 
-        // then
         assertThat(result).isEmpty();
     }
 
@@ -107,81 +139,93 @@ class SearchMessageServiceTest {
         );
     }
 
+    @ParameterizedTest(name = "{0}글자 키워드 \"{1}\"는 거부된다")
+    @MethodSource("shortKeywordSource")
+    @DisplayName("3글자 미만 키워드는 검색을 거부한다 (블라인드 인덱스 트라이그램 불가)")
+    void should_rejectKeyword_when_shorterThanThreeChars(int len, String keyword) {
+        Long chatRoomId = 1L;
+        Long userId = 100L;
+
+        given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, userId)).willReturn(true);
+
+        assertThatThrownBy(() -> searchMessageService.searchInChatRoom(chatRoomId, userId, keyword, 0, 20))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("3글자");
+    }
+
+    @Test
+    @DisplayName("전체 채팅방 검색에서도 3글자 미만 키워드는 거부한다")
+    void should_rejectKeyword_when_shortInAllChatRooms() {
+        assertThatThrownBy(() -> searchMessageService.searchAcrossAllChatRooms(100L, "가나", 0, 20))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("3글자");
+    }
+
+    static Stream<Arguments> shortKeywordSource() {
+        return Stream.of(
+                Arguments.of(1, "가"),
+                Arguments.of(2, "가나"),
+                Arguments.of(2, "ab")
+        );
+    }
+
     @Test
     @DisplayName("사용자의 모든 채팅방에서 메시지 검색 성공")
     void should_returnMessages_when_searchAcrossAllChatRooms() {
-        // given
         Long userId = 100L;
-        String keyword = "회의";
+        String keyword = "회의시간";
+        stubTokenizer(keyword);
 
-        Message message1 = Message.builder()
-                .id(1L)
-                .chatRoomId(1L)
-                .senderId(100L)
-                .content("회의 시간 알려주세요")
-                .build();
+        Message m1 = Message.builder().id(1L).chatRoomId(1L).senderId(100L).content("회의시간 알려주세요").build();
+        Message m2 = Message.builder().id(2L).chatRoomId(2L).senderId(200L).content("회의시간 정했어요").build();
 
-        Message message2 = Message.builder()
-                .id(2L)
-                .chatRoomId(2L)
-                .senderId(200L)
-                .content("회의 끝났어요")
-                .build();
+        given(messageRepository.searchByTokensInUserChatRooms(eq(userId), any(), anyLong(), anyInt(), anyInt()))
+                .willReturn(List.of(m1, m2));
 
-        given(messageRepository.searchByKeywordInUserChatRooms(userId, keyword, 0, 20))
-                .willReturn(List.of(message1, message2));
-
-        // when
         List<Message> result = searchMessageService.searchAcrossAllChatRooms(userId, keyword, 0, 20);
 
-        // then
         assertThat(result).hasSize(2);
     }
 
     @Test
-    @DisplayName("검색 결과가 없는 경우 빈 리스트 반환")
-    void should_returnEmptyList_when_noMatchingMessages() {
-        // given
+    @DisplayName("소프트 삭제된 메시지는 결과에서 제외된다")
+    void should_excludeDeletedMessages() {
         Long chatRoomId = 1L;
         Long userId = 100L;
-        String keyword = "존재하지않는키워드";
+        String keyword = "회의시간";
+        stubTokenizer(keyword);
+
+        Message alive = Message.builder().id(1L).chatRoomId(chatRoomId).senderId(100L).content("회의시간 공유").build();
+        Message deleted = Message.builder().id(2L).chatRoomId(chatRoomId).senderId(200L).content("회의시간 변경").deleted(true).build();
 
         given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, userId)).willReturn(true);
-        given(messageRepository.searchByKeywordInChatRoom(chatRoomId, keyword, 0, 20))
-                .willReturn(List.of());
+        given(messageRepository.searchByTokensInChatRoom(eq(chatRoomId), any(), anyLong(), anyInt(), anyInt()))
+                .willReturn(List.of(alive, deleted));
 
-        // when
         List<Message> result = searchMessageService.searchInChatRoom(chatRoomId, userId, keyword, 0, 20);
 
-        // then
-        assertThat(result).isEmpty();
+        assertThat(result).extracting(Message::getId).containsExactly(1L);
     }
 
     @Test
-    @DisplayName("전체 채팅방 검색에서 null 키워드는 빈 결과 반환")
-    void should_returnEmpty_when_keywordIsNullInAllChatRooms() {
-        // given
+    @DisplayName("over-fetch: substring 통과분을 size만큼만 잘라 반환한다")
+    void should_limitToSize_afterOverFetch() {
+        Long chatRoomId = 1L;
         Long userId = 100L;
-        String keyword = null;
+        String keyword = "회의시간";
+        stubTokenizer(keyword);
 
-        // when
-        List<Message> result = searchMessageService.searchAcrossAllChatRooms(userId, keyword, 0, 20);
+        // size=2 이지만 substring 통과 메시지가 3개 → 2개만 반환
+        Message a = Message.builder().id(1L).chatRoomId(chatRoomId).senderId(100L).content("회의시간 1").build();
+        Message b = Message.builder().id(2L).chatRoomId(chatRoomId).senderId(100L).content("회의시간 2").build();
+        Message c = Message.builder().id(3L).chatRoomId(chatRoomId).senderId(100L).content("회의시간 3").build();
 
-        // then
-        assertThat(result).isEmpty();
-    }
+        given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, userId)).willReturn(true);
+        given(messageRepository.searchByTokensInChatRoom(eq(chatRoomId), any(), anyLong(), anyInt(), anyInt()))
+                .willReturn(List.of(a, b, c));
 
-    @Test
-    @DisplayName("전체 채팅방 검색에서 빈 키워드는 빈 결과 반환")
-    void should_returnEmpty_when_keywordIsEmptyInAllChatRooms() {
-        // given
-        Long userId = 100L;
-        String keyword = "";
+        List<Message> result = searchMessageService.searchInChatRoom(chatRoomId, userId, keyword, 0, 2);
 
-        // when
-        List<Message> result = searchMessageService.searchAcrossAllChatRooms(userId, keyword, 0, 20);
-
-        // then
-        assertThat(result).isEmpty();
+        assertThat(result).hasSize(2).extracting(Message::getId).containsExactly(1L, 2L);
     }
 }

--- a/src/test/java/com/cotalk/application/service/message/SendMessageServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/message/SendMessageServiceTest.java
@@ -49,6 +49,12 @@ class SendMessageServiceTest {
     private MessageRepository messageRepository;
 
     @Mock
+    private com.cotalk.domain.port.outbound.MessageSearchTokenRepository messageSearchTokenRepository;
+
+    @Mock
+    private com.cotalk.domain.port.outbound.BlindIndexTokenizer blindIndexTokenizer;
+
+    @Mock
     private ChatRoomMemberRepository chatRoomMemberRepository;
 
     @Mock
@@ -93,10 +99,14 @@ class SendMessageServiceTest {
     @BeforeEach
     void setUp() {
         sendMessageService = new SendMessageService(
-                messageRepository, chatRoomMemberRepository, chatRoomRepository, userRepository, idGenerator,
+                messageRepository, messageSearchTokenRepository, blindIndexTokenizer,
+                chatRoomMemberRepository, chatRoomRepository, userRepository, idGenerator,
                 notificationCommandPort, chatRoomPresenceTracker, customMetrics,
                 messageLinkPreviewService, messageBroadcastService, transactionTemplate, timeProvider,
                 new com.cotalk.domain.validator.FileMessageValidator(), fileObjectResolver, blockValidator);
+
+        // 기본 토큰화 동작 (lenient): TEXT 메시지 전송 시 호출됨
+        lenient().when(blindIndexTokenizer.tokenize(anyString())).thenReturn(Set.of("tok"));
 
         // TransactionTemplate: 콜백을 즉시 실행 (트랜잭션 없이 동기 실행)
         lenient().when(transactionTemplate.execute(any(TransactionCallback.class)))

--- a/src/test/java/com/cotalk/application/service/message/UpdateMessageServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/message/UpdateMessageServiceTest.java
@@ -3,8 +3,10 @@ package com.cotalk.application.service.message;
 import com.cotalk.domain.entity.Message;
 import com.cotalk.domain.exception.MessageNotFoundException;
 import com.cotalk.domain.exception.ResourceAccessDeniedException;
+import com.cotalk.domain.port.outbound.BlindIndexTokenizer;
 import com.cotalk.domain.port.outbound.ChatMessageBroker;
 import com.cotalk.domain.port.outbound.MessageRepository;
+import com.cotalk.domain.port.outbound.MessageSearchTokenRepository;
 import com.cotalk.domain.port.outbound.TimeProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -31,6 +33,12 @@ class UpdateMessageServiceTest {
     private MessageRepository messageRepository;
 
     @Mock
+    private MessageSearchTokenRepository messageSearchTokenRepository;
+
+    @Mock
+    private BlindIndexTokenizer blindIndexTokenizer;
+
+    @Mock
     private ChatMessageBroker chatMessageBroker;
 
     @Mock
@@ -42,7 +50,8 @@ class UpdateMessageServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new UpdateMessageService(messageRepository, chatMessageBroker, timeProvider);
+        service = new UpdateMessageService(messageRepository, messageSearchTokenRepository,
+                blindIndexTokenizer, chatMessageBroker, timeProvider);
     }
 
     @Test

--- a/src/test/java/com/cotalk/infrastructure/crypto/EncryptionServiceTest.java
+++ b/src/test/java/com/cotalk/infrastructure/crypto/EncryptionServiceTest.java
@@ -38,7 +38,8 @@ class EncryptionServiceTest {
                 new AppProperties.PasswordReset(30),
                 new AppProperties.Terms("1.0", "1.0"),
                 new AppProperties.Encryption(encryptionKey, enabled),
-                new AppProperties.Swagger("http://localhost:8080", "API 서버")
+                new AppProperties.Swagger("http://localhost:8080", "API 서버"),
+                new AppProperties.Search("dGVzdC1ibGluZC1pbmRleC1zZWNyZXQtZm9yLXVuaXQtdGVzdHM=")
         );
     }
 

--- a/src/test/java/com/cotalk/infrastructure/crypto/HmacBlindIndexTokenizerTest.java
+++ b/src/test/java/com/cotalk/infrastructure/crypto/HmacBlindIndexTokenizerTest.java
@@ -142,4 +142,22 @@ class HmacBlindIndexTokenizerTest {
         assertThatThrownBy(() -> new HmacBlindIndexTokenizer(appPropertiesWithSecret("")))
                 .isInstanceOf(IllegalStateException.class);
     }
+
+    @Test
+    @DisplayName("시크릿이 null(미설정)이면 — AppProperties가 \"\"로 치환해도 — 생성 시 fail-fast로 거부한다")
+    void should_throw_when_secretNull() {
+        // AppProperties.Search compact 생성자가 null→""로 치환하므로, 빈 시크릿 거부 경로로 수렴해야 한다.
+        // (설정 누락 시 빈 시크릿으로 조용히 동작하는 보안 구멍이 없음을 보장)
+        assertThat(new AppProperties.Search(null).blindIndexSecret()).isEmpty();
+        assertThatThrownBy(() -> new HmacBlindIndexTokenizer(appPropertiesWithSecret(null)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("blind-index-secret");
+    }
+
+    @Test
+    @DisplayName("공백만 있는 시크릿도 fail-fast로 거부한다")
+    void should_throw_when_secretBlank() {
+        assertThatThrownBy(() -> new HmacBlindIndexTokenizer(appPropertiesWithSecret("   ")))
+                .isInstanceOf(IllegalStateException.class);
+    }
 }

--- a/src/test/java/com/cotalk/infrastructure/crypto/HmacBlindIndexTokenizerTest.java
+++ b/src/test/java/com/cotalk/infrastructure/crypto/HmacBlindIndexTokenizerTest.java
@@ -1,0 +1,145 @@
+package com.cotalk.infrastructure.crypto;
+
+import com.cotalk.infrastructure.config.properties.AppProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.text.Normalizer;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * {@link HmacBlindIndexTokenizer} 단위 테스트.
+ *
+ * <p>정규화, 글자 단위 3-gram 추출, HMAC 결정성, 한국어/이모지 코드포인트 처리,
+ * 길이 가드(3글자 미만)를 검증한다.</p>
+ */
+@DisplayName("HmacBlindIndexTokenizer")
+class HmacBlindIndexTokenizerTest {
+
+    // 고정 더미 시크릿 (Base64) — 결정성 검증용
+    private static final String SECRET = "dGVzdC1ibGluZC1pbmRleC1zZWNyZXQtZm9yLXVuaXQtdGVzdHM=";
+
+    private HmacBlindIndexTokenizer tokenizer() {
+        AppProperties props = appPropertiesWithSecret(SECRET);
+        return new HmacBlindIndexTokenizer(props);
+    }
+
+    private AppProperties appPropertiesWithSecret(String secret) {
+        return new AppProperties(
+                "http://localhost:3000",
+                new AppProperties.Cors("http://localhost:3000"),
+                new AppProperties.Redis("chat:room:", "user:event:"),
+                new AppProperties.PasswordReset(30),
+                new AppProperties.Terms("1.0", "1.0"),
+                new AppProperties.Encryption("dGhpc2lzYXRlc3RrZXlmb3JkZXZlbG9wbWVudG9ubHk=", false),
+                new AppProperties.Swagger("http://localhost:8080", "API 서버"),
+                new AppProperties.Search(secret)
+        );
+    }
+
+    @Test
+    @DisplayName("3글자 이상 한국어를 글자 단위 트라이그램 개수만큼 토큰화한다")
+    void should_produceTrigramTokens_when_koreanTextGiven() {
+        Set<String> tokens = tokenizer().tokenize("비밀번호");
+        // "비밀번호" → [비밀번, 밀번호] = 2개
+        assertThat(tokens).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("동일 입력에 대해 결정적(deterministic)으로 같은 토큰을 생성한다")
+    void should_beDeterministic_when_sameInput() {
+        HmacBlindIndexTokenizer t1 = tokenizer();
+        HmacBlindIndexTokenizer t2 = tokenizer();
+        assertThat(t1.tokenize("안녕하세요")).isEqualTo(t2.tokenize("안녕하세요"));
+    }
+
+    @Test
+    @DisplayName("시크릿이 다르면 같은 평문이라도 다른 토큰을 생성한다 (HMAC 키 의존)")
+    void should_differ_when_secretDiffers() {
+        HmacBlindIndexTokenizer t1 = tokenizer();
+        HmacBlindIndexTokenizer t2 = new HmacBlindIndexTokenizer(
+                appPropertiesWithSecret("YW5vdGhlci1zZWNyZXQtdmFsdWUtZm9yLXRoZS10ZXN0LWNhc2U="));
+        assertThat(t1.tokenize("비밀번호")).isNotEqualTo(t2.tokenize("비밀번호"));
+    }
+
+    @Test
+    @DisplayName("키워드 토큰화 결과는 본문 토큰화 결과의 부분집합이다 (부분일치 매칭 성립)")
+    void should_keywordTokensBeSubsetOfContentTokens() {
+        HmacBlindIndexTokenizer t = tokenizer();
+        Set<String> content = t.tokenize("오늘 비밀번호를 변경했어요");
+        Set<String> query = t.tokenizeQuery("비밀번호");
+        assertThat(query).isNotEmpty();
+        assertThat(content).containsAll(query);
+    }
+
+    @Test
+    @DisplayName("대소문자/공백/유니코드 정규화가 토큰화에 반영된다")
+    void should_normalize_caseAndWhitespace() {
+        HmacBlindIndexTokenizer t = tokenizer();
+        // "Hello" 와 "h e l l o" 는 정규화(소문자+공백제거) 후 같은 시퀀스
+        assertThat(t.tokenize("Hello")).isEqualTo(t.tokenize("h e l l o"));
+    }
+
+    @Test
+    @DisplayName("NFC 정규화로 분해형/완성형 한글이 같은 토큰을 만든다")
+    void should_normalizeNfc_when_decomposedHangul() {
+        HmacBlindIndexTokenizer t = tokenizer();
+        String composed = Normalizer.normalize("가나다", Normalizer.Form.NFC);
+        String decomposed = Normalizer.normalize("가나다", Normalizer.Form.NFD);
+        assertThat(decomposed).isNotEqualTo(composed); // 입력은 다름
+        assertThat(t.tokenize(decomposed)).isEqualTo(t.tokenize(composed)); // 토큰은 같음
+    }
+
+    @Test
+    @DisplayName("이모지(서로게이트 페어)를 코드포인트 단위로 처리한다")
+    void should_handleEmoji_asCodePoints() {
+        HmacBlindIndexTokenizer t = tokenizer();
+        // 이모지 3개 → 1개 트라이그램 (서로게이트 분리 없이 글자 3개로 인식)
+        Set<String> tokens = t.tokenize("😀😁😂");
+        assertThat(tokens).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("3글자 미만은 빈 토큰 집합을 반환한다")
+    void should_returnEmpty_when_fewerThanThreeChars() {
+        HmacBlindIndexTokenizer t = tokenizer();
+        assertThat(t.tokenize("가")).isEmpty();
+        assertThat(t.tokenize("가나")).isEmpty();
+        assertThat(t.tokenizeQuery("ab")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("null/빈 문자열은 빈 토큰 집합을 반환한다")
+    void should_returnEmpty_when_nullOrBlank() {
+        HmacBlindIndexTokenizer t = tokenizer();
+        assertThat(t.tokenize(null)).isEmpty();
+        assertThat(t.tokenize("")).isEmpty();
+        assertThat(t.tokenize("   ")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("토큰 길이는 VARCHAR(24) 이내다")
+    void should_produceTokensWithinColumnLength() {
+        HmacBlindIndexTokenizer t = tokenizer();
+        assertThat(t.tokenize("비밀번호변경")).allSatisfy(tok ->
+                assertThat(tok.length()).isLessThanOrEqualTo(24));
+    }
+
+    @Test
+    @DisplayName("normalize는 소문자+공백제거+NFC를 적용한다")
+    void should_normalizeConsistently() {
+        HmacBlindIndexTokenizer t = tokenizer();
+        assertThat(t.normalize("  Hello World  ")).isEqualTo("helloworld");
+        assertThat(t.normalize(null)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("시크릿이 비어있으면 생성 시 예외를 던진다")
+    void should_throw_when_secretMissing() {
+        assertThatThrownBy(() -> new HmacBlindIndexTokenizer(appPropertiesWithSecret("")))
+                .isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/src/test/java/com/cotalk/infrastructure/messaging/RedisChatMessageBrokerTest.java
+++ b/src/test/java/com/cotalk/infrastructure/messaging/RedisChatMessageBrokerTest.java
@@ -59,7 +59,8 @@ class RedisChatMessageBrokerTest {
                 new AppProperties.PasswordReset(30),
                 new AppProperties.Terms("1.0", "1.0"),
                 new AppProperties.Encryption("", true),
-                new AppProperties.Swagger("http://localhost:8080", "API 서버")
+                new AppProperties.Swagger("http://localhost:8080", "API 서버"),
+                new AppProperties.Search("dGVzdC1ibGluZC1pbmRleC1zZWNyZXQtZm9yLXVuaXQtdGVzdHM=")
         );
     }
 

--- a/src/test/java/com/cotalk/infrastructure/messaging/RedisChatMessageSubscriberTest.java
+++ b/src/test/java/com/cotalk/infrastructure/messaging/RedisChatMessageSubscriberTest.java
@@ -61,7 +61,8 @@ class RedisChatMessageSubscriberTest {
                 new AppProperties.PasswordReset(30),
                 new AppProperties.Terms("1.0", "1.0"),
                 new AppProperties.Encryption("", true),
-                new AppProperties.Swagger("http://localhost:8080", "API 서버")
+                new AppProperties.Swagger("http://localhost:8080", "API 서버"),
+                new AppProperties.Search("dGVzdC1ibGluZC1pbmRleC1zZWNyZXQtZm9yLXVuaXQtdGVzdHM=")
         );
     }
 

--- a/src/test/java/com/cotalk/infrastructure/messaging/RedisMessagingConfigTest.java
+++ b/src/test/java/com/cotalk/infrastructure/messaging/RedisMessagingConfigTest.java
@@ -41,7 +41,8 @@ class RedisMessagingConfigTest {
                 new AppProperties.PasswordReset(30),
                 new AppProperties.Terms("1.0", "1.0"),
                 new AppProperties.Encryption("", true),
-                new AppProperties.Swagger("http://localhost:8080", "API 서버")
+                new AppProperties.Swagger("http://localhost:8080", "API 서버"),
+                new AppProperties.Search("dGVzdC1ibGluZC1pbmRleC1zZWNyZXQtZm9yLXVuaXQtdGVzdHM=")
         );
     }
 

--- a/src/test/java/com/cotalk/infrastructure/messaging/RedisUserEventBrokerTest.java
+++ b/src/test/java/com/cotalk/infrastructure/messaging/RedisUserEventBrokerTest.java
@@ -49,7 +49,8 @@ class RedisUserEventBrokerTest {
                 new AppProperties.PasswordReset(30),
                 new AppProperties.Terms("1.0", "1.0"),
                 new AppProperties.Encryption("", true),
-                new AppProperties.Swagger("http://localhost:8080", "API 서버")
+                new AppProperties.Swagger("http://localhost:8080", "API 서버"),
+                new AppProperties.Search("dGVzdC1ibGluZC1pbmRleC1zZWNyZXQtZm9yLXVuaXQtdGVzdHM=")
         );
     }
 

--- a/src/test/java/com/cotalk/infrastructure/messaging/RedisUserEventSubscriberTest.java
+++ b/src/test/java/com/cotalk/infrastructure/messaging/RedisUserEventSubscriberTest.java
@@ -52,7 +52,8 @@ class RedisUserEventSubscriberTest {
                 new AppProperties.PasswordReset(30),
                 new AppProperties.Terms("1.0", "1.0"),
                 new AppProperties.Encryption("", true),
-                new AppProperties.Swagger("http://localhost:8080", "API 서버")
+                new AppProperties.Swagger("http://localhost:8080", "API 서버"),
+                new AppProperties.Search("dGVzdC1ibGluZC1pbmRleC1zZWNyZXQtZm9yLXVuaXQtdGVzdHM=")
         );
     }
 

--- a/src/test/java/com/cotalk/integration/MessageIntegrationTest.java
+++ b/src/test/java/com/cotalk/integration/MessageIntegrationTest.java
@@ -206,10 +206,10 @@ class MessageIntegrationTest {
     }
 
     @Test
-    @DisplayName("메시지 검색")
+    @DisplayName("메시지 검색 (블라인드 인덱스 3글자 이상 부분일치)")
     void should_searchMessages() throws Exception {
-        // 1. 여러 메시지 전송
-        String[] messages = {"안녕하세요", "반갑습니다", "오늘 날씨가 좋네요", "안녕히 가세요"};
+        // 1. 여러 메시지 전송 — 두 메시지가 "안녕하세" 3-gram을 공유
+        String[] messages = {"안녕하세요", "반갑습니다", "오늘 날씨가 좋네요", "다들 안녕하세 인사"};
         setSecurityContext(user1Id);
         for (String msg : messages) {
             SendMessageRequest request = new SendMessageRequest(chatRoomId, msg);
@@ -219,16 +219,35 @@ class MessageIntegrationTest {
                     .andExpect(status().isCreated());
         }
 
-        // 2. "안녕" 키워드로 검색
+        // 2. "안녕하세" 키워드로 검색 (3글자 이상 — 블라인드 인덱스 부분일치)
+        setSecurityContext(user1Id);
+        mockMvc.perform(get("/api/v1/messages/search")
+                        .param("chatRoomId", chatRoomId.toString())
+                        .param("keyword", "안녕하세")
+                        .param("page", "0")
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.messages").isArray())
+                .andExpect(jsonPath("$.messages.length()").value(2));
+    }
+
+    @Test
+    @DisplayName("3글자 미만 검색어는 400을 반환한다")
+    void should_returnBadRequest_when_keywordTooShort() throws Exception {
+        SendMessageRequest request = new SendMessageRequest(chatRoomId, "안녕하세요");
+        setSecurityContext(user1Id);
+        mockMvc.perform(post("/api/v1/chat/messages")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated());
+
         setSecurityContext(user1Id);
         mockMvc.perform(get("/api/v1/messages/search")
                         .param("chatRoomId", chatRoomId.toString())
                         .param("keyword", "안녕")
                         .param("page", "0")
                         .param("size", "20"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.messages").isArray())
-                .andExpect(jsonPath("$.messages.length()").value(2));
+                .andExpect(status().isBadRequest());
     }
 
     @Test

--- a/src/test/java/com/cotalk/integration/MessageSearchBlindIndexIntegrationTest.java
+++ b/src/test/java/com/cotalk/integration/MessageSearchBlindIndexIntegrationTest.java
@@ -235,6 +235,40 @@ class MessageSearchBlindIndexIntegrationTest {
     }
 
     @Test
+    @DisplayName("page>0 페이징이 사용자 페이지 기준 오프셋으로 동작한다 (over-fetch 윈도우와 무관하게 누락/중복 없음)")
+    void should_paginateCorrectly_when_pageGreaterThanZero() {
+        Long sender = createUser("p@test.com", "페이지");
+        Long roomId = createRoomWithMembers(sender);
+
+        // 10건 저장 (createdAt DESC 정렬 — 나중에 보낸 것이 앞).
+        for (int i = 0; i < 10; i++) {
+            sendMessageUseCase.sendMessage(roomId, sender, "회의시간 메시지 " + i);
+        }
+
+        // page=0, size=3 → 첫 3건. page=1 → 다음 3건. 겹치지 않아야 한다.
+        List<Message> page0 = searchMessageUseCase.searchInChatRoom(roomId, sender, "회의시간", 0, 3);
+        List<Message> page1 = searchMessageUseCase.searchInChatRoom(roomId, sender, "회의시간", 1, 3);
+        List<Message> page2 = searchMessageUseCase.searchInChatRoom(roomId, sender, "회의시간", 2, 3);
+
+        assertThat(page0).hasSize(3);
+        assertThat(page1).hasSize(3);
+        assertThat(page2).hasSize(3);
+
+        List<Long> ids0 = page0.stream().map(Message::getId).toList();
+        List<Long> ids1 = page1.stream().map(Message::getId).toList();
+        List<Long> ids2 = page2.stream().map(Message::getId).toList();
+
+        // 페이지 간 중복 없음 (버그 시: page1 오프셋이 9가 되어 누락/중복 발생)
+        assertThat(ids0).doesNotContainAnyElementsOf(ids1);
+        assertThat(ids1).doesNotContainAnyElementsOf(ids2);
+        assertThat(ids0).doesNotContainAnyElementsOf(ids2);
+
+        // 세 페이지 합쳐 9개 distinct (전체 10개 중 연속된 윈도우)
+        assertThat(java.util.stream.Stream.of(ids0, ids1, ids2)
+                .flatMap(List::stream).distinct().count()).isEqualTo(9L);
+    }
+
+    @Test
     @DisplayName("메시지 수정 시 재토큰화되어 새 키워드로 검색되고 옛 키워드로는 검색되지 않는다")
     void should_reTokenize_onUpdate() {
         Long sender = createUser("h@test.com", "거북이");

--- a/src/test/java/com/cotalk/integration/MessageSearchBlindIndexIntegrationTest.java
+++ b/src/test/java/com/cotalk/integration/MessageSearchBlindIndexIntegrationTest.java
@@ -1,0 +1,256 @@
+package com.cotalk.integration;
+
+import com.cotalk.domain.entity.ChatRoom;
+import com.cotalk.domain.entity.ChatRoomMember;
+import com.cotalk.domain.entity.Message;
+import com.cotalk.domain.entity.User;
+import com.cotalk.domain.model.Email;
+import com.cotalk.domain.port.inbound.message.SearchMessageUseCase;
+import com.cotalk.domain.port.inbound.message.SendMessageUseCase;
+import com.cotalk.domain.port.inbound.message.UpdateMessageUseCase;
+import com.cotalk.domain.port.outbound.ChatRoomMemberRepository;
+import com.cotalk.domain.port.outbound.ChatRoomRepository;
+import com.cotalk.domain.port.outbound.IdGenerator;
+import com.cotalk.domain.port.outbound.MessageRepository;
+import com.cotalk.domain.port.outbound.UserRepository;
+import com.cotalk.config.TestRedisConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * 암호화 ON + 실제 Flyway(PostgreSQL testcontainer) 환경에서 블라인드 인덱스 메시지 검색이
+ * 실제로 동작함을 검증하는 통합 테스트 (재발방지 핵심 산출물).
+ *
+ * <p>기존 검색 실패의 근본 원인은 단위/JPA 테스트가 {@code app.encryption.enabled=false}로 돌아
+ * 평문 LIKE가 통과했고, prod(암호화 ON)에서만 깨진 것이다. 이 테스트는 prod 동등 환경
+ * (PostgreSQL + 실제 Flyway V17 + 암호화 ON + 고정 키/시크릿)에서 검색을 검증해 그 괴리를 막는다.</p>
+ *
+ * <p>검증 시나리오: 한국어 메시지 저장 시 DB raw content가 평문과 다름(=암호화 확인) →
+ * 부분일치("밀번") 검색 매칭 → 1~2글자 거부 → false positive(트라이그램은 맞지만 substring 아님)의
+ * 2단계 제거 → 소프트삭제 제외 → 멤버십 격리 → over-fetch 페이징 → 수정 재토큰화.</p>
+ *
+ * @author seunggu.lee
+ */
+@Testcontainers(disabledWithoutDocker = true)
+@SpringBootTest
+@ActiveProfiles("test")
+@Import(TestRedisConfiguration.class)
+@DisplayName("암호화 ON 블라인드 인덱스 검색 통합")
+class MessageSearchBlindIndexIntegrationTest {
+
+    @SuppressWarnings("resource")
+    @Container
+    static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine")
+            .withDatabaseName("cotalk")
+            .withUsername("test")
+            .withPassword("test");
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry registry) {
+        // PostgreSQL + 실제 Flyway 마이그레이션(V17 포함)으로 prod 동등 스키마 구성
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+        registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+        // ddl-auto는 끄고 Flyway가 스키마를 소유 (V17 message_search_tokens 실제 적용)
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+        registry.add("spring.flyway.enabled", () -> "true");
+        // 핵심: 암호화 ON + 고정 키/시크릿 (prod 동등)
+        registry.add("app.encryption.enabled", () -> "true");
+        registry.add("app.encryption.key", () -> "dGhpc2lzYXRlc3RrZXlmb3JkZXZlbG9wbWVudG9ubHk=");
+        registry.add("app.search.blind-index-secret",
+                () -> "dGVzdC1ibGluZC1pbmRleC1zZWNyZXQtZm9yLWludGVncmF0aW9uLXRlc3Q=");
+    }
+
+    @Autowired
+    private SendMessageUseCase sendMessageUseCase;
+    @Autowired
+    private SearchMessageUseCase searchMessageUseCase;
+    @Autowired
+    private UpdateMessageUseCase updateMessageUseCase;
+    @Autowired
+    private MessageRepository messageRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+    @Autowired
+    private ChatRoomMemberRepository chatRoomMemberRepository;
+    @Autowired
+    private IdGenerator idGenerator;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @AfterEach
+    void cleanUp() {
+        // 물리 삭제로 테스트 간 격리 (토큰은 FK CASCADE로 함께 삭제됨)
+        jdbcTemplate.update("DELETE FROM message_search_tokens");
+        jdbcTemplate.update("DELETE FROM messages");
+        jdbcTemplate.update("DELETE FROM chat_room_members");
+        jdbcTemplate.update("DELETE FROM chat_rooms");
+        jdbcTemplate.update("DELETE FROM users");
+    }
+
+    private Long createUser(String email, String nickname) {
+        Long id = idGenerator.nextId();
+        userRepository.save(User.builder()
+                .id(id)
+                .email(new Email(email))
+                .nickname(nickname)
+                .passwordHash("$2a$10$dummyhashdummyhashdummyhashdummyhashdummyhash")
+                .build());
+        return id;
+    }
+
+    private Long createRoomWithMembers(Long... userIds) {
+        Long roomId = idGenerator.nextId();
+        chatRoomRepository.save(ChatRoom.builder().id(roomId).type(ChatRoom.ChatRoomType.GROUP).name("방").build());
+        for (Long userId : userIds) {
+            chatRoomMemberRepository.save(ChatRoomMember.builder()
+                    .id(idGenerator.nextId()).chatRoomId(roomId).userId(userId).build());
+        }
+        return roomId;
+    }
+
+    @Test
+    @DisplayName("한국어 메시지는 DB에 암호문으로 저장되고(평문과 다름) 부분일치 검색이 매칭한다")
+    void should_encryptContent_andMatchPartialKeyword() {
+        Long sender = createUser("a@test.com", "철수");
+        Long roomId = createRoomWithMembers(sender);
+
+        Message sent = sendMessageUseCase.sendMessage(roomId, sender, "오늘 비밀번호를 변경했어요");
+
+        // DB raw content가 평문과 다름 = 실제 암호화 확인 (이게 핵심 — 항진이 아님을 보장)
+        String rawContent = jdbcTemplate.queryForObject(
+                "SELECT content FROM messages WHERE id = ?", String.class, sent.getId());
+        assertThat(rawContent).isNotNull().isNotEqualTo("오늘 비밀번호를 변경했어요");
+        assertThat(rawContent).doesNotContain("비밀번호");
+        // 토큰이 실제 적재됐는지 확인
+        Integer tokenCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM message_search_tokens WHERE message_id = ?", Integer.class, sent.getId());
+        assertThat(tokenCount).isGreaterThan(0);
+
+        // 부분일치 검색 ("밀번" — 단어 중간 부분 문자열)
+        List<Message> results = searchMessageUseCase.searchInChatRoom(roomId, sender, "밀번호", 0, 20);
+        assertThat(results).extracting(Message::getId).containsExactly(sent.getId());
+        assertThat(results.get(0).getContent()).isEqualTo("오늘 비밀번호를 변경했어요"); // 복호화 확인
+    }
+
+    @Test
+    @DisplayName("1~2글자 키워드는 검색을 거부한다")
+    void should_rejectKeyword_when_shorterThanThree() {
+        Long sender = createUser("b@test.com", "영희");
+        Long roomId = createRoomWithMembers(sender);
+        sendMessageUseCase.sendMessage(roomId, sender, "안녕하세요 반갑습니다");
+
+        assertThatThrownBy(() -> searchMessageUseCase.searchInChatRoom(roomId, sender, "안녕", 0, 20))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("3글자");
+    }
+
+    @Test
+    @DisplayName("트라이그램은 맞지만 substring이 아닌 false positive는 2단계 복호화 검증에서 제거된다")
+    void should_removeFalsePositive_when_substringNotPresent() {
+        Long sender = createUser("c@test.com", "민수");
+        Long roomId = createRoomWithMembers(sender);
+
+        // "비밀번호"의 트라이그램(비밀번/밀번호)이 흩어져 존재하지만 연속 substring은 아닌 메시지
+        Message falsePositive = sendMessageUseCase.sendMessage(roomId, sender, "비밀번 얘기와 번호 변경");
+        Message realHit = sendMessageUseCase.sendMessage(roomId, sender, "새 비밀번호 설정 완료");
+
+        List<Message> results = searchMessageUseCase.searchInChatRoom(roomId, sender, "비밀번호", 0, 20);
+
+        // 1단계 토큰 AND는 둘 다 후보가 될 수 있으나, 2단계 substring으로 realHit만 남아야 함
+        assertThat(results).extracting(Message::getId).containsExactly(realHit.getId());
+        assertThat(results).extracting(Message::getId).doesNotContain(falsePositive.getId());
+    }
+
+    @Test
+    @DisplayName("소프트 삭제된 메시지는 검색에서 제외된다")
+    void should_excludeSoftDeletedMessages() {
+        Long sender = createUser("d@test.com", "지수");
+        Long roomId = createRoomWithMembers(sender);
+
+        Message alive = sendMessageUseCase.sendMessage(roomId, sender, "회의시간 정합시다");
+        Message toDelete = sendMessageUseCase.sendMessage(roomId, sender, "회의시간 취소됐어요");
+
+        // 소프트 삭제 (토큰은 유지되지만 검색에서 deleted 필터로 제외돼야 함)
+        toDelete.delete(java.time.LocalDateTime.now());
+        messageRepository.save(toDelete);
+
+        List<Message> results = searchMessageUseCase.searchInChatRoom(roomId, sender, "회의시간", 0, 20);
+        assertThat(results).extracting(Message::getId).containsExactly(alive.getId());
+    }
+
+    @Test
+    @DisplayName("멤버가 아닌 방의 메시지는 검색되지 않는다 (멤버십 격리)")
+    void should_isolateByMembership() {
+        Long alice = createUser("e@test.com", "앨리스");
+        Long bob = createUser("f@test.com", "밥");
+        Long aliceRoom = createRoomWithMembers(alice);
+        Long bobRoom = createRoomWithMembers(bob);
+
+        sendMessageUseCase.sendMessage(aliceRoom, alice, "공통키워드 앨리스방");
+        sendMessageUseCase.sendMessage(bobRoom, bob, "공통키워드 밥방");
+
+        // 전체 검색: alice는 자기 방 메시지만 봐야 함
+        List<Message> aliceResults = searchMessageUseCase.searchAcrossAllChatRooms(alice, "공통키워드", 0, 20);
+        assertThat(aliceResults).hasSize(1);
+        assertThat(aliceResults.get(0).getChatRoomId()).isEqualTo(aliceRoom);
+
+        // 채팅방 검색: alice가 bob의 방을 검색하면 멤버십 거부
+        assertThatThrownBy(() -> searchMessageUseCase.searchInChatRoom(bobRoom, alice, "공통키워드", 0, 20))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("over-fetch 페이징: substring 통과분을 size만큼만 반환한다")
+    void should_limitToSize_afterOverFetch() {
+        Long sender = createUser("g@test.com", "토끼");
+        Long roomId = createRoomWithMembers(sender);
+
+        for (int i = 0; i < 5; i++) {
+            sendMessageUseCase.sendMessage(roomId, sender, "회의시간 안내 " + i);
+        }
+
+        List<Message> results = searchMessageUseCase.searchInChatRoom(roomId, sender, "회의시간", 0, 2);
+        assertThat(results).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("메시지 수정 시 재토큰화되어 새 키워드로 검색되고 옛 키워드로는 검색되지 않는다")
+    void should_reTokenize_onUpdate() {
+        Long sender = createUser("h@test.com", "거북이");
+        Long roomId = createRoomWithMembers(sender);
+
+        Message msg = sendMessageUseCase.sendMessage(roomId, sender, "원본키워드 메시지");
+        // 옛 키워드로 검색되는지 먼저 확인
+        assertThat(searchMessageUseCase.searchInChatRoom(roomId, sender, "원본키워드", 0, 20)).hasSize(1);
+
+        // 수정 (5분 이내라 가능) — 본문 교체
+        updateMessageUseCase.updateMessage(msg.getId(), sender, "변경키워드 새내용");
+
+        // 새 키워드로는 검색되고
+        assertThat(searchMessageUseCase.searchInChatRoom(roomId, sender, "변경키워드", 0, 20))
+                .extracting(Message::getId).containsExactly(msg.getId());
+        // 옛 키워드로는 검색되지 않아야 함 (delete-then-insert 재토큰화)
+        assertThat(searchMessageUseCase.searchInChatRoom(roomId, sender, "원본키워드", 0, 20)).isEmpty();
+    }
+}

--- a/src/test/resources/application-ratelimit-test.yml
+++ b/src/test/resources/application-ratelimit-test.yml
@@ -65,3 +65,5 @@ app:
   encryption:
     key: dGhpc2lzYXRlc3RrZXlmb3JkZXZlbG9wbWVudG9ubHk=
     enabled: false
+  search:
+    blind-index-secret: dGVzdC1ibGluZC1pbmRleC1zZWNyZXQtZm9yLXVuaXQtdGVzdHM=

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -53,3 +53,6 @@ app:
   encryption:
     key: dGhpc2lzYXRlc3RrZXlmb3JkZXZlbG9wbWVudG9ubHk=
     enabled: false  # 테스트에서는 암호화 비활성화 (검색 테스트 등)
+  search:
+    # 블라인드 인덱스 HMAC 시크릿 (테스트 고정 더미값)
+    blind-index-secret: dGVzdC1ibGluZC1pbmRleC1zZWNyZXQtZm9yLXVuaXQtdGVzdHM=


### PR DESCRIPTION
## 배경
`Message.content`는 AES-256-GCM(랜덤 IV) 애플리케이션 암호화로 저장되어, 같은 평문도 매번 다른 암호문이 된다. 기존 검색은 **암호문 컬럼**을 `LOWER(content) LIKE '%keyword%'`로 조회해 운영(암호화 ON)에서 **0건**이 되는 기능 정지 상태였다. #172의 trgm GIN 인덱스도 암호문 트라이그램이라 무의미해 닫았다.

근본 원인: 단위/JPA 테스트가 `encryption.enabled=false`로 돌아 평문 LIKE가 통과했고, prod(암호화 ON)에서만 깨졌다. **암호화 ON + 실제 검색** 통합테스트가 없었던 것이 재발 원인이다.

## 변경 — Blind Index (HMAC 트라이그램 토큰 + 2단계 검색)
평문 글자 단위 3-gram을 HMAC-SHA256으로 변환한 **결정적 토큰**을 별도 테이블(`message_search_tokens`)에 적재하고, 2단계로 검색한다.

1. **1단계(DB)**: 키워드를 동일 파이프라인으로 토큰화 → `token IN :tokens GROUP BY message_id HAVING COUNT(DISTINCT token)=:n`으로 "모든 트라이그램을 포함하는 메시지"를 조회(over-fetch).
2. **2단계(앱)**: JPA `@Convert`로 복호화된 본문을 동일 규칙으로 정규화 후 `contains`로 substring 최종 검증 → 트라이그램 흩어짐 **false positive 제거**(정확도의 진실).

주요 구성:
- Flyway `V17`: `message_search_tokens(message_id, token VARCHAR(24), PK(message_id,token), FK→messages ON DELETE CASCADE)` + `idx_mst_token`. 토큰은 exact match라 trgm/GIN 불필요, B-Tree 하나로 충분.
- domain 포트 `BlindIndexTokenizer`/`MessageSearchTokenRepository`, infra `HmacBlindIndexTokenizer`(NFC·소문자·공백제거·글자단위 3-gram·HMAC·truncate base64url). 헥사고날 의존 방향 준수(ArchUnit green).
- `SendMessageService` save 직후(같은 트랜잭션) TEXT 토큰 적재, `UpdateMessageService` 재토큰화(delete-then-insert), `SearchMessageService` 길이 가드+토큰화+복호화 substring 필터.
- #172 trgm: main에 V16 trgm 인덱스가 머지되지 않아(닫힌 PR) 제거 마이그레이션 불필요. 닉네임 trgm은 손대지 않음.

## 채택된 결정 (설계 12절)
1. **1~2글자 키워드: 3글자 미만 검색 거부**(`SearchMessageService` 가드, 400/"3글자 이상" 안내).
2. **HMAC secret: AES 키와 완전 분리** — `app.search.blind-index-secret`(Base64, 기본값 없음/prod 필수, test 고정 더미).
3. **파일명 검색: 1차 TEXT만** 토큰화(FILE/IMAGE/SYSTEM 제외).
4. **수정 재토큰화 / 소프트삭제 토큰 유지** + 검색에서 `deleted=false` 필터.
5. **페이징: over-fetch(×3)** — 2단계 검증으로 정확 페이지 크기 미보장(approximate) 수용.
6. **백필은 PR2(범위 외)** — 신규 메시지부터 검색 동작(기존은 점진).

## 재발방지 — 암호화 ON 통합테스트
`MessageSearchBlindIndexIntegrationTest`: **PostgreSQL testcontainer + 실제 Flyway V17 + 암호화 ON + 고정 키/시크릿**(prod 동등). DB raw content가 평문과 다름(=실제 암호화 확인, 항진 아님)을 단언하고, 부분일치 매칭·1~2글자 거부·false positive 2단계 제거·소프트삭제 제외·멤버십 격리·over-fetch 페이징·수정 재토큰화를 검증한다.

## 한계 (설계 7절)
- 1~2글자 키워드 미지원(트라이그램 불가).
- 결정적 토큰은 빈도분석/존재추론 메타데이터 누출 잔존(HMAC 시크릿이 단일 방어선, 평문 복원은 불가). 토큰 별도 테이블 격리·truncation으로 완화.

## 검증
- `./gradlew build` 성공, 전체 **1729 tests / 0 failures / 0 errors**, ArchUnit green, JaCoCo 60% 게이트 통과.
- 통합테스트가 암호화 ON에서 실제 검색 동작을 검증(testcontainers PostgreSQL).