### PR TITLE
feat(search): 기존 암호화 메시지 blind index 백필 (PR2)

### DIFF
--- a/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageJpaRepository.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageJpaRepository.java
@@ -313,4 +313,18 @@ public interface MessageJpaRepository extends JpaRepository<Message, Long> {
      * @param senderId 발신자(사용자) ID
      */
     void deleteBySenderId(Long senderId);
+
+    /**
+     * 검색 토큰 백필 대상이 되는 TEXT(미삭제) 메시지를 {@code id} 오름차순 커서 청크로 조회한다. (PR2)
+     *
+     * <p>조건: {@code id > afterId AND type = 'TEXT' AND is_deleted = false}.
+     * 대량 데이터를 메모리에 한 번에 올리지 않도록 {@code afterId} 커서 + {@code Pageable} limit로
+     * 제한된 범위만 조회한다. 반환 메시지의 {@code content}는 JPA 컨버터로 이미 복호화된 평문이다.</p>
+     *
+     * @param afterId  이 ID보다 큰 메시지만 조회 (커서)
+     * @param pageable 청크 크기(limit) 정보
+     * @return id 오름차순 TEXT 미삭제 메시지 목록
+     */
+    @Query("SELECT m FROM Message m WHERE m.id > :afterId AND m.type = com.cotalk.domain.entity.Message.MessageType.TEXT AND m.deleted = false ORDER BY m.id ASC")
+    List<Message> findTextMessagesForBackfill(@Param("afterId") long afterId, Pageable pageable);
 }

--- a/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageSearchBackfillAdapter.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageSearchBackfillAdapter.java
@@ -1,0 +1,48 @@
+package com.cotalk.adapter.outbound.persistence.message;
+
+import com.cotalk.domain.entity.Message;
+import com.cotalk.domain.port.outbound.MessageSearchBackfillPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+/**
+ * 기존 메시지 검색 토큰 백필용 영속성 어댑터 (PR2).
+ *
+ * <p>{@link MessageSearchBackfillPort}를 JPA로 구현한다. {@code id} 커서 청크 조회와
+ * 토큰 존재 여부 확인을 제공한다.</p>
+ *
+ * @author seunggu.lee
+ */
+@Repository
+@RequiredArgsConstructor
+public class MessageSearchBackfillAdapter implements MessageSearchBackfillPort {
+
+    private final MessageJpaRepository messageJpaRepository;
+    private final MessageSearchTokenJpaRepository messageSearchTokenJpaRepository;
+
+    /**
+     * TEXT(미삭제) 메시지를 id 오름차순 커서 청크로 조회한다.
+     *
+     * @param afterId   커서 (이 ID보다 큰 메시지)
+     * @param chunkSize 청크 크기
+     * @return id 오름차순 메시지 목록
+     */
+    @Override
+    public List<Message> findTextMessagesForBackfill(long afterId, int chunkSize) {
+        return messageJpaRepository.findTextMessagesForBackfill(afterId, PageRequest.of(0, chunkSize));
+    }
+
+    /**
+     * 메시지에 검색 토큰이 이미 존재하는지 확인한다.
+     *
+     * @param messageId 메시지 ID
+     * @return 토큰이 존재하면 {@code true}
+     */
+    @Override
+    public boolean hasTokens(long messageId) {
+        return messageSearchTokenJpaRepository.existsByMessageId(messageId);
+    }
+}

--- a/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageSearchBackfillAdapter.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageSearchBackfillAdapter.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * 기존 메시지 검색 토큰 백필용 영속성 어댑터 (PR2).
@@ -36,13 +37,19 @@ public class MessageSearchBackfillAdapter implements MessageSearchBackfillPort {
     }
 
     /**
-     * 메시지에 검색 토큰이 이미 존재하는지 확인한다.
+     * 주어진 메시지 ID 집합 중 이미 검색 토큰이 적재된 ID들을 한 번의 {@code IN} 쿼리로 조회한다.
      *
-     * @param messageId 메시지 ID
-     * @return 토큰이 존재하면 {@code true}
+     * <p>청크당 SELECT 1회로 skip-existing N+1을 제거한다. 빈 입력이면 DB 조회 없이 빈 집합을
+     * 반환한다(빈 {@code IN} 절 회피).</p>
+     *
+     * @param messageIds 확인할 메시지 ID 목록
+     * @return 토큰이 존재하는 메시지 ID 집합
      */
     @Override
-    public boolean hasTokens(long messageId) {
-        return messageSearchTokenJpaRepository.existsByMessageId(messageId);
+    public Set<Long> findExistingTokenMessageIds(List<Long> messageIds) {
+        if (messageIds == null || messageIds.isEmpty()) {
+            return Set.of();
+        }
+        return Set.copyOf(messageSearchTokenJpaRepository.findExistingTokenMessageIds(messageIds));
     }
 }

--- a/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageSearchTokenJpaRepository.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageSearchTokenJpaRepository.java
@@ -21,4 +21,12 @@ public interface MessageSearchTokenJpaRepository
     @Modifying
     @Query("DELETE FROM MessageSearchTokenJpaEntity t WHERE t.messageId = :messageId")
     void deleteByMessageId(@Param("messageId") Long messageId);
+
+    /**
+     * 특정 메시지에 검색 토큰이 1개 이상 존재하는지 확인한다. (백필 skip-existing 최적화용)
+     *
+     * @param messageId 메시지 ID
+     * @return 토큰이 존재하면 {@code true}
+     */
+    boolean existsByMessageId(Long messageId);
 }

--- a/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageSearchTokenJpaRepository.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageSearchTokenJpaRepository.java
@@ -5,6 +5,9 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
+import java.util.List;
+
 /**
  * 메시지 검색 토큰 JPA 리포지토리.
  *
@@ -23,10 +26,14 @@ public interface MessageSearchTokenJpaRepository
     void deleteByMessageId(@Param("messageId") Long messageId);
 
     /**
-     * 특정 메시지에 검색 토큰이 1개 이상 존재하는지 확인한다. (백필 skip-existing 최적화용)
+     * 주어진 메시지 ID들 중 검색 토큰이 1개 이상 존재하는 ID를 한 번의 {@code IN} 쿼리로 조회한다.
+     * (백필 skip-existing N+1 방지용)
      *
-     * @param messageId 메시지 ID
-     * @return 토큰이 존재하면 {@code true}
+     * <p>청크의 모든 message_id를 한 번에 조회해 청크당 SELECT를 1회로 줄인다.</p>
+     *
+     * @param messageIds 확인할 메시지 ID 목록
+     * @return 토큰이 존재하는 message_id의 distinct 목록
      */
-    boolean existsByMessageId(Long messageId);
+    @Query("SELECT DISTINCT t.messageId FROM MessageSearchTokenJpaEntity t WHERE t.messageId IN :messageIds")
+    List<Long> findExistingTokenMessageIds(@Param("messageIds") Collection<Long> messageIds);
 }

--- a/src/main/java/com/cotalk/application/service/message/MessageSearchBackfillService.java
+++ b/src/main/java/com/cotalk/application/service/message/MessageSearchBackfillService.java
@@ -27,8 +27,12 @@ import java.util.Set;
  *       토큰 PK가 {@code (message_id, token)}이라 중복 적재가 발생하지 않으며, 몇 번을 다시 돌려도
  *       결과가 동일하다.</li>
  *   <li><b>중단 복구</b>: 진행 커서가 {@code id} 기반이라 마지막으로 처리한 ID부터 재개하면 그대로
- *       이어진다(매 실행은 0부터 시작하되 처리 완료분은 idempotent로 재처리, 작은 데이터면 단순).
- *       처리 진행 로그로 마지막 커서를 추적할 수 있다.</li>
+ *       이어진다. 다만 커서를 영속화하지 않아 매 실행은 항상 {@code cursor=0}부터 시작하되,
+ *       이미 처리된 메시지는 {@code skipExisting}(청크당 1회 배치 IN 조회)로 복호화/HMAC 없이
+ *       건너뛰어 재처리 비용이 낮다. 이는 본 작업이 <b>1회성 관리 작업</b>이고 delete-then-insert로
+ *       완전 idempotent하기 때문에 택한 의도적 단순화다(상태 테이블 도입의 운영 복잡도 회피).
+ *       <b>한계:</b> 매우 큰 데이터에서 중단 후 재기동하면 처음부터 다시 스캔하므로(처리분은 skip)
+ *       완료까지 시간이 더 걸릴 수 있다. 진행 로그의 "마지막 커서 id"로 진척도를 추적한다.</li>
  *   <li><b>부하 제어</b>: {@code skipExisting=true}면 이미 토큰이 있는 메시지(신규 PR1 적재분)는
  *       복호화/HMAC 없이 건너뛴다. 청크마다 {@code throttleMillis}만큼 슬립해 운영 윈도우 부하를 낮춘다.</li>
  * </ul>
@@ -86,30 +90,39 @@ public class MessageSearchBackfillService {
         long indexed = 0L;
         long skipped = 0L;
 
-        while (true) {
-            List<Message> chunk = backfillPort.findTextMessagesForBackfill(cursor, opts.chunkSize());
-            if (chunk.isEmpty()) {
-                break;
+        try {
+            while (true) {
+                List<Message> chunk = backfillPort.findTextMessagesForBackfill(cursor, opts.chunkSize());
+                if (chunk.isEmpty()) {
+                    break;
+                }
+
+                ChunkResult chunkResult = processChunk(chunk, opts);
+                scanned += chunk.size();
+                indexed += chunkResult.indexed();
+                skipped += chunkResult.skipped();
+                cursor = chunkResult.lastId();
+
+                log.info("백필 진행: 누적 scanned={}, indexed={}, skipped={}, 마지막 커서 id={}",
+                        scanned, indexed, skipped, cursor);
+
+                throttle(opts.throttleMillis());
+
+                // 마지막 청크(요청 크기 미만)면 더 이상 조회할 게 없으므로 종료
+                if (chunk.size() < opts.chunkSize()) {
+                    break;
+                }
             }
-
-            ChunkResult chunkResult = processChunk(chunk, opts);
-            scanned += chunk.size();
-            indexed += chunkResult.indexed();
-            skipped += chunkResult.skipped();
-            cursor = chunkResult.lastId();
-
-            log.info("백필 진행: 누적 scanned={}, indexed={}, skipped={}, 마지막 커서 id={}",
-                    scanned, indexed, skipped, cursor);
-
-            throttle(opts.throttleMillis());
-
-            // 마지막 청크(요청 크기 미만)면 더 이상 조회할 게 없으므로 종료
-            if (chunk.size() < opts.chunkSize()) {
-                break;
-            }
+        } catch (RuntimeException e) {
+            // 청크 처리 중 실패: 이 청크는 트랜잭션 롤백되어 미반영이므로, 직전 청크까지의 진행분을
+            // completed=false로 반환한다. 운영자가 "완료"로 오인하지 않도록 가시성을 확보하고,
+            // idempotent(skipExisting)이라 재실행으로 마지막 커서 이후를 다시 이어갈 수 있다.
+            BackfillResult partial = new BackfillResult(scanned, indexed, skipped, cursor, false);
+            log.error("메시지 검색 토큰 백필 중단(실패): {} — 재실행으로 재개 가능(idempotent)", partial, e);
+            throw new BackfillInterruptedException(partial, e);
         }
 
-        BackfillResult result = new BackfillResult(scanned, indexed, skipped, cursor);
+        BackfillResult result = new BackfillResult(scanned, indexed, skipped, cursor, true);
         log.info("메시지 검색 토큰 백필 완료: {}", result);
         return result;
     }
@@ -122,14 +135,21 @@ public class MessageSearchBackfillService {
      * @return 이 청크의 색인/스킵 건수와 마지막 메시지 ID
      */
     private ChunkResult processChunk(List<Message> chunk, BackfillOptions options) {
-        ChunkResult fallback = new ChunkResult(0L, 0L, chunk.get(chunk.size() - 1).getId());
-        ChunkResult result = transactionTemplate.execute(status -> {
+        // skip-existing N+1 방지: 청크의 message_id들을 한 번의 IN 쿼리로 미리 조회한다.
+        // (skipExisting=false면 조회 자체를 생략한다.)
+        Set<Long> existingTokenIds = options.skipExisting()
+                ? backfillPort.findExistingTokenMessageIds(chunk.stream().map(Message::getId).toList())
+                : Set.of();
+
+        // 콜백은 항상 non-null ChunkResult를 반환하고, TransactionTemplate은 콜백 반환값을
+        // 그대로 돌려주므로(예외 시 throw) 여기서 result는 절대 null이 아니다.
+        return transactionTemplate.execute(status -> {
             long indexed = 0L;
             long skipped = 0L;
             long lastId = 0L;
             for (Message message : chunk) {
                 lastId = message.getId();
-                if (options.skipExisting() && backfillPort.hasTokens(message.getId())) {
+                if (options.skipExisting() && existingTokenIds.contains(message.getId())) {
                     skipped++;
                     continue;
                 }
@@ -143,7 +163,6 @@ public class MessageSearchBackfillService {
             }
             return new ChunkResult(indexed, skipped, lastId);
         });
-        return result == null ? fallback : result;
     }
 
     private void throttle(long throttleMillis) {
@@ -205,10 +224,46 @@ public class MessageSearchBackfillService {
     /**
      * 백필 결과 요약.
      *
-     * @param scanned   조회(스캔)한 총 메시지 수
-     * @param indexed   토큰을 적재한 메시지 수
-     * @param skipped   이미 토큰이 있어 건너뛴 메시지 수
-     * @param lastCursorId 마지막으로 처리한 메시지 ID(중단/재개 추적용)
+     * @param scanned      조회(스캔)한 총 메시지 수
+     * @param indexed      토큰을 적재한 메시지 수
+     * @param skipped      이미 토큰이 있어 건너뛴 메시지 수
+     * @param lastCursorId 마지막으로 처리(커밋)한 메시지 ID(중단/재개 추적용)
+     * @param completed    전체 백필이 끝까지 정상 완료되었는지 여부.
+     *                     {@code false}면 중간에 실패해 진행분만 반영된 상태(재실행 필요)
      */
-    public record BackfillResult(long scanned, long indexed, long skipped, long lastCursorId) {}
+    public record BackfillResult(long scanned, long indexed, long skipped, long lastCursorId, boolean completed) {}
+
+    /**
+     * 백필이 중간에 실패해 끝까지 완료되지 못했음을 나타내는 예외.
+     *
+     * <p>실패 시점까지의 부분 진행 결과({@link #partialResult()})를 함께 담아, 운영자가 진행분과
+     * 마지막 커서를 확인하고 재실행(idempotent)으로 재개할 수 있게 한다. 호출자(러너)는 이를
+     * "완료"가 아닌 "중단/실패"로 명확히 구분해 보고해야 한다.</p>
+     *
+     * @author seunggu.lee
+     */
+    public static class BackfillInterruptedException extends RuntimeException {
+
+        private final transient BackfillResult partialResult;
+
+        /**
+         * 부분 결과와 원인 예외로 중단 예외를 만든다.
+         *
+         * @param partialResult 실패 시점까지의 진행 결과({@code completed=false})
+         * @param cause         원인 예외
+         */
+        public BackfillInterruptedException(BackfillResult partialResult, Throwable cause) {
+            super("백필이 중간에 중단되었습니다: " + partialResult, cause);
+            this.partialResult = partialResult;
+        }
+
+        /**
+         * 실패 시점까지의 부분 진행 결과를 반환한다.
+         *
+         * @return 부분 결과({@code completed=false})
+         */
+        public BackfillResult partialResult() {
+            return partialResult;
+        }
+    }
 }

--- a/src/main/java/com/cotalk/application/service/message/MessageSearchBackfillService.java
+++ b/src/main/java/com/cotalk/application/service/message/MessageSearchBackfillService.java
@@ -1,0 +1,214 @@
+package com.cotalk.application.service.message;
+
+import com.cotalk.domain.entity.Message;
+import com.cotalk.domain.port.outbound.BlindIndexTokenizer;
+import com.cotalk.domain.port.outbound.MessageSearchBackfillPort;
+import com.cotalk.domain.port.outbound.MessageSearchTokenRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 기존 암호화 메시지 검색 토큰 백필 서비스 (PR2).
+ *
+ * <p>PR1(블라인드 인덱스 인프라)은 신규 메시지부터만 {@code message_search_tokens}에 토큰을
+ * 적재한다. 이 서비스는 그 이전에 저장된 모든 TEXT(미삭제) 메시지를 복호화 → 토큰화 →
+ * 토큰 적재하여 과거 메시지도 검색되도록 복구하는 <b>1회성 관리 작업</b>이다.</p>
+ *
+ * <h2>처리 방식</h2>
+ * <ul>
+ *   <li><b>커서 청크</b>: {@code id} 오름차순 커서로 {@code chunkSize}건씩 순회한다
+ *       ({@link MessageSearchBackfillPort#findTextMessagesForBackfill}). 전체를 메모리에 올리지 않는다.</li>
+ *   <li><b>청크 단위 트랜잭션</b>: 청크 하나를 한 트랜잭션으로 커밋한다. 장기 트랜잭션/락을 피한다.</li>
+ *   <li><b>재실행 안전(idempotent)</b>: 메시지별 {@code deleteByMessageId} 후 재적재(delete-then-insert).
+ *       토큰 PK가 {@code (message_id, token)}이라 중복 적재가 발생하지 않으며, 몇 번을 다시 돌려도
+ *       결과가 동일하다.</li>
+ *   <li><b>중단 복구</b>: 진행 커서가 {@code id} 기반이라 마지막으로 처리한 ID부터 재개하면 그대로
+ *       이어진다(매 실행은 0부터 시작하되 처리 완료분은 idempotent로 재처리, 작은 데이터면 단순).
+ *       처리 진행 로그로 마지막 커서를 추적할 수 있다.</li>
+ *   <li><b>부하 제어</b>: {@code skipExisting=true}면 이미 토큰이 있는 메시지(신규 PR1 적재분)는
+ *       복호화/HMAC 없이 건너뛴다. 청크마다 {@code throttleMillis}만큼 슬립해 운영 윈도우 부하를 낮춘다.</li>
+ * </ul>
+ *
+ * <h2>헥사고날</h2>
+ * <p>application 서비스는 아웃바운드 포트({@link MessageSearchBackfillPort},
+ * {@link MessageSearchTokenRepository}, {@link BlindIndexTokenizer})만 의존하며 infrastructure를
+ * 직접 참조하지 않는다(ArchUnit 준수).</p>
+ *
+ * @author seunggu.lee
+ */
+@Slf4j
+@Service
+public class MessageSearchBackfillService {
+
+    private final MessageSearchBackfillPort backfillPort;
+    private final MessageSearchTokenRepository messageSearchTokenRepository;
+    private final BlindIndexTokenizer blindIndexTokenizer;
+    private final TransactionTemplate transactionTemplate;
+
+    /**
+     * 백필 서비스 생성자.
+     *
+     * @param backfillPort                 백필 대상 메시지 청크 조회 포트
+     * @param messageSearchTokenRepository 검색 토큰 적재/삭제 포트
+     * @param blindIndexTokenizer          블라인드 인덱스 토큰화 포트
+     * @param transactionTemplate          청크 단위 트랜잭션 템플릿
+     */
+    public MessageSearchBackfillService(MessageSearchBackfillPort backfillPort,
+                                        MessageSearchTokenRepository messageSearchTokenRepository,
+                                        BlindIndexTokenizer blindIndexTokenizer,
+                                        TransactionTemplate transactionTemplate) {
+        this.backfillPort = backfillPort;
+        this.messageSearchTokenRepository = messageSearchTokenRepository;
+        this.blindIndexTokenizer = blindIndexTokenizer;
+        this.transactionTemplate = transactionTemplate;
+    }
+
+    /**
+     * 기존 TEXT 메시지의 검색 토큰을 백필한다.
+     *
+     * <p>{@code id} 오름차순 커서로 청크를 반복 조회해, 청크 단위 트랜잭션 안에서 각 메시지를
+     * delete-then-insert로 재토큰화한다. 더 이상 처리할 메시지가 없으면(빈 청크) 종료한다.</p>
+     *
+     * @param options 백필 옵션(청크 크기, throttle, skip-existing)
+     * @return 백필 결과 요약(스캔/색인/스킵 건수, 마지막 커서)
+     */
+    public BackfillResult backfill(BackfillOptions options) {
+        BackfillOptions opts = options == null ? BackfillOptions.defaults() : options.sanitized();
+        log.info("메시지 검색 토큰 백필 시작: chunkSize={}, throttleMillis={}, skipExisting={}",
+                opts.chunkSize(), opts.throttleMillis(), opts.skipExisting());
+
+        long cursor = 0L;
+        long scanned = 0L;
+        long indexed = 0L;
+        long skipped = 0L;
+
+        while (true) {
+            List<Message> chunk = backfillPort.findTextMessagesForBackfill(cursor, opts.chunkSize());
+            if (chunk.isEmpty()) {
+                break;
+            }
+
+            ChunkResult chunkResult = processChunk(chunk, opts);
+            scanned += chunk.size();
+            indexed += chunkResult.indexed();
+            skipped += chunkResult.skipped();
+            cursor = chunkResult.lastId();
+
+            log.info("백필 진행: 누적 scanned={}, indexed={}, skipped={}, 마지막 커서 id={}",
+                    scanned, indexed, skipped, cursor);
+
+            throttle(opts.throttleMillis());
+
+            // 마지막 청크(요청 크기 미만)면 더 이상 조회할 게 없으므로 종료
+            if (chunk.size() < opts.chunkSize()) {
+                break;
+            }
+        }
+
+        BackfillResult result = new BackfillResult(scanned, indexed, skipped, cursor);
+        log.info("메시지 검색 토큰 백필 완료: {}", result);
+        return result;
+    }
+
+    /**
+     * 청크 하나를 한 트랜잭션으로 처리한다(메시지별 delete-then-insert 재토큰화).
+     *
+     * @param chunk   처리할 메시지 청크(id 오름차순)
+     * @param options 백필 옵션
+     * @return 이 청크의 색인/스킵 건수와 마지막 메시지 ID
+     */
+    private ChunkResult processChunk(List<Message> chunk, BackfillOptions options) {
+        ChunkResult fallback = new ChunkResult(0L, 0L, chunk.get(chunk.size() - 1).getId());
+        ChunkResult result = transactionTemplate.execute(status -> {
+            long indexed = 0L;
+            long skipped = 0L;
+            long lastId = 0L;
+            for (Message message : chunk) {
+                lastId = message.getId();
+                if (options.skipExisting() && backfillPort.hasTokens(message.getId())) {
+                    skipped++;
+                    continue;
+                }
+                Set<String> tokens = blindIndexTokenizer.tokenize(message.getContent());
+                // idempotent: 기존 토큰 제거 후 재적재. 토큰이 비어도(3글자 미만) 기존 토큰은 정리한다.
+                messageSearchTokenRepository.deleteByMessageId(message.getId());
+                if (!tokens.isEmpty()) {
+                    messageSearchTokenRepository.saveTokens(message.getId(), tokens);
+                    indexed++;
+                }
+            }
+            return new ChunkResult(indexed, skipped, lastId);
+        });
+        return result == null ? fallback : result;
+    }
+
+    private void throttle(long throttleMillis) {
+        if (throttleMillis <= 0) {
+            return;
+        }
+        try {
+            Thread.sleep(throttleMillis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("백필 throttle 슬립이 인터럽트되었습니다. 백필을 중단합니다.");
+            throw new IllegalStateException("백필이 인터럽트로 중단되었습니다.", e);
+        }
+    }
+
+    /**
+     * 한 청크 처리 결과(내부용).
+     *
+     * @param indexed 토큰을 적재한 메시지 수
+     * @param skipped 스킵한 메시지 수
+     * @param lastId  처리한 마지막 메시지 ID(다음 커서)
+     */
+    private record ChunkResult(long indexed, long skipped, long lastId) {}
+
+    /**
+     * 백필 실행 옵션.
+     *
+     * @param chunkSize      한 청크(=한 트랜잭션) 당 메시지 수
+     * @param throttleMillis 청크 사이 슬립(ms). 0이면 슬립 없음
+     * @param skipExisting   이미 토큰이 있는 메시지는 건너뛸지 여부
+     */
+    public record BackfillOptions(int chunkSize, long throttleMillis, boolean skipExisting) {
+
+        /** 기본 청크 크기. */
+        public static final int DEFAULT_CHUNK_SIZE = 500;
+        private static final int MAX_CHUNK_SIZE = 5000;
+
+        /**
+         * 안전 기본 옵션을 만든다(청크 500, throttle 0, skip-existing true).
+         *
+         * @return 기본 옵션
+         */
+        public static BackfillOptions defaults() {
+            return new BackfillOptions(DEFAULT_CHUNK_SIZE, 0L, true);
+        }
+
+        /**
+         * 비정상 값을 안전 범위로 보정한 옵션을 반환한다.
+         *
+         * @return 보정된 옵션
+         */
+        public BackfillOptions sanitized() {
+            int safeChunk = Math.min(Math.max(chunkSize, 1), MAX_CHUNK_SIZE);
+            long safeThrottle = Math.max(throttleMillis, 0L);
+            return new BackfillOptions(safeChunk, safeThrottle, skipExisting);
+        }
+    }
+
+    /**
+     * 백필 결과 요약.
+     *
+     * @param scanned   조회(스캔)한 총 메시지 수
+     * @param indexed   토큰을 적재한 메시지 수
+     * @param skipped   이미 토큰이 있어 건너뛴 메시지 수
+     * @param lastCursorId 마지막으로 처리한 메시지 ID(중단/재개 추적용)
+     */
+    public record BackfillResult(long scanned, long indexed, long skipped, long lastCursorId) {}
+}

--- a/src/main/java/com/cotalk/domain/port/outbound/MessageSearchBackfillPort.java
+++ b/src/main/java/com/cotalk/domain/port/outbound/MessageSearchBackfillPort.java
@@ -1,0 +1,47 @@
+package com.cotalk.domain.port.outbound;
+
+import com.cotalk.domain.entity.Message;
+
+import java.util.List;
+
+/**
+ * 기존 암호화 메시지의 검색 토큰 백필을 위한 아웃바운드 포트.
+ *
+ * <p>PR1(블라인드 인덱스 인프라)은 <b>신규</b> 메시지부터 토큰을 적재하므로,
+ * 그 이전에 저장된 메시지는 검색되지 않는다. 이 포트는 백필 작업이 기존 TEXT 메시지를
+ * {@code id} 커서 청크 단위로 순회하며 복호화(JPA {@code @Convert} 자동 처리)된 본문을 얻기 위한
+ * 조회 경로를 제공한다.</p>
+ *
+ * <p>대량 데이터를 한 번에 메모리에 올리지 않도록 반드시 커서({@code afterId}) + 청크 크기
+ * ({@code chunkSize})로 제한된 범위만 조회한다. 검색 대상이 아닌 FILE/IMAGE/SYSTEM 메시지와
+ * 소프트 삭제된 메시지는 제외한다.</p>
+ *
+ * @author seunggu.lee
+ */
+public interface MessageSearchBackfillPort {
+
+    /**
+     * 토큰 백필 대상이 되는 TEXT(미삭제) 메시지를 {@code id} 오름차순 커서 청크로 조회한다.
+     *
+     * <p>조건: {@code id > afterId AND type = 'TEXT' AND is_deleted = false},
+     * {@code ORDER BY id ASC LIMIT chunkSize}. 반환된 메시지의 {@code content}는 JPA 컨버터로
+     * 이미 복호화된 평문이다.</p>
+     *
+     * @param afterId   이 ID보다 큰 메시지만 조회 (커서; 첫 호출은 0)
+     * @param chunkSize 한 번에 조회할 최대 메시지 수
+     * @return id 오름차순 메시지 목록 (더 이상 없으면 빈 목록)
+     */
+    List<Message> findTextMessagesForBackfill(long afterId, int chunkSize);
+
+    /**
+     * 특정 메시지에 이미 검색 토큰이 적재되어 있는지 확인한다.
+     *
+     * <p>"이미 토큰이 있는 메시지는 건너뛰기(skip-existing)" 최적화에 사용한다. 백필 자체는
+     * delete-then-insert로 항상 idempotent하지만, 신규 메시지(PR1)로 이미 토큰이 있는 메시지의
+     * 불필요한 복호화/HMAC 재계산을 피해 대량 데이터에서 부하를 줄인다.</p>
+     *
+     * @param messageId 확인할 메시지 ID
+     * @return 토큰이 1개 이상 존재하면 {@code true}
+     */
+    boolean hasTokens(long messageId);
+}

--- a/src/main/java/com/cotalk/domain/port/outbound/MessageSearchBackfillPort.java
+++ b/src/main/java/com/cotalk/domain/port/outbound/MessageSearchBackfillPort.java
@@ -3,6 +3,7 @@ package com.cotalk.domain.port.outbound;
 import com.cotalk.domain.entity.Message;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * 기존 암호화 메시지의 검색 토큰 백필을 위한 아웃바운드 포트.
@@ -34,14 +35,18 @@ public interface MessageSearchBackfillPort {
     List<Message> findTextMessagesForBackfill(long afterId, int chunkSize);
 
     /**
-     * 특정 메시지에 이미 검색 토큰이 적재되어 있는지 확인한다.
+     * 주어진 메시지 ID 집합 중 이미 검색 토큰이 적재된 ID들을 한 번의 쿼리로 조회한다.
      *
      * <p>"이미 토큰이 있는 메시지는 건너뛰기(skip-existing)" 최적화에 사용한다. 백필 자체는
      * delete-then-insert로 항상 idempotent하지만, 신규 메시지(PR1)로 이미 토큰이 있는 메시지의
      * 불필요한 복호화/HMAC 재계산을 피해 대량 데이터에서 부하를 줄인다.</p>
      *
-     * @param messageId 확인할 메시지 ID
-     * @return 토큰이 1개 이상 존재하면 {@code true}
+     * <p><b>N+1 방지:</b> 청크의 메시지마다 단건 존재 조회를 하면 청크 크기만큼 SELECT가
+     * 발생한다. 이 메서드는 청크의 모든 message_id를 {@code IN} 절로 한 번에 조회해 청크당
+     * SELECT를 1회로 줄인다. 빈 입력이면 빈 집합을 반환한다.</p>
+     *
+     * @param messageIds 확인할 메시지 ID 목록(보통 한 청크)
+     * @return 토큰이 1개 이상 존재하는 메시지 ID 집합
      */
-    boolean hasTokens(long messageId);
+    Set<Long> findExistingTokenMessageIds(List<Long> messageIds);
 }

--- a/src/main/java/com/cotalk/infrastructure/config/MessageSearchBackfillRunner.java
+++ b/src/main/java/com/cotalk/infrastructure/config/MessageSearchBackfillRunner.java
@@ -1,6 +1,7 @@
 package com.cotalk.infrastructure.config;
 
 import com.cotalk.application.service.message.MessageSearchBackfillService;
+import com.cotalk.application.service.message.MessageSearchBackfillService.BackfillInterruptedException;
 import com.cotalk.application.service.message.MessageSearchBackfillService.BackfillOptions;
 import com.cotalk.application.service.message.MessageSearchBackfillService.BackfillResult;
 import com.cotalk.infrastructure.config.properties.AppProperties;
@@ -63,11 +64,21 @@ public class MessageSearchBackfillRunner implements ApplicationRunner {
 
         try {
             BackfillResult result = backfillService.backfill(options);
-            log.info("=== 백필 완료: scanned={}, indexed={}, skipped={}, 마지막 커서 id={} ===",
+            log.info("=== 백필 상태=SUCCESS(완료): scanned={}, indexed={}, skipped={}, 마지막 커서 id={} ===",
                     result.scanned(), result.indexed(), result.skipped(), result.lastCursorId());
+        } catch (BackfillInterruptedException e) {
+            // 백필이 중간에 실패해 일부만 반영됨. "완료"로 오인하지 않도록 상태=PARTIAL로 명확히 보고하고,
+            // 진행분/마지막 커서를 노출한다. 기동 실패로 번지지 않게 흡수하되(재실행 안전 — idempotent),
+            // 운영자가 재실행으로 재개해야 함을 강조한다.
+            BackfillResult partial = e.partialResult();
+            log.error("=== 백필 상태=PARTIAL(중단/실패): 끝까지 완료되지 못했습니다. "
+                            + "scanned={}, indexed={}, skipped={}, 마지막 커서 id={}. "
+                            + "idempotent하므로 재실행으로 재개 필요. ===",
+                    partial.scanned(), partial.indexed(), partial.skipped(), partial.lastCursorId(), e.getCause());
         } catch (RuntimeException e) {
-            // 기동 실패로 번지지 않도록 백필 실패는 로그로 남기고 흡수한다(재실행 안전 — idempotent).
-            log.error("=== 백필 실행 중 오류 발생. idempotent하므로 재실행으로 재개 가능합니다. ===", e);
+            // 백필 시작 전/조회 단계 등에서의 예기치 못한 실패. 진행 통계 없이 상태=FAILED로 보고.
+            log.error("=== 백필 상태=FAILED(실패): 진행 통계 없이 중단되었습니다. "
+                    + "idempotent하므로 재실행으로 재개 가능합니다. ===", e);
         }
     }
 }

--- a/src/main/java/com/cotalk/infrastructure/config/MessageSearchBackfillRunner.java
+++ b/src/main/java/com/cotalk/infrastructure/config/MessageSearchBackfillRunner.java
@@ -1,0 +1,73 @@
+package com.cotalk.infrastructure.config;
+
+import com.cotalk.application.service.message.MessageSearchBackfillService;
+import com.cotalk.application.service.message.MessageSearchBackfillService.BackfillOptions;
+import com.cotalk.application.service.message.MessageSearchBackfillService.BackfillResult;
+import com.cotalk.infrastructure.config.properties.AppProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * 기존 암호화 메시지 검색 토큰 백필 실행기 (PR2, 1회성 관리 작업).
+ *
+ * <p>{@code app.search.backfill.enabled=true}일 때만 빈으로 등록되어 애플리케이션 기동 직후
+ * {@link MessageSearchBackfillService#backfill}을 실행한다. 기본값은 false라 평상시 배포에서는
+ * 실행되지 않는다(실수 실행 방지).</p>
+ *
+ * <h2>운영 런북 (요약)</h2>
+ * <ul>
+ *   <li><b>실행</b>: 백필 전용 인스턴스(또는 운영 윈도우)에 환경변수
+ *       {@code SEARCH_BACKFILL_ENABLED=true}(또는 {@code app.search.backfill.enabled=true})로 기동.
+ *       청크/throttle은 {@code app.search.backfill.chunk-size},
+ *       {@code app.search.backfill.throttle-millis}로 조절.</li>
+ *   <li><b>모니터링</b>: 진행 로그("백필 진행: 누적 scanned/indexed/skipped, 마지막 커서 id=...")로
+ *       처리량과 커서를 추적. 완료 시 "백필 완료" 로그 + 결과 요약.</li>
+ *   <li><b>중단/재개</b>: idempotent(delete-then-insert) + {@code skipExisting}이라 다시 기동해도
+ *       안전하게 재개/재처리된다.</li>
+ *   <li><b>롤백</b>: {@code TRUNCATE message_search_tokens;}로 전체 토큰 제거(검색은 신규 메시지부터
+ *       다시 점진 채워짐). 부분 롤백이 필요하면 메시지 ID 범위로 {@code DELETE}.</li>
+ *   <li><b>완료 후</b>: {@code enabled=false}(기본)로 되돌려 재기동 시 재실행되지 않게 한다.</li>
+ * </ul>
+ *
+ * @author seunggu.lee
+ */
+@Slf4j
+@Component
+@Order(0)
+@ConditionalOnProperty(prefix = "app.search.backfill", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class MessageSearchBackfillRunner implements ApplicationRunner {
+
+    private final MessageSearchBackfillService backfillService;
+    private final AppProperties appProperties;
+
+    /**
+     * 애플리케이션 기동 시 백필을 1회 실행한다.
+     *
+     * @param args 애플리케이션 인자(미사용)
+     */
+    @Override
+    public void run(ApplicationArguments args) {
+        AppProperties.Backfill cfg = appProperties.search().backfill();
+        log.info("=== 기존 메시지 검색 토큰 백필 실행기 시작 (app.search.backfill.enabled=true) ===");
+
+        BackfillOptions options = new BackfillOptions(
+                cfg.chunkSize() <= 0 ? BackfillOptions.DEFAULT_CHUNK_SIZE : cfg.chunkSize(),
+                cfg.throttleMillis(),
+                cfg.skipExisting());
+
+        try {
+            BackfillResult result = backfillService.backfill(options);
+            log.info("=== 백필 완료: scanned={}, indexed={}, skipped={}, 마지막 커서 id={} ===",
+                    result.scanned(), result.indexed(), result.skipped(), result.lastCursorId());
+        } catch (RuntimeException e) {
+            // 기동 실패로 번지지 않도록 백필 실패는 로그로 남기고 흡수한다(재실행 안전 — idempotent).
+            log.error("=== 백필 실행 중 오류 발생. idempotent하므로 재실행으로 재개 가능합니다. ===", e);
+        }
+    }
+}

--- a/src/main/java/com/cotalk/infrastructure/config/properties/AppProperties.java
+++ b/src/main/java/com/cotalk/infrastructure/config/properties/AppProperties.java
@@ -114,13 +114,45 @@ public record AppProperties(
      * 프로덕션에서는 반드시 환경변수로 주입해야 하며 기본값이 없다(보안).</p>
      *
      * @param blindIndexSecret 블라인드 인덱스 HMAC 시크릿 (Base64, 기본값 없음)
+     * @param backfill         기존 메시지 검색 토큰 백필(1회성 관리 작업) 설정
      */
-    public record Search(String blindIndexSecret) {
+    public record Search(String blindIndexSecret, Backfill backfill) {
         public Search {
             if (blindIndexSecret == null) {
                 blindIndexSecret = "";
             }
+            if (backfill == null) {
+                backfill = new Backfill(false, 0, 0L, true);
+            }
         }
+
+        /**
+         * 백필 설정을 생략하고 시크릿만으로 {@link Search}를 만든다(백필 기본 비활성).
+         *
+         * <p>{@code @ConfigurationProperties} 생성자 바인딩이 모호해지지 않도록(단일 생성자 유지)
+         * 별도 생성자가 아닌 정적 팩터리로 제공한다. 테스트/수동 생성용.</p>
+         *
+         * @param blindIndexSecret 블라인드 인덱스 HMAC 시크릿
+         * @return 백필 기본값(비활성)을 가진 {@link Search}
+         */
+        public static Search of(String blindIndexSecret) {
+            return new Search(blindIndexSecret, null);
+        }
+    }
+
+    /**
+     * 기존 암호화 메시지 검색 토큰 백필(PR2) 설정.
+     *
+     * <p>대량 데이터를 복호화→토큰화→적재하는 1회성 관리 작업이라 실수 실행을 막기 위해
+     * 기본 비활성({@code enabled=false})이다. 운영에서는 {@code app.search.backfill.enabled=true}로
+     * 명시적으로 켜고, 청크 크기/throttle로 부하를 제어한다.</p>
+     *
+     * @param enabled        애플리케이션 기동 시 백필 자동 실행 여부 (기본 false — 안전)
+     * @param chunkSize      한 청크(=한 트랜잭션) 당 메시지 수 (0/음수면 서비스 기본 500)
+     * @param throttleMillis 청크 사이 슬립(ms). 운영 부하 제어용 (기본 0 = 슬립 없음)
+     * @param skipExisting   이미 토큰이 있는 메시지(신규 PR1 적재분)는 건너뛸지 여부 (기본 true)
+     */
+    public record Backfill(boolean enabled, int chunkSize, long throttleMillis, boolean skipExisting) {
     }
 
     /**
@@ -169,7 +201,7 @@ public record AppProperties(
             swagger = new Swagger("http://localhost:8080", "API 서버");
         }
         if (search == null) {
-            search = new Search("");
+            search = new Search("", null);
         }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -156,6 +156,13 @@ app:
     # AES 암호화 키와 완전히 분리된 별도 시크릿. 프로덕션: 반드시 환경변수로 설정 (기본값 없음)
     # 키 생성: openssl rand -base64 32
     blind-index-secret: ${BLIND_INDEX_SECRET}  # 필수 환경변수 - 기본값 없음 (보안)
+    # 기존 메시지 검색 토큰 백필(PR2, 1회성 관리 작업). 기본 비활성 — 실수 실행 방지.
+    # 운영: 백필 윈도우에서만 SEARCH_BACKFILL_ENABLED=true로 기동, 완료 후 다시 false.
+    backfill:
+      enabled: ${SEARCH_BACKFILL_ENABLED:false}             # true면 기동 시 1회 백필 실행
+      chunk-size: ${SEARCH_BACKFILL_CHUNK_SIZE:500}         # 한 트랜잭션 당 메시지 수
+      throttle-millis: ${SEARCH_BACKFILL_THROTTLE_MILLIS:0} # 청크 사이 슬립(부하 제어)
+      skip-existing: ${SEARCH_BACKFILL_SKIP_EXISTING:true}  # 이미 토큰이 있는 메시지는 건너뜀
   cors:
     allowed-origins: ${CORS_ALLOWED_ORIGINS:http://localhost:3000}
   redis:

--- a/src/test/java/com/cotalk/application/service/message/MessageSearchBackfillServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/message/MessageSearchBackfillServiceTest.java
@@ -1,5 +1,6 @@
 package com.cotalk.application.service.message;
 
+import com.cotalk.application.service.message.MessageSearchBackfillService.BackfillInterruptedException;
 import com.cotalk.application.service.message.MessageSearchBackfillService.BackfillOptions;
 import com.cotalk.application.service.message.MessageSearchBackfillService.BackfillResult;
 import com.cotalk.domain.entity.Message;
@@ -21,6 +22,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -114,12 +116,14 @@ class MessageSearchBackfillServiceTest {
         Message m1 = textMessage(10L, "이미 토큰 있음");
         Message m2 = textMessage(20L, "토큰 없음 신규");
         given(backfillPort.findTextMessagesForBackfill(0L, 500)).willReturn(List.of(m1, m2));
-        given(backfillPort.hasTokens(10L)).willReturn(true);
-        given(backfillPort.hasTokens(20L)).willReturn(false);
+        // 청크의 message_id들을 한 번에 배치 조회(N+1 방지). 10L만 토큰 존재.
+        given(backfillPort.findExistingTokenMessageIds(List.of(10L, 20L))).willReturn(Set.of(10L));
         given(blindIndexTokenizer.tokenize("토큰 없음 신규")).willReturn(Set.of("x"));
 
         BackfillResult result = service.backfill(new BackfillOptions(500, 0L, true));
 
+        // 단건 hasTokens가 아니라 청크당 1회 배치 조회만 일어난다(N+1 제거).
+        verify(backfillPort, times(1)).findExistingTokenMessageIds(List.of(10L, 20L));
         verify(blindIndexTokenizer, never()).tokenize("이미 토큰 있음");
         verify(messageSearchTokenRepository, never()).deleteByMessageId(10L);
         verify(messageSearchTokenRepository).deleteByMessageId(20L);
@@ -138,7 +142,8 @@ class MessageSearchBackfillServiceTest {
 
         service.backfill(new BackfillOptions(500, 0L, false));
 
-        verify(backfillPort, never()).hasTokens(anyLong());
+        // skipExisting=false면 배치 존재 조회 자체를 생략한다(불필요한 SELECT 회피).
+        verify(backfillPort, never()).findExistingTokenMessageIds(any());
         verify(messageSearchTokenRepository).deleteByMessageId(10L);
     }
 
@@ -196,5 +201,42 @@ class MessageSearchBackfillServiceTest {
 
         assertThat(result.scanned()).isZero();
         verify(backfillPort).findTextMessagesForBackfill(0L, 1);
+    }
+
+    @Test
+    @DisplayName("정상 완료 시 결과의 completed=true 로 끝까지 완료됐음을 표시한다")
+    void should_markCompletedTrue_onSuccess() {
+        Message m1 = textMessage(10L, "정상 완료 메시지");
+        given(backfillPort.findTextMessagesForBackfill(0L, 500)).willReturn(List.of(m1));
+        given(blindIndexTokenizer.tokenize(any())).willReturn(Set.of("t"));
+
+        BackfillResult result = service.backfill(new BackfillOptions(500, 0L, false));
+
+        assertThat(result.completed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("청크 처리 중 실패하면 직전까지의 진행분을 담은 BackfillInterruptedException(completed=false)을 던진다")
+    void should_throwInterrupted_withPartialResult_onChunkFailure() {
+        Message m1 = textMessage(10L, "성공 청크");
+        Message m2 = textMessage(20L, "실패 청크");
+        // chunkSize=1: 첫 청크[m1] 성공 → 둘째 청크[m2]에서 토큰화 실패
+        given(backfillPort.findTextMessagesForBackfill(0L, 1)).willReturn(List.of(m1));
+        given(backfillPort.findTextMessagesForBackfill(10L, 1)).willReturn(List.of(m2));
+        given(blindIndexTokenizer.tokenize("성공 청크")).willReturn(Set.of("t1"));
+        given(blindIndexTokenizer.tokenize("실패 청크"))
+                .willThrow(new IllegalStateException("토큰화 실패"));
+
+        BackfillInterruptedException ex = catchThrowableOfType(
+                () -> service.backfill(new BackfillOptions(1, 0L, false)),
+                BackfillInterruptedException.class);
+
+        assertThat(ex).isNotNull();
+        BackfillResult partial = ex.partialResult();
+        // 첫 청크(m1)는 반영, 실패한 둘째 청크(m2)는 롤백되어 미반영. completed=false 로 가시화.
+        assertThat(partial.completed()).isFalse();
+        assertThat(partial.scanned()).isEqualTo(1L);
+        assertThat(partial.indexed()).isEqualTo(1L);
+        assertThat(partial.lastCursorId()).isEqualTo(10L);
     }
 }

--- a/src/test/java/com/cotalk/application/service/message/MessageSearchBackfillServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/message/MessageSearchBackfillServiceTest.java
@@ -1,0 +1,200 @@
+package com.cotalk.application.service.message;
+
+import com.cotalk.application.service.message.MessageSearchBackfillService.BackfillOptions;
+import com.cotalk.application.service.message.MessageSearchBackfillService.BackfillResult;
+import com.cotalk.domain.entity.Message;
+import com.cotalk.domain.entity.Message.MessageType;
+import com.cotalk.domain.port.outbound.BlindIndexTokenizer;
+import com.cotalk.domain.port.outbound.MessageSearchBackfillPort;
+import com.cotalk.domain.port.outbound.MessageSearchTokenRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * {@link MessageSearchBackfillService} 단위 테스트.
+ *
+ * <p>커서 청크 반복, 토큰화 호출, idempotent delete-then-insert, 커서 진행, skip-existing,
+ * 빈 토큰(3글자 미만) 처리를 Mockito로 검증한다.</p>
+ *
+ * @author seunggu.lee
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("메시지 검색 토큰 백필 서비스")
+class MessageSearchBackfillServiceTest {
+
+    @Mock
+    private MessageSearchBackfillPort backfillPort;
+    @Mock
+    private MessageSearchTokenRepository messageSearchTokenRepository;
+    @Mock
+    private BlindIndexTokenizer blindIndexTokenizer;
+    @Mock
+    private TransactionTemplate transactionTemplate;
+
+    private MessageSearchBackfillService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new MessageSearchBackfillService(
+                backfillPort, messageSearchTokenRepository, blindIndexTokenizer, transactionTemplate);
+        // 트랜잭션 콜백을 즉시 실행
+        lenient().when(transactionTemplate.execute(any(TransactionCallback.class)))
+                .thenAnswer(invocation -> {
+                    TransactionCallback<?> callback = invocation.getArgument(0);
+                    return callback.doInTransaction(null);
+                });
+    }
+
+    private Message textMessage(long id, String content) {
+        return Message.builder().id(id).chatRoomId(1L).senderId(1L)
+                .content(content).type(MessageType.TEXT).build();
+    }
+
+    @Test
+    @DisplayName("커서 청크를 반복 조회해 빈 청크가 나올 때까지 모든 메시지를 토큰화한다")
+    void should_iterateChunks_untilEmpty() {
+        Message m1 = textMessage(10L, "첫번째 메시지");
+        Message m2 = textMessage(20L, "두번째 메시지");
+        Message m3 = textMessage(30L, "세번째 메시지");
+
+        // chunkSize=2: [m1,m2] → [m3] → []
+        given(backfillPort.findTextMessagesForBackfill(0L, 2)).willReturn(List.of(m1, m2));
+        given(backfillPort.findTextMessagesForBackfill(20L, 2)).willReturn(List.of(m3));
+        given(blindIndexTokenizer.tokenize(any())).willReturn(Set.of("tokA", "tokB"));
+
+        BackfillResult result = service.backfill(new BackfillOptions(2, 0L, false));
+
+        // m3 청크가 chunkSize 미만이라 추가 조회 없이 종료
+        verify(backfillPort).findTextMessagesForBackfill(0L, 2);
+        verify(backfillPort).findTextMessagesForBackfill(20L, 2);
+        verify(blindIndexTokenizer, times(3)).tokenize(any());
+        assertThat(result.scanned()).isEqualTo(3L);
+        assertThat(result.indexed()).isEqualTo(3L);
+        assertThat(result.lastCursorId()).isEqualTo(30L);
+    }
+
+    @Test
+    @DisplayName("메시지별로 delete-then-insert 순서로 idempotent하게 재적재한다")
+    void should_deleteThenInsert_perMessage() {
+        Message m1 = textMessage(10L, "회의시간 안내");
+        given(backfillPort.findTextMessagesForBackfill(0L, 500)).willReturn(List.of(m1));
+        given(blindIndexTokenizer.tokenize("회의시간 안내")).willReturn(Set.of("t1", "t2"));
+
+        service.backfill(BackfillOptions.defaults());
+
+        InOrder order = inOrder(messageSearchTokenRepository);
+        order.verify(messageSearchTokenRepository).deleteByMessageId(10L);
+        order.verify(messageSearchTokenRepository).saveTokens(eq(10L), eq(Set.of("t1", "t2")));
+    }
+
+    @Test
+    @DisplayName("skipExisting=true면 이미 토큰이 있는 메시지는 복호화/토큰화 없이 건너뛴다")
+    void should_skipMessagesWithExistingTokens_when_skipExisting() {
+        Message m1 = textMessage(10L, "이미 토큰 있음");
+        Message m2 = textMessage(20L, "토큰 없음 신규");
+        given(backfillPort.findTextMessagesForBackfill(0L, 500)).willReturn(List.of(m1, m2));
+        given(backfillPort.hasTokens(10L)).willReturn(true);
+        given(backfillPort.hasTokens(20L)).willReturn(false);
+        given(blindIndexTokenizer.tokenize("토큰 없음 신규")).willReturn(Set.of("x"));
+
+        BackfillResult result = service.backfill(new BackfillOptions(500, 0L, true));
+
+        verify(blindIndexTokenizer, never()).tokenize("이미 토큰 있음");
+        verify(messageSearchTokenRepository, never()).deleteByMessageId(10L);
+        verify(messageSearchTokenRepository).deleteByMessageId(20L);
+        verify(messageSearchTokenRepository).saveTokens(eq(20L), any());
+        assertThat(result.scanned()).isEqualTo(2L);
+        assertThat(result.indexed()).isEqualTo(1L);
+        assertThat(result.skipped()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("skipExisting=false면 토큰 존재 여부를 확인하지 않고 모두 재토큰화한다")
+    void should_notCheckExistence_when_skipExistingFalse() {
+        Message m1 = textMessage(10L, "강제 재토큰화");
+        given(backfillPort.findTextMessagesForBackfill(0L, 500)).willReturn(List.of(m1));
+        given(blindIndexTokenizer.tokenize(any())).willReturn(Set.of("a"));
+
+        service.backfill(new BackfillOptions(500, 0L, false));
+
+        verify(backfillPort, never()).hasTokens(anyLong());
+        verify(messageSearchTokenRepository).deleteByMessageId(10L);
+    }
+
+    @Test
+    @DisplayName("토큰이 비어도(3글자 미만) 기존 토큰은 삭제하되 새 토큰은 적재하지 않는다")
+    void should_deleteButNotInsert_when_tokensEmpty() {
+        Message m1 = textMessage(10L, "ab");
+        given(backfillPort.findTextMessagesForBackfill(0L, 500)).willReturn(List.of(m1));
+        given(blindIndexTokenizer.tokenize("ab")).willReturn(Set.of());
+
+        BackfillResult result = service.backfill(new BackfillOptions(500, 0L, false));
+
+        verify(messageSearchTokenRepository).deleteByMessageId(10L);
+        verify(messageSearchTokenRepository, never()).saveTokens(anyLong(), any());
+        assertThat(result.indexed()).isEqualTo(0L);
+        assertThat(result.scanned()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("처리할 메시지가 없으면 즉시 종료하고 빈 결과를 반환한다")
+    void should_returnEmpty_when_noMessages() {
+        given(backfillPort.findTextMessagesForBackfill(0L, 500)).willReturn(List.of());
+
+        BackfillResult result = service.backfill(BackfillOptions.defaults());
+
+        assertThat(result.scanned()).isZero();
+        assertThat(result.indexed()).isZero();
+        assertThat(result.lastCursorId()).isZero();
+        verify(blindIndexTokenizer, never()).tokenize(any());
+    }
+
+    @Test
+    @DisplayName("재실행해도 동일한 delete-then-insert 결과로 idempotent하다")
+    void should_beIdempotent_onRerun() {
+        Message m1 = textMessage(10L, "재실행 안전 메시지");
+        given(backfillPort.findTextMessagesForBackfill(0L, 500)).willReturn(List.of(m1));
+        given(blindIndexTokenizer.tokenize(any())).willReturn(Set.of("z1", "z2"));
+
+        BackfillResult first = service.backfill(new BackfillOptions(500, 0L, false));
+        BackfillResult second = service.backfill(new BackfillOptions(500, 0L, false));
+
+        assertThat(first).isEqualTo(second);
+        // 두 번 실행 → delete-then-insert 두 번 (중복/오류 없음)
+        verify(messageSearchTokenRepository, times(2)).deleteByMessageId(10L);
+        verify(messageSearchTokenRepository, times(2)).saveTokens(eq(10L), any());
+    }
+
+    @Test
+    @DisplayName("null/비정상 옵션은 안전 기본값으로 보정한다")
+    void should_sanitizeOptions() {
+        given(backfillPort.findTextMessagesForBackfill(0L, 1)).willReturn(List.of());
+
+        // chunkSize=0 → 1로 보정되어 NPE/무한루프 없이 동작
+        BackfillResult result = service.backfill(new BackfillOptions(0, -5L, true));
+
+        assertThat(result.scanned()).isZero();
+        verify(backfillPort).findTextMessagesForBackfill(0L, 1);
+    }
+}

--- a/src/test/java/com/cotalk/infrastructure/crypto/EncryptionServiceTest.java
+++ b/src/test/java/com/cotalk/infrastructure/crypto/EncryptionServiceTest.java
@@ -39,7 +39,7 @@ class EncryptionServiceTest {
                 new AppProperties.Terms("1.0", "1.0"),
                 new AppProperties.Encryption(encryptionKey, enabled),
                 new AppProperties.Swagger("http://localhost:8080", "API 서버"),
-                new AppProperties.Search("dGVzdC1ibGluZC1pbmRleC1zZWNyZXQtZm9yLXVuaXQtdGVzdHM=")
+                AppProperties.Search.of("dGVzdC1ibGluZC1pbmRleC1zZWNyZXQtZm9yLXVuaXQtdGVzdHM=")
         );
     }
 

--- a/src/test/java/com/cotalk/infrastructure/crypto/HmacBlindIndexTokenizerTest.java
+++ b/src/test/java/com/cotalk/infrastructure/crypto/HmacBlindIndexTokenizerTest.java
@@ -36,7 +36,7 @@ class HmacBlindIndexTokenizerTest {
                 new AppProperties.Terms("1.0", "1.0"),
                 new AppProperties.Encryption("dGhpc2lzYXRlc3RrZXlmb3JkZXZlbG9wbWVudG9ubHk=", false),
                 new AppProperties.Swagger("http://localhost:8080", "API 서버"),
-                new AppProperties.Search(secret)
+                AppProperties.Search.of(secret)
         );
     }
 
@@ -148,7 +148,7 @@ class HmacBlindIndexTokenizerTest {
     void should_throw_when_secretNull() {
         // AppProperties.Search compact 생성자가 null→""로 치환하므로, 빈 시크릿 거부 경로로 수렴해야 한다.
         // (설정 누락 시 빈 시크릿으로 조용히 동작하는 보안 구멍이 없음을 보장)
-        assertThat(new AppProperties.Search(null).blindIndexSecret()).isEmpty();
+        assertThat(AppProperties.Search.of(null).blindIndexSecret()).isEmpty();
         assertThatThrownBy(() -> new HmacBlindIndexTokenizer(appPropertiesWithSecret(null)))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("blind-index-secret");

--- a/src/test/java/com/cotalk/infrastructure/messaging/RedisChatMessageBrokerTest.java
+++ b/src/test/java/com/cotalk/infrastructure/messaging/RedisChatMessageBrokerTest.java
@@ -60,7 +60,7 @@ class RedisChatMessageBrokerTest {
                 new AppProperties.Terms("1.0", "1.0"),
                 new AppProperties.Encryption("", true),
                 new AppProperties.Swagger("http://localhost:8080", "API 서버"),
-                new AppProperties.Search("dGVzdC1ibGluZC1pbmRleC1zZWNyZXQtZm9yLXVuaXQtdGVzdHM=")
+                AppProperties.Search.of("dGVzdC1ibGluZC1pbmRleC1zZWNyZXQtZm9yLXVuaXQtdGVzdHM=")
         );
     }
 

--- a/src/test/java/com/cotalk/infrastructure/messaging/RedisChatMessageSubscriberTest.java
+++ b/src/test/java/com/cotalk/infrastructure/messaging/RedisChatMessageSubscriberTest.java
@@ -62,7 +62,7 @@ class RedisChatMessageSubscriberTest {
                 new AppProperties.Terms("1.0", "1.0"),
                 new AppProperties.Encryption("", true),
                 new AppProperties.Swagger("http://localhost:8080", "API 서버"),
-                new AppProperties.Search("dGVzdC1ibGluZC1pbmRleC1zZWNyZXQtZm9yLXVuaXQtdGVzdHM=")
+                AppProperties.Search.of("dGVzdC1ibGluZC1pbmRleC1zZWNyZXQtZm9yLXVuaXQtdGVzdHM=")
         );
     }
 

--- a/src/test/java/com/cotalk/infrastructure/messaging/RedisMessagingConfigTest.java
+++ b/src/test/java/com/cotalk/infrastructure/messaging/RedisMessagingConfigTest.java
@@ -42,7 +42,7 @@ class RedisMessagingConfigTest {
                 new AppProperties.Terms("1.0", "1.0"),
                 new AppProperties.Encryption("", true),
                 new AppProperties.Swagger("http://localhost:8080", "API 서버"),
-                new AppProperties.Search("dGVzdC1ibGluZC1pbmRleC1zZWNyZXQtZm9yLXVuaXQtdGVzdHM=")
+                AppProperties.Search.of("dGVzdC1ibGluZC1pbmRleC1zZWNyZXQtZm9yLXVuaXQtdGVzdHM=")
         );
     }
 

--- a/src/test/java/com/cotalk/infrastructure/messaging/RedisUserEventBrokerTest.java
+++ b/src/test/java/com/cotalk/infrastructure/messaging/RedisUserEventBrokerTest.java
@@ -50,7 +50,7 @@ class RedisUserEventBrokerTest {
                 new AppProperties.Terms("1.0", "1.0"),
                 new AppProperties.Encryption("", true),
                 new AppProperties.Swagger("http://localhost:8080", "API 서버"),
-                new AppProperties.Search("dGVzdC1ibGluZC1pbmRleC1zZWNyZXQtZm9yLXVuaXQtdGVzdHM=")
+                AppProperties.Search.of("dGVzdC1ibGluZC1pbmRleC1zZWNyZXQtZm9yLXVuaXQtdGVzdHM=")
         );
     }
 

--- a/src/test/java/com/cotalk/infrastructure/messaging/RedisUserEventSubscriberTest.java
+++ b/src/test/java/com/cotalk/infrastructure/messaging/RedisUserEventSubscriberTest.java
@@ -53,7 +53,7 @@ class RedisUserEventSubscriberTest {
                 new AppProperties.Terms("1.0", "1.0"),
                 new AppProperties.Encryption("", true),
                 new AppProperties.Swagger("http://localhost:8080", "API 서버"),
-                new AppProperties.Search("dGVzdC1ibGluZC1pbmRleC1zZWNyZXQtZm9yLXVuaXQtdGVzdHM=")
+                AppProperties.Search.of("dGVzdC1ibGluZC1pbmRleC1zZWNyZXQtZm9yLXVuaXQtdGVzdHM=")
         );
     }
 

--- a/src/test/java/com/cotalk/integration/MessageSearchBackfillIntegrationTest.java
+++ b/src/test/java/com/cotalk/integration/MessageSearchBackfillIntegrationTest.java
@@ -1,0 +1,268 @@
+package com.cotalk.integration;
+
+import com.cotalk.application.service.message.MessageSearchBackfillService;
+import com.cotalk.application.service.message.MessageSearchBackfillService.BackfillOptions;
+import com.cotalk.application.service.message.MessageSearchBackfillService.BackfillResult;
+import com.cotalk.config.TestRedisConfiguration;
+import com.cotalk.domain.entity.ChatRoom;
+import com.cotalk.domain.entity.ChatRoomMember;
+import com.cotalk.domain.entity.Message;
+import com.cotalk.domain.entity.User;
+import com.cotalk.domain.model.Email;
+import com.cotalk.domain.port.inbound.message.SearchMessageUseCase;
+import com.cotalk.domain.port.inbound.message.SendMessageUseCase;
+import com.cotalk.domain.port.outbound.ChatRoomMemberRepository;
+import com.cotalk.domain.port.outbound.ChatRoomRepository;
+import com.cotalk.domain.port.outbound.IdGenerator;
+import com.cotalk.domain.port.outbound.MessageRepository;
+import com.cotalk.domain.port.outbound.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 기존 암호화 메시지 검색 토큰 백필(PR2) 통합 테스트.
+ *
+ * <p>암호화 ON + 실제 Flyway(PostgreSQL testcontainer)에서, 토큰 없이 저장된 "기존" 메시지를
+ * 백필이 복호화→토큰화→적재하여 과거 메시지가 다시 검색됨을 검증한다(재발방지의 PR2 산출물).</p>
+ *
+ * <p>레거시 상태 재현: PR1 발송 경로가 자동 적재한 토큰을 {@code message_search_tokens}에서
+ * 비워(=PR1 이전에 저장된 메시지 상태) 검색이 0건이 되게 한 뒤 백필을 실행한다.</p>
+ *
+ * <p>검증 시나리오: (1) 백필 전 검색 0건 → 백필 후 과거 메시지 검색됨, (2) 재실행해도 중복/오류 없음
+ * (idempotent), (3) TEXT만 처리(FILE/SYSTEM 제외), (4) 소프트 삭제 메시지는 검색에서 제외.</p>
+ *
+ * @author seunggu.lee
+ */
+@Testcontainers(disabledWithoutDocker = true)
+@SpringBootTest
+@ActiveProfiles("test")
+@Import(TestRedisConfiguration.class)
+@DisplayName("기존 암호화 메시지 백필 통합")
+class MessageSearchBackfillIntegrationTest {
+
+    @SuppressWarnings("resource")
+    @Container
+    static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine")
+            .withDatabaseName("cotalk")
+            .withUsername("test")
+            .withPassword("test");
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+        registry.add("spring.jpa.database-platform", () -> "org.hibernate.dialect.PostgreSQLDialect");
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "validate");
+        registry.add("spring.flyway.enabled", () -> "true");
+        // 암호화 ON + 고정 키/시크릿 (prod 동등)
+        registry.add("app.encryption.enabled", () -> "true");
+        registry.add("app.encryption.key", () -> "dGhpc2lzYXRlc3RrZXlmb3JkZXZlbG9wbWVudG9ubHk=");
+        registry.add("app.search.blind-index-secret",
+                () -> "dGVzdC1ibGluZC1pbmRleC1zZWNyZXQtZm9yLWludGVncmF0aW9uLXRlc3Q=");
+        // 백필 러너는 끈 채로 서비스를 직접 호출해 검증한다(러너는 단순 위임).
+        registry.add("app.search.backfill.enabled", () -> "false");
+    }
+
+    @Autowired
+    private SendMessageUseCase sendMessageUseCase;
+    @Autowired
+    private SearchMessageUseCase searchMessageUseCase;
+    @Autowired
+    private MessageSearchBackfillService backfillService;
+    @Autowired
+    private MessageRepository messageRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+    @Autowired
+    private ChatRoomMemberRepository chatRoomMemberRepository;
+    @Autowired
+    private IdGenerator idGenerator;
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @AfterEach
+    void cleanUp() {
+        jdbcTemplate.update("DELETE FROM message_search_tokens");
+        jdbcTemplate.update("DELETE FROM messages");
+        jdbcTemplate.update("DELETE FROM chat_room_members");
+        jdbcTemplate.update("DELETE FROM chat_rooms");
+        jdbcTemplate.update("DELETE FROM users");
+    }
+
+    private Long createUser(String email, String nickname) {
+        Long id = idGenerator.nextId();
+        userRepository.save(User.builder()
+                .id(id)
+                .email(new Email(email))
+                .nickname(nickname)
+                .passwordHash("$2a$10$dummyhashdummyhashdummyhashdummyhashdummyhash")
+                .build());
+        return id;
+    }
+
+    private Long createRoomWithMembers(Long... userIds) {
+        Long roomId = idGenerator.nextId();
+        chatRoomRepository.save(ChatRoom.builder().id(roomId).type(ChatRoom.ChatRoomType.GROUP).name("방").build());
+        for (Long userId : userIds) {
+            chatRoomMemberRepository.save(ChatRoomMember.builder()
+                    .id(idGenerator.nextId()).chatRoomId(roomId).userId(userId).build());
+        }
+        return roomId;
+    }
+
+    /** PR1 이전에 저장된 "기존 메시지" 상태 재현: 자동 적재된 토큰을 전부 비운다. */
+    private void simulateLegacyMessagesWithoutTokens() {
+        jdbcTemplate.update("DELETE FROM message_search_tokens");
+    }
+
+    private int tokenCount() {
+        Integer c = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM message_search_tokens", Integer.class);
+        return c == null ? 0 : c;
+    }
+
+    @Test
+    @DisplayName("토큰 없이 저장된 기존 메시지를 백필하면 과거 메시지가 다시 검색된다")
+    void should_makeLegacyMessagesSearchable_afterBackfill() {
+        Long sender = createUser("a@test.com", "철수");
+        Long roomId = createRoomWithMembers(sender);
+
+        sendMessageUseCase.sendMessage(roomId, sender, "오늘 비밀번호를 변경했어요");
+        sendMessageUseCase.sendMessage(roomId, sender, "회의시간 안내드립니다");
+
+        // 레거시 상태 재현 → 검색 0건 확인
+        simulateLegacyMessagesWithoutTokens();
+        assertThat(tokenCount()).isZero();
+        assertThat(searchMessageUseCase.searchInChatRoom(roomId, sender, "비밀번호", 0, 20)).isEmpty();
+
+        // 백필 실행
+        BackfillResult result = backfillService.backfill(new BackfillOptions(500, 0L, false));
+
+        // 과거 메시지가 다시 검색됨
+        assertThat(result.scanned()).isEqualTo(2L);
+        assertThat(result.indexed()).isEqualTo(2L);
+        assertThat(tokenCount()).isGreaterThan(0);
+        List<Message> hits = searchMessageUseCase.searchInChatRoom(roomId, sender, "비밀번호", 0, 20);
+        assertThat(hits).extracting(Message::getContent).containsExactly("오늘 비밀번호를 변경했어요");
+        assertThat(searchMessageUseCase.searchInChatRoom(roomId, sender, "회의시간", 0, 20)).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("백필을 재실행해도 중복/오류 없이 동일하게 검색된다 (idempotent)")
+    void should_beIdempotent_onRerun() {
+        Long sender = createUser("b@test.com", "영희");
+        Long roomId = createRoomWithMembers(sender);
+        sendMessageUseCase.sendMessage(roomId, sender, "재실행 안전 메시지 확인");
+        simulateLegacyMessagesWithoutTokens();
+
+        BackfillResult first = backfillService.backfill(new BackfillOptions(500, 0L, false));
+        int afterFirst = tokenCount();
+        BackfillResult second = backfillService.backfill(new BackfillOptions(500, 0L, false));
+        int afterSecond = tokenCount();
+
+        // 토큰 수가 늘어나지 않음(중복 없음) + 검색 정상
+        assertThat(afterSecond).isEqualTo(afterFirst);
+        assertThat(first.indexed()).isEqualTo(second.indexed());
+        assertThat(searchMessageUseCase.searchInChatRoom(roomId, sender, "재실행", 0, 20)).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("skipExisting=true면 이미 토큰이 있는 메시지(신규 적재분)는 건너뛴다")
+    void should_skipMessagesWithExistingTokens() {
+        Long sender = createUser("c@test.com", "민수");
+        Long roomId = createRoomWithMembers(sender);
+        // 토큰이 이미 적재된 신규 메시지 (PR1 경로) — 비우지 않는다.
+        sendMessageUseCase.sendMessage(roomId, sender, "토큰 있는 신규메시지 본문");
+
+        BackfillResult result = backfillService.backfill(new BackfillOptions(500, 0L, true));
+
+        assertThat(result.scanned()).isEqualTo(1L);
+        assertThat(result.skipped()).isEqualTo(1L);
+        assertThat(result.indexed()).isZero();
+        assertThat(searchMessageUseCase.searchInChatRoom(roomId, sender, "신규메시지", 0, 20)).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("FILE/SYSTEM 메시지는 백필 대상에서 제외되고 TEXT만 색인된다")
+    void should_indexOnlyTextMessages() {
+        Long sender = createUser("d@test.com", "지수");
+        Long roomId = createRoomWithMembers(sender);
+
+        sendMessageUseCase.sendMessage(roomId, sender, "텍스트 메시지 본문");
+        // FILE 메시지: content=파일명. SYSTEM: 시스템 메시지. 둘 다 직접 저장(senderId는 FK 충족 위해 실제 사용자).
+        messageRepository.save(Message.builder()
+                .id(idGenerator.nextId()).chatRoomId(roomId).senderId(sender)
+                .content("문서파일이름.pdf").type(Message.MessageType.FILE)
+                .fileUrl("https://example.com/f.pdf").fileName("문서파일이름.pdf").build());
+        messageRepository.save(Message.builder()
+                .id(idGenerator.nextId()).chatRoomId(roomId).senderId(sender)
+                .content("시스템 입장 알림").type(Message.MessageType.SYSTEM).build());
+
+        simulateLegacyMessagesWithoutTokens();
+        BackfillResult result = backfillService.backfill(new BackfillOptions(500, 0L, false));
+
+        // TEXT 1건만 스캔/색인 (FILE/SYSTEM 제외)
+        assertThat(result.scanned()).isEqualTo(1L);
+        assertThat(result.indexed()).isEqualTo(1L);
+        assertThat(searchMessageUseCase.searchInChatRoom(roomId, sender, "텍스트", 0, 20)).hasSize(1);
+        // 파일명은 백필되지 않아 검색되지 않음
+        assertThat(searchMessageUseCase.searchInChatRoom(roomId, sender, "문서파일", 0, 20)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("소프트 삭제된 메시지는 백필 대상에서 제외된다")
+    void should_excludeSoftDeletedMessages() {
+        Long sender = createUser("e@test.com", "토끼");
+        Long roomId = createRoomWithMembers(sender);
+
+        Message alive = sendMessageUseCase.sendMessage(roomId, sender, "살아있는 회의시간");
+        Message deleted = sendMessageUseCase.sendMessage(roomId, sender, "삭제된 회의시간");
+        deleted.delete(java.time.LocalDateTime.now());
+        messageRepository.save(deleted);
+
+        simulateLegacyMessagesWithoutTokens();
+        BackfillResult result = backfillService.backfill(new BackfillOptions(500, 0L, false));
+
+        // 미삭제 1건만 백필
+        assertThat(result.scanned()).isEqualTo(1L);
+        List<Message> hits = searchMessageUseCase.searchInChatRoom(roomId, sender, "회의시간", 0, 20);
+        assertThat(hits).extracting(Message::getId).containsExactly(alive.getId());
+        assertThat(hits).extracting(Message::getId).doesNotContain(deleted.getId());
+    }
+
+    @Test
+    @DisplayName("청크 크기보다 많은 메시지도 커서 청크 반복으로 모두 백필된다")
+    void should_backfillAcrossMultipleChunks() {
+        Long sender = createUser("f@test.com", "다람쥐");
+        Long roomId = createRoomWithMembers(sender);
+        for (int i = 0; i < 7; i++) {
+            sendMessageUseCase.sendMessage(roomId, sender, "회의시간 청크테스트 " + i);
+        }
+        simulateLegacyMessagesWithoutTokens();
+
+        // chunkSize=2 → 여러 청크에 걸쳐 처리
+        BackfillResult result = backfillService.backfill(new BackfillOptions(2, 0L, false));
+
+        assertThat(result.scanned()).isEqualTo(7L);
+        assertThat(result.indexed()).isEqualTo(7L);
+        assertThat(searchMessageUseCase.searchInChatRoom(roomId, sender, "청크테스트", 0, 20)).hasSize(7);
+    }
+}

--- a/src/test/java/com/cotalk/integration/MessageSearchBackfillIntegrationTest.java
+++ b/src/test/java/com/cotalk/integration/MessageSearchBackfillIntegrationTest.java
@@ -197,7 +197,39 @@ class MessageSearchBackfillIntegrationTest {
         assertThat(result.scanned()).isEqualTo(1L);
         assertThat(result.skipped()).isEqualTo(1L);
         assertThat(result.indexed()).isZero();
+        assertThat(result.completed()).isTrue();
         assertThat(searchMessageUseCase.searchInChatRoom(roomId, sender, "신규메시지", 0, 20)).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("skipExisting=true: 토큰 있는 메시지는 건너뛰고 토큰 없는 레거시 메시지만 배치 조회 후 색인한다")
+    void should_skipExistingAndIndexOnlyLegacy_withBatchLookup() {
+        Long sender = createUser("c2@test.com", "민지");
+        Long roomId = createRoomWithMembers(sender);
+
+        // (1) 토큰이 이미 있는 신규 메시지 (PR1 경로)
+        Message withTokens = sendMessageUseCase.sendMessage(roomId, sender, "이미색인 신규메시지 본문");
+        // (2) 토큰 없는 레거시 메시지 — 이 메시지의 토큰만 비워 "토큰 없음" 상태로 만든다.
+        Message legacy = sendMessageUseCase.sendMessage(roomId, sender, "레거시메시지 백필대상 본문");
+        jdbcTemplate.update("DELETE FROM message_search_tokens WHERE message_id = ?", legacy.getId());
+
+        // 사전 상태: 토큰 있는 메시지만 검색됨, 레거시는 검색 0건
+        assertThat(searchMessageUseCase.searchInChatRoom(roomId, sender, "이미색인", 0, 20)).hasSize(1);
+        assertThat(searchMessageUseCase.searchInChatRoom(roomId, sender, "레거시메시지", 0, 20)).isEmpty();
+
+        BackfillResult result = backfillService.backfill(new BackfillOptions(500, 0L, true));
+
+        // 2건 스캔(배치 IN 조회) → 토큰 있는 1건 skip, 레거시 1건만 색인
+        assertThat(result.scanned()).isEqualTo(2L);
+        assertThat(result.skipped()).isEqualTo(1L);
+        assertThat(result.indexed()).isEqualTo(1L);
+        assertThat(result.completed()).isTrue();
+
+        // 레거시 메시지가 색인되어 검색됨, 기존 메시지도 여전히 검색됨
+        List<Message> legacyHits = searchMessageUseCase.searchInChatRoom(roomId, sender, "레거시메시지", 0, 20);
+        assertThat(legacyHits).extracting(Message::getId).containsExactly(legacy.getId());
+        assertThat(searchMessageUseCase.searchInChatRoom(roomId, sender, "이미색인", 0, 20))
+                .extracting(Message::getId).containsExactly(withTokens.getId());
     }
 
     @Test


### PR DESCRIPTION
## 배경
PR1(#173)은 블라인드 인덱스 인프라를 도입해 **신규 메시지부터** 검색이 동작한다(발송 시 토큰 자동 적재). 그러나 그 이전에 저장된 기존 TEXT 메시지는 토큰이 없어 검색되지 않는다. 본 PR은 기존 암호화 메시지를 **복호화 → 토큰화 → `message_search_tokens` 적재**하여 과거 메시지 검색을 복구한다(설계서 5절 / 10절 PR2).

## 구현
- **수단**: `ApplicationRunner` + 실행 플래그 `app.search.backfill.enabled`(기본 **false** — 실수 실행 방지). 운영에서는 백필 윈도우에만 `SEARCH_BACKFILL_ENABLED=true`로 기동.
- **커서 청크**: `id` 오름차순 커서로 `WHERE id > :cursor AND type='TEXT' AND is_deleted=false ORDER BY id ASC LIMIT :chunk` 반복 조회(기본 청크 500). 전체를 메모리에 올리지 않는다.
- **청크 단위 트랜잭션**: 청크 하나 = 한 트랜잭션(장기 트랜잭션/락 회피).
- **idempotent**: 메시지별 `deleteByMessageId` 후 재적재(delete-then-insert). 토큰 PK `(message_id, token)`이라 중복 적재가 없고, 몇 번을 다시 돌려도 결과 동일.
- **중단 복구**: `id` 커서 기반이라 재기동 시 idempotent하게 재개/재처리. 진행 로그로 마지막 커서 추적.
- **부하 제어**: `skip-existing`(이미 토큰 있는 신규 적재분은 복호화/HMAC 없이 건너뜀) + `throttle-millis`(청크 사이 슬립).
- **헥사고날**: application 서비스는 아웃바운드 포트(`MessageSearchBackfillPort`, `MessageSearchTokenRepository`, `BlindIndexTokenizer`)만 의존. ArchUnit 통과.
- **PR1 인프라 재사용**: 토큰화/적재/삭제 포트를 그대로 사용(중복 구현 없음).

## 검증
- **단위(Mockito)**: 커서 청크 반복, delete-then-insert, idempotent(재실행 동일 결과), skip-existing, 빈 토큰(3글자 미만) 처리, 커서 진행, 옵션 보정.
- **통합(암호화 ON + PostgreSQL testcontainers + 실제 Flyway)**: 토큰 없이 저장된 기존 메시지를 백필 → 과거 메시지 검색됨. 재실행해도 토큰 수 불변(중복/오류 없음). TEXT만 처리(FILE/SYSTEM 제외). 소프트삭제 제외. 다중 청크 순회.
- `./gradlew build` **성공**(전체 테스트 + ArchUnit + JaCoCo 게이트 그린).

## 운영 런북
- **실행**: 백필 전용/윈도우 인스턴스에 `SEARCH_BACKFILL_ENABLED=true`로 기동. `SEARCH_BACKFILL_CHUNK_SIZE`(기본 500), `SEARCH_BACKFILL_THROTTLE_MILLIS`(기본 0), `SEARCH_BACKFILL_SKIP_EXISTING`(기본 true)로 부하 조절.
- **모니터링**: "백필 진행: 누적 scanned/indexed/skipped, 마지막 커서 id=..." 로그로 처리량·커서 추적. 완료 시 "백필 완료" + 결과 요약.
- **중단/재개**: idempotent + skip-existing이라 재기동으로 안전 재개.
- **롤백**: `TRUNCATE message_search_tokens;`(검색은 신규 메시지부터 다시 점진 채워짐). 부분 롤백은 메시지 ID 범위 `DELETE`.
- **완료 후**: `enabled=false`(기본)로 되돌려 재기동 시 재실행 방지.

## 부분배포 호환
백필 전이라도 신규 메시지는 PR1 경로로 이미 토큰화되므로 검색이 점진적으로 채워지며(과거 메시지만 누락), 백필 완료 후 전체 정상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
