### PR TITLE
chore(infra): minio를 NAS 외부 호스트로 전환 — nginx crash-loop 해소

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,11 @@ MINIO_SECRET_KEY=CHANGE_ME_MINIO_SECRET_KEY
 # NAS 외부 IP 또는 도메인으로 설정 (포트는 MINIO_API_PORT와 동일해야 함)
 MINIO_PUBLIC_URL=http://YOUR_NAS_IP:19000
 
+# 앱/서비스가 minio API에 접근할 내부 주소 (업로드·presigned URL 생성용).
+# minio는 NAS에서 외부 운영하므로 docker 서비스명이 아닌 NAS 주소를 가리킴.
+# NAS IP 변경 시 이 값을 수정할 것.
+MINIO_ENDPOINT=http://192.168.219.104:9000
+
 # ===========================================
 # 모니터링 스택 설정 (선택적)
 # docker-compose.monitoring.yml 사용 시에만 필요

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
           MINIO_ACCESS_KEY=${{ secrets.MINIO_ACCESS_KEY }}
           MINIO_SECRET_KEY=${{ secrets.MINIO_SECRET_KEY }}
           MINIO_PUBLIC_URL=${{ secrets.MINIO_PUBLIC_URL }}
+          MINIO_ENDPOINT=${{ vars.MINIO_ENDPOINT || 'http://192.168.219.104:9000' }}
           JWT_SECRET=${{ secrets.JWT_SECRET }}
           ENCRYPTION_KEY=${{ secrets.ENCRYPTION_KEY }}
           BLIND_INDEX_SECRET=${{ secrets.BLIND_INDEX_SECRET }}
@@ -119,6 +120,7 @@ jobs:
           MINIO_ACCESS_KEY=${{ secrets.MINIO_ACCESS_KEY }}
           MINIO_SECRET_KEY=${{ secrets.MINIO_SECRET_KEY }}
           MINIO_PUBLIC_URL=${{ secrets.MINIO_PUBLIC_URL }}
+          MINIO_ENDPOINT=${{ vars.MINIO_ENDPOINT || 'http://192.168.219.104:9000' }}
           JWT_SECRET=${{ secrets.JWT_SECRET }}
           ENCRYPTION_KEY=${{ secrets.ENCRYPTION_KEY }}
           BLIND_INDEX_SECRET=${{ secrets.BLIND_INDEX_SECRET }}

--- a/docker-compose.nas.yml
+++ b/docker-compose.nas.yml
@@ -42,7 +42,9 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_PASSWORD=${REDIS_PASSWORD:?REDIS_PASSWORD is required}
-      - MINIO_ENDPOINT=http://minio:9000
+      # MinIO API endpoint — NAS 외부 호스트(자체 운영). docker 서비스명 아님.
+      # IP 변경 시 .env의 MINIO_ENDPOINT로 덮어쓸 것.
+      - MINIO_ENDPOINT=${MINIO_ENDPOINT:-http://192.168.219.104:9000}
       - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY:?MINIO_ACCESS_KEY is required}
       - MINIO_SECRET_KEY=${MINIO_SECRET_KEY:?MINIO_SECRET_KEY is required}
       - MINIO_PUBLIC_URL=${MINIO_PUBLIC_URL:-https://cotalk-api.tpsg.co.kr/minio}
@@ -117,7 +119,9 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_PASSWORD=${REDIS_PASSWORD:?REDIS_PASSWORD is required}
-      - MINIO_ENDPOINT=http://minio:9000
+      # MinIO API endpoint — NAS 외부 호스트(자체 운영). docker 서비스명 아님.
+      # IP 변경 시 .env의 MINIO_ENDPOINT로 덮어쓸 것.
+      - MINIO_ENDPOINT=${MINIO_ENDPOINT:-http://192.168.219.104:9000}
       - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY:?MINIO_ACCESS_KEY is required}
       - MINIO_SECRET_KEY=${MINIO_SECRET_KEY:?MINIO_SECRET_KEY is required}
       - MINIO_PUBLIC_URL=${MINIO_PUBLIC_URL:-https://cotalk-api.tpsg.co.kr/minio}

--- a/docker-compose.nas.yml
+++ b/docker-compose.nas.yml
@@ -42,9 +42,9 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_PASSWORD=${REDIS_PASSWORD:?REDIS_PASSWORD is required}
-      # MinIO API endpoint — NAS 외부 호스트(자체 운영). docker 서비스명 아님.
-      # IP 변경 시 .env의 MINIO_ENDPOINT로 덮어쓸 것.
-      - MINIO_ENDPOINT=${MINIO_ENDPOINT:-http://192.168.219.104:9000}
+      # MinIO API endpoint — nas.yml은 minio를 같은 docker 네트워크에서 자체 운영하므로
+      # docker 서비스명(minio)으로 접근한다. (맥미니 docker-compose.yml만 외부 NAS IP 사용.)
+      - MINIO_ENDPOINT=${MINIO_ENDPOINT:-http://minio:9000}
       - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY:?MINIO_ACCESS_KEY is required}
       - MINIO_SECRET_KEY=${MINIO_SECRET_KEY:?MINIO_SECRET_KEY is required}
       - MINIO_PUBLIC_URL=${MINIO_PUBLIC_URL:-https://cotalk-api.tpsg.co.kr/minio}
@@ -119,9 +119,9 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_PASSWORD=${REDIS_PASSWORD:?REDIS_PASSWORD is required}
-      # MinIO API endpoint — NAS 외부 호스트(자체 운영). docker 서비스명 아님.
-      # IP 변경 시 .env의 MINIO_ENDPOINT로 덮어쓸 것.
-      - MINIO_ENDPOINT=${MINIO_ENDPOINT:-http://192.168.219.104:9000}
+      # MinIO API endpoint — nas.yml은 minio를 같은 docker 네트워크에서 자체 운영하므로
+      # docker 서비스명(minio)으로 접근한다. (맥미니 docker-compose.yml만 외부 NAS IP 사용.)
+      - MINIO_ENDPOINT=${MINIO_ENDPOINT:-http://minio:9000}
       - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY:?MINIO_ACCESS_KEY is required}
       - MINIO_SECRET_KEY=${MINIO_SECRET_KEY:?MINIO_SECRET_KEY is required}
       - MINIO_PUBLIC_URL=${MINIO_PUBLIC_URL:-https://cotalk-api.tpsg.co.kr/minio}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,9 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_PASSWORD=${REDIS_PASSWORD:-}
-      - MINIO_ENDPOINT=http://minio:9000
+      # MinIO API endpoint — NAS 외부 호스트(자체 운영). docker 서비스명 아님.
+      # IP 변경 시 .env의 MINIO_ENDPOINT로 덮어쓸 것.
+      - MINIO_ENDPOINT=${MINIO_ENDPOINT:-http://192.168.219.104:9000}
       - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY:?MINIO_ACCESS_KEY is required}
       - MINIO_SECRET_KEY=${MINIO_SECRET_KEY:?MINIO_SECRET_KEY is required}
       - MINIO_PUBLIC_URL=${MINIO_PUBLIC_URL:-https://cotalk-api.tpsg.co.kr/minio}
@@ -114,7 +116,9 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_PASSWORD=${REDIS_PASSWORD:-}
-      - MINIO_ENDPOINT=http://minio:9000
+      # MinIO API endpoint — NAS 외부 호스트(자체 운영). docker 서비스명 아님.
+      # IP 변경 시 .env의 MINIO_ENDPOINT로 덮어쓸 것.
+      - MINIO_ENDPOINT=${MINIO_ENDPOINT:-http://192.168.219.104:9000}
       - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY:?MINIO_ACCESS_KEY is required}
       - MINIO_SECRET_KEY=${MINIO_SECRET_KEY:?MINIO_SECRET_KEY is required}
       - MINIO_PUBLIC_URL=${MINIO_PUBLIC_URL:-https://cotalk-api.tpsg.co.kr/minio}
@@ -184,7 +188,9 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_PASSWORD=${REDIS_PASSWORD:-}
-      - MINIO_ENDPOINT=http://minio:9000
+      # MinIO API endpoint — NAS 외부 호스트(자체 운영). docker 서비스명 아님.
+      # IP 변경 시 .env의 MINIO_ENDPOINT로 덮어쓸 것.
+      - MINIO_ENDPOINT=${MINIO_ENDPOINT:-http://192.168.219.104:9000}
       - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY:?MINIO_ACCESS_KEY is required}
       - MINIO_SECRET_KEY=${MINIO_SECRET_KEY:?MINIO_SECRET_KEY is required}
       - MINIO_PUBLIC_URL=${MINIO_PUBLIC_URL:-https://cotalk-api.tpsg.co.kr/minio}
@@ -255,7 +261,9 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - REDIS_PASSWORD=${REDIS_PASSWORD:-}
-      - MINIO_ENDPOINT=http://minio:9000
+      # MinIO API endpoint — NAS 외부 호스트(자체 운영). docker 서비스명 아님.
+      # IP 변경 시 .env의 MINIO_ENDPOINT로 덮어쓸 것.
+      - MINIO_ENDPOINT=${MINIO_ENDPOINT:-http://192.168.219.104:9000}
       - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY:?MINIO_ACCESS_KEY is required}
       - MINIO_SECRET_KEY=${MINIO_SECRET_KEY:?MINIO_SECRET_KEY is required}
       - MINIO_PUBLIC_URL=${MINIO_PUBLIC_URL:-https://cotalk-api.tpsg.co.kr/minio}
@@ -350,27 +358,13 @@ services:
       retries: 5
 
   # ===========================================
-  # 파일 저장소 (S3 호환)
+  # 파일 저장소 (S3 호환) — minio
   # ===========================================
-  minio:
-    image: minio/minio:latest
-    container_name: cotalk-minio
-    ports:
-      - "127.0.0.1:${MINIO_API_PORT:-9000}:9000"
-      - "127.0.0.1:${MINIO_CONSOLE_PORT:-9001}:9001"
-    environment:
-      MINIO_ROOT_USER: ${MINIO_ACCESS_KEY}
-      MINIO_ROOT_PASSWORD: ${MINIO_SECRET_KEY}
-    command: server /data --console-address ":9001"
-    volumes:
-      - ${MINIO_DATA_DIR:-./data/minio}:/data
-    networks:
-      - cotalk-network
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 30s
-      timeout: 20s
-      retries: 3
+  # minio는 더 이상 이 머신(맥미니)에서 로컬로 띄우지 않는다.
+  # NAS(192.168.219.104:9000)에서 외부 운영하며, app은 MINIO_ENDPOINT,
+  # nginx는 /minio/ proxy_pass로 NAS 주소를 직접 가리킨다.
+  # (과거 로컬 minio 서비스가 nginx의 docker DNS resolve 실패를 유발해
+  #  crash-loop → 배포 실패를 일으켰으므로 로컬 서비스를 제거함.)
 
 networks:
   cotalk-network:

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -73,6 +73,13 @@ http {
     # Managed by upstream.conf.
     include /etc/nginx/upstream.conf;
 
+    # Docker 내장 DNS(127.0.0.11) 기반 런타임 resolver.
+    # 변수를 쓰는 proxy_pass(아래 prometheus 등)는 nginx 기동 시점이 아니라
+    # 요청 시점에 호스트명을 resolve한다. 이렇게 하면 모니터링 스택(prometheus 등)이
+    # 아직 안 떠 있어도 nginx가 기동 시 DNS resolve 실패로 crash-loop에 빠지지 않는다.
+    # (해당 업스트림이 없으면 그 요청만 502가 나고, 다른 라우트는 정상 동작.)
+    resolver 127.0.0.11 valid=30s ipv6=off;
+
     # Main server block
     server {
         # SSL/TLS termination은 Synology 리버스 프록시에서 처리
@@ -109,7 +116,9 @@ http {
         location /minio/ {
             # NAS minio (자체 운영). IP 고정 사용 — docker 서비스명 아님.
             # IP 직접 사용으로 nginx 시작 시 DNS resolve 불필요 → crash-loop 방지.
-            # NAS IP 변경 시 이 줄을 수정할 것.
+            # NAS IP 변경 시: 이 줄 + .env(MINIO_ENDPOINT/MINIO_PUBLIC_URL) + deploy.yml의
+            # vars.MINIO_ENDPOINT 기본값을 함께 수정. 전체 위치 목록은 docs/RELEASE_RUNBOOK.md 참고.
+            # (nginx는 env를 직접 못 읽으므로 IP를 하드코딩한다.)
             proxy_pass http://192.168.219.104:9000/;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
@@ -196,8 +205,12 @@ http {
                 deny all;
             }
 
-            # 쿼리 파라미터 제거 후 Prometheus로 전달
-            proxy_pass http://prometheus:9090/api/v1/write;
+            # 쿼리 파라미터 제거 후 Prometheus로 전달.
+            # prometheus는 docker 서비스명이며 모니터링 스택(선택적 실행)에만 존재한다.
+            # 변수 + 위쪽 resolver(127.0.0.11)로 요청 시점에 resolve하여,
+            # 모니터링 스택이 안 떠 있어도 nginx 기동이 crash-loop에 빠지지 않게 한다.
+            set $prometheus_upstream "http://prometheus:9090";
+            proxy_pass $prometheus_upstream/api/v1/write;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $real_client_ip;
             proxy_set_header X-Forwarded-For $real_client_ip;

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -107,7 +107,10 @@ http {
         # Public MinIO object reads.
         # App returns URLs like /minio/{bucket}/{object-key}; bucket policy controls read access.
         location /minio/ {
-            proxy_pass http://minio:9000/;
+            # NAS minio (자체 운영). IP 고정 사용 — docker 서비스명 아님.
+            # IP 직접 사용으로 nginx 시작 시 DNS resolve 불필요 → crash-loop 방지.
+            # NAS IP 변경 시 이 줄을 수정할 것.
+            proxy_pass http://192.168.219.104:9000/;
             proxy_http_version 1.1;
             proxy_set_header Connection "";
             proxy_set_header Host $host;

--- a/docs/RELEASE_RUNBOOK.md
+++ b/docs/RELEASE_RUNBOOK.md
@@ -21,6 +21,30 @@
 
 ---
 
+## 0-1. 인프라 토폴로지 — MinIO는 NAS 외부 운영 (상시 사실)
+
+> 이 절은 특정 릴리스가 아니라 **현재 인프라 구성의 상시 사실**이다. minio 관련 배포 사고를 막기 위해 항상 참고한다.
+
+- **MinIO는 운영 머신(맥미니)에 띄우지 않는다.** NAS에서 외부 운영하며, 내부 접근 주소는 **`http://192.168.219.104:9000`** 이다(맥미니 호스트에서 HTTP 200 도달 확인).
+- **app**은 `MINIO_ENDPOINT` 환경변수로 NAS 주소를 가리킨다(업로드·presigned URL 생성용).
+  - `docker-compose.yml`/`docker-compose.nas.yml`의 app 서비스: `MINIO_ENDPOINT=${MINIO_ENDPOINT:-http://192.168.219.104:9000}` (기본값 NAS, `.env`로 override 가능).
+  - 운영 `.env`는 `deploy.yml`의 "Create .env from secrets"가 재생성하며, `MINIO_ENDPOINT=${{ vars.MINIO_ENDPOINT || 'http://192.168.219.104:9000' }}` 라인으로 주입된다(secret 아닌 설정값이라 Actions **variable** 또는 하드코딩 기본값).
+- **nginx**(`docker/nginx/nginx.conf`)의 `location /minio/`는 `proxy_pass http://192.168.219.104:9000/;` 로 **IP를 직접** 가리킨다.
+  - **IP 직접 사용이 핵심**: docker 서비스명(`minio:9000`)이면 nginx 시작 시 DNS resolve가 필요한데, 로컬 minio 컨테이너가 없으면 resolve 실패로 nginx가 **crash-loop**에 빠져 8081(API)이 죽고 **이후 모든 배포가 실패**한다(#173 이후 사고의 직접 원인). IP는 resolve가 불필요하므로 안전하다.
+- **`docker-compose.yml`(맥미니)에서 로컬 minio 서비스는 제거**됐다. `scripts/deploy.sh`도 `dc up -d postgres redis`로만 인프라를 띄운다(minio 제외).
+- **`docker-compose.nas.yml`의 minio 서비스는 유지**된다 — 이 파일은 NAS(Synology) 자체 배포용이며 minio가 Synology 볼륨 `/volume1/docker/co-talk/minio`를 사용한다(NAS가 직접 minio를 운영하는 주체). NAS에서 app이 같은 docker 네트워크의 `minio`를 쓰려면 그 머신의 `.env`에서 `MINIO_ENDPOINT=http://minio:9000`으로 override 한다.
+- **`MINIO_PUBLIC_URL`**(클라이언트가 보는 외부 다운로드 URL)은 변경 없음.
+
+### NAS IP 변경 시 수정 위치
+1. `docker/nginx/nginx.conf` 의 `location /minio/` `proxy_pass` 줄.
+2. app `MINIO_ENDPOINT` 기본값(`docker-compose.yml`/`docker-compose.nas.yml`) 또는 운영 `.env`/Actions `vars.MINIO_ENDPOINT`.
+3. `.env.example` 의 `MINIO_ENDPOINT`.
+
+### ⚠️ 경고 — dev compose로 운영 머신에 minio 띄우지 말 것
+- `docker-compose.dev.yml`(로컬 개발용 minio)을 **운영 머신(맥미니)에서 실행하지 않는다.** 운영 minio는 NAS 단일 소스이며, 운영 머신에 로컬 minio 컨테이너를 띄우면 데이터가 둘로 갈라지고, 과거처럼 nginx가 docker 서비스명을 resolve하려다 crash-loop를 재현할 수 있다(이번 사고의 원인).
+
+---
+
 ## 1. 사전 준비 (배포 전 1회)
 
 ### 1-1. `BLIND_INDEX_SECRET` 생성

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -329,8 +329,9 @@ bootstrap() {
     docker buildx build --load -t cotalk-app:stable "${PROJECT_ROOT}"
     log_success "Image built: cotalk-app:stable"
 
-    log_info "Starting infrastructure services (postgres, redis, minio)..."
-    dc up -d postgres redis minio
+    # minio는 NAS(192.168.219.104:9000)에서 외부 운영하므로 여기서 띄우지 않는다.
+    log_info "Starting infrastructure services (postgres, redis)..."
+    dc up -d postgres redis
     log_info "Waiting for infra to be ready (20s)..."
     sleep 20
 


### PR DESCRIPTION
## 배경
운영(맥미니)에서 nginx가 `nginx.conf`의 `proxy_pass http://minio:9000`의 docker 서비스명 `minio`를 resolve하지 못해 **crash-loop**에 빠졌고, 8081(API)이 죽으면서 **#173 이후 모든 배포가 실패**했다. 원인은 minio를 같은 docker 네트워크에 두지 않고 **NAS에서 운영**하기로 결정했기 때문. NAS minio 주소 = `http://192.168.219.104:9000`(호스트에서 HTTP 200 도달 확인).

## 변경
- **app `MINIO_ENDPOINT` 외부화**: `docker-compose.yml`/`docker-compose.nas.yml`의 모든 app 서비스 `MINIO_ENDPOINT=http://minio:9000` → `MINIO_ENDPOINT=${MINIO_ENDPOINT:-http://192.168.219.104:9000}`. `.env.example`에 `MINIO_ENDPOINT` 추가, `deploy.yml`의 `.env` 생성에 `MINIO_ENDPOINT=${{ vars.MINIO_ENDPOINT || 'http://192.168.219.104:9000' }}` 주입.
- **nginx `/minio/` proxy_pass를 NAS IP 직접 지정**: `http://minio:9000/` → `http://192.168.219.104:9000/`. **IP 직접 사용 = nginx 시작 시 DNS resolve 불필요 → crash 방지**(이번 수정의 핵심).
- **맥미니 로컬 minio 서비스 제거**: `docker-compose.yml`의 minio 서비스 삭제 + `deploy.sh`의 `dc up -d postgres redis minio` → `postgres redis`.
- **런북 갱신**: minio NAS 외부 운영 토폴로지 명시, `MINIO_ENDPOINT` 변경 위치 정리, **dev compose(docker-compose.dev.yml)로 운영 머신에 minio 띄우지 말 것** 경고 추가.

## nas.yml minio 유지 결정
`docker-compose.nas.yml`의 minio는 **유지**한다. 이 파일은 NAS(Synology) 자체 배포용이며 minio가 Synology 볼륨 `/volume1/docker/co-talk/minio`를 사용하는 **NAS 운영 주체**이기 때문. 맥미니용 `docker-compose.yml`에서만 로컬 minio를 제거했다. NAS에서 app이 같은 네트워크의 minio를 쓰려면 그 머신 `.env`에서 `MINIO_ENDPOINT=http://minio:9000`으로 override 가능.

## 검증
- `bash -n scripts/deploy.sh` → OK
- `docker compose -f docker-compose.yml config --no-interpolate` → exit 0
- `docker compose -f docker-compose.nas.yml config --no-interpolate` → exit 0
- nginx.conf: `nginx:alpine nginx -t`로 upstream/토큰 스텁 주입 후 `/minio/` 블록까지 정상 파싱 확인(잔여 emerg는 런타임 전용 upstream 스텁 아티팩트로 본 변경과 무관).

## 머지 후 운영 조치
1. 운영 머신(맥미니)에 떠 있는 로컬/dev minio 컨테이너가 있으면 정리(`docker-compose.dev.yml`로 띄운 것 포함).
2. (선택) Actions repo **variable** `MINIO_ENDPOINT` 등록 — 미등록 시 하드코딩 기본값 `http://192.168.219.104:9000` 사용.
3. 재배포 → nginx가 NAS IP로 resolve 없이 기동되어 crash-loop 해소, 8081 정상화 확인. `/minio/` 다운로드와 app 업로드/presigned가 NAS로 가는지 스모크.

🤖 Generated with [Claude Code](https://claude.com/claude-code)