### PR TITLE
feat(security): OAuth 프로바이더 토큰 서버검증으로 계정 탈취 차단 (C-1)

### DIFF
--- a/src/main/java/com/cotalk/adapter/inbound/rest/OAuthController.java
+++ b/src/main/java/com/cotalk/adapter/inbound/rest/OAuthController.java
@@ -33,27 +33,23 @@ public class OAuthController {
 
     /**
      * OAuth 제공자를 통해 로그인한다.
+     * 클라이언트가 보낸 제공자 토큰을 서버가 검증하여 식별 정보를 도출하며,
      * 신규 사용자는 자동으로 회원가입 처리된다.
      *
-     * @param request OAuth 로그인 요청 정보 (제공자, OAuth ID, 이메일, 닉네임, 아바타 URL)
+     * @param request OAuth 로그인 요청 정보 (제공자, 제공자 토큰)
      * @return JWT 토큰 정보 및 신규 사용자 여부
      */
-    @Operation(summary = "소셜 로그인", description = "OAuth 제공자(카카오, 구글, 애플)를 통해 로그인합니다. 신규 사용자는 자동으로 회원가입됩니다.")
+    @Operation(summary = "소셜 로그인", description = "OAuth 제공자(카카오, 구글, 애플) 토큰을 서버에서 검증해 로그인합니다. 신규 사용자는 자동으로 회원가입됩니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "로그인 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청")
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "401", description = "제공자 토큰 검증 실패")
     })
     @PostMapping("/login")
     public ResponseEntity<OAuthLoginResponse> loginWithOAuth(@Valid @RequestBody OAuthLoginRequest request) {
         User.OAuthProvider provider = User.OAuthProvider.valueOf(request.provider());
 
-        OAuthLoginResult result = oAuthLoginService.loginWithOAuth(
-                provider,
-                request.oauthId(),
-                request.email(),
-                request.nickname(),
-                request.avatarUrl()
-        );
+        OAuthLoginResult result = oAuthLoginService.loginWithOAuth(provider, request.token());
 
         return ResponseEntity.ok(OAuthLoginResponse.of(
                 result.token(),

--- a/src/main/java/com/cotalk/adapter/inbound/rest/dto/auth/OAuthLoginRequest.java
+++ b/src/main/java/com/cotalk/adapter/inbound/rest/dto/auth/OAuthLoginRequest.java
@@ -1,50 +1,32 @@
 package com.cotalk.adapter.inbound.rest.dto.auth;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 /**
  * OAuth 로그인 요청 DTO.
  *
- * @param provider  OAuth 제공자 (KAKAO, GOOGLE, APPLE)
- * @param oauthId   OAuth 제공자에서 발급한 사용자 고유 ID
- * @param email     이메일 주소
- * @param nickname  닉네임
- * @param avatarUrl 프로필 이미지 URL (선택)
+ * <p>보안: 클라이언트는 더 이상 oauthId/email/nickname 등 식별 정보를 직접 보내지 않는다.
+ * 제공자 토큰만 보내며, 서버가 이를 검증하여 신뢰 가능한 식별 정보를 도출한다.</p>
+ *
+ * @param provider OAuth 제공자 (KAKAO, GOOGLE, APPLE)
+ * @param token    제공자 토큰 (카카오: access token, 구글/애플: id_token)
  * @author seunggu.lee
  */
 public record OAuthLoginRequest(
         @NotBlank(message = "OAuth 제공자는 필수입니다.")
         String provider,
 
-        @NotBlank(message = "OAuth ID는 필수입니다.")
-        String oauthId,
-
-        @NotBlank(message = "이메일은 필수입니다.")
-        @Email(message = "올바른 이메일 형식이 아닙니다.")
-        String email,
-
-        @NotBlank(message = "닉네임은 필수입니다.")
-        String nickname,
-
-        String avatarUrl
+        @NotBlank(message = "OAuth 토큰은 필수입니다.")
+        String token
 ) {
     /**
      * OAuthLoginRequest 인스턴스를 생성합니다.
      *
-     * @param provider  OAuth 제공자 (KAKAO, GOOGLE, APPLE)
-     * @param oauthId   OAuth 제공자에서 발급한 사용자 고유 ID
-     * @param email     이메일 주소
-     * @param nickname  닉네임
-     * @param avatarUrl 프로필 이미지 URL (선택)
+     * @param provider OAuth 제공자 (KAKAO, GOOGLE, APPLE)
+     * @param token    제공자 토큰 (카카오: access token, 구글/애플: id_token)
      * @return OAuthLoginRequest 인스턴스
      */
-    public static OAuthLoginRequest of(
-            String provider,
-            String oauthId,
-            String email,
-            String nickname,
-            String avatarUrl) {
-        return new OAuthLoginRequest(provider, oauthId, email, nickname, avatarUrl);
+    public static OAuthLoginRequest of(String provider, String token) {
+        return new OAuthLoginRequest(provider, token);
     }
 }

--- a/src/main/java/com/cotalk/application/service/auth/OAuthLoginService.java
+++ b/src/main/java/com/cotalk/application/service/auth/OAuthLoginService.java
@@ -2,10 +2,12 @@ package com.cotalk.application.service.auth;
 
 import com.cotalk.domain.entity.User;
 import com.cotalk.domain.model.Email;
+import com.cotalk.domain.model.VerifiedOAuthIdentity;
 import com.cotalk.domain.port.inbound.auth.OAuthLoginUseCase;
 import com.cotalk.domain.port.outbound.AuthTokenPort;
 import com.cotalk.domain.port.outbound.IdGenerator;
 import com.cotalk.domain.port.outbound.MetricsPort;
+import com.cotalk.domain.port.outbound.OAuthIdentityVerifier;
 import com.cotalk.domain.port.outbound.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +17,9 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * OAuth 로그인 서비스.
  * 소셜 로그인(카카오, 구글, 애플)을 처리하고 신규 사용자인 경우 자동 회원가입을 진행한다.
+ *
+ * <p>보안: 식별 정보(oauthId/email/nickname/avatar)는 클라이언트 입력을 신뢰하지 않고,
+ * 제공자 토큰을 {@link OAuthIdentityVerifier}로 서버 검증하여 도출한 값만 사용한다.</p>
  *
  * @author seunggu.lee
  */
@@ -28,30 +33,26 @@ public class OAuthLoginService implements OAuthLoginUseCase {
     private final AuthTokenPort authTokenPort;
     private final IdGenerator idGenerator;
     private final MetricsPort metricsPort;
+    private final OAuthIdentityVerifier oAuthIdentityVerifier;
 
     /**
      * OAuth 로그인을 처리한다.
-     * 기존 사용자인 경우 바로 로그인하고, 신규 사용자인 경우 자동 회원가입 후 로그인한다.
+     * 제공자 토큰을 검증하여 식별 정보를 도출한 뒤, 기존 사용자인 경우 바로 로그인하고
+     * 신규 사용자인 경우 자동 회원가입 후 로그인한다.
      *
-     * @param provider OAuth 제공자 (KAKAO, GOOGLE, APPLE)
-     * @param oauthId OAuth 제공자가 제공한 사용자 고유 ID
-     * @param email 사용자 이메일
-     * @param nickname 사용자 닉네임
-     * @param avatarUrl 프로필 이미지 URL (선택)
+     * @param provider      OAuth 제공자 (KAKAO, GOOGLE, APPLE)
+     * @param providerToken 제공자 토큰 (카카오: access token, 구글/애플: id_token)
      * @return 로그인 결과 (JWT 토큰, 신규 사용자 여부, 사용자 ID)
      */
-    public OAuthLoginResult loginWithOAuth(
-            User.OAuthProvider provider,
-            String oauthId,
-            String email,
-            String nickname,
-            String avatarUrl) {
+    @Override
+    public OAuthLoginResult loginWithOAuth(User.OAuthProvider provider, String providerToken) {
+        VerifiedOAuthIdentity identity = oAuthIdentityVerifier.verify(provider, providerToken);
 
-        log.debug("OAuth login attempt: provider={}, email={}", provider, maskEmail(email));
+        log.debug("OAuth login attempt: provider={}, email={}", provider, maskEmail(identity.email()));
 
-        return userRepository.findByOAuthProviderAndOAuthId(provider, oauthId)
+        return userRepository.findByOAuthProviderAndOAuthId(provider, identity.oauthId())
                 .map(existingUser -> loginExistingUser(existingUser, provider))
-                .orElseGet(() -> signUpAndLogin(provider, oauthId, email, nickname, avatarUrl));
+                .orElseGet(() -> signUpAndLogin(provider, identity));
     }
 
     private OAuthLoginResult loginExistingUser(User user, User.OAuthProvider provider) {
@@ -66,20 +67,14 @@ public class OAuthLoginService implements OAuthLoginUseCase {
         return new OAuthLoginResult(token, false, user.getId());
     }
 
-    private OAuthLoginResult signUpAndLogin(
-            User.OAuthProvider provider,
-            String oauthId,
-            String email,
-            String nickname,
-            String avatarUrl) {
-
+    private OAuthLoginResult signUpAndLogin(User.OAuthProvider provider, VerifiedOAuthIdentity identity) {
         User newUser = User.builder()
                 .id(idGenerator.nextId())
-                .email(new Email(email))
-                .nickname(nickname)
-                .avatarUrl(avatarUrl)
+                .email(resolveEmail(provider, identity))
+                .nickname(resolveNickname(identity))
+                .avatarUrl(identity.avatarUrl())
                 .oauthProvider(provider)
-                .oauthId(oauthId)
+                .oauthId(identity.oauthId())
                 .build();
 
         User savedUser = userRepository.save(newUser);
@@ -88,8 +83,40 @@ public class OAuthLoginService implements OAuthLoginUseCase {
         metricsPort.incrementUserRegistration();
         metricsPort.incrementLoginSuccess();
         log.info("OAuth sign-up and login successful: userId={}, provider={}, email={}",
-                savedUser.getId(), provider, maskEmail(email));
+                savedUser.getId(), provider, maskEmail(identity.email()));
         return new OAuthLoginResult(token, true, savedUser.getId());
+    }
+
+    /**
+     * 검증된 이메일로 {@link Email} 값 객체를 만든다.
+     * 제공자(특히 애플)가 이메일을 내려주지 않은 경우 합성 이메일을 생성한다.
+     *
+     * @param provider OAuth 제공자
+     * @param identity 검증된 식별 정보
+     * @return 이메일 값 객체
+     */
+    private Email resolveEmail(User.OAuthProvider provider, VerifiedOAuthIdentity identity) {
+        String email = identity.email();
+        if (email == null || email.isBlank()) {
+            String synthesized = provider.name().toLowerCase() + "_" + identity.oauthId() + "@oauth.cotalk.local";
+            log.info("OAuth provider did not return email; using synthesized email for provider={}", provider);
+            return new Email(synthesized);
+        }
+        return new Email(email);
+    }
+
+    /**
+     * 검증된 닉네임을 결정한다. 제공자가 닉네임을 내려주지 않은 경우 기본 닉네임을 생성한다.
+     *
+     * @param identity 검증된 식별 정보
+     * @return 닉네임
+     */
+    private String resolveNickname(VerifiedOAuthIdentity identity) {
+        String nickname = identity.nickname();
+        if (nickname == null || nickname.isBlank()) {
+            return "user_" + identity.oauthId();
+        }
+        return nickname;
     }
 
     /**

--- a/src/main/java/com/cotalk/application/service/auth/OAuthLoginService.java
+++ b/src/main/java/com/cotalk/application/service/auth/OAuthLoginService.java
@@ -1,6 +1,7 @@
 package com.cotalk.application.service.auth;
 
 import com.cotalk.domain.entity.User;
+import com.cotalk.domain.exception.DuplicateEmailException;
 import com.cotalk.domain.model.Email;
 import com.cotalk.domain.model.VerifiedOAuthIdentity;
 import com.cotalk.domain.port.inbound.auth.OAuthLoginUseCase;
@@ -67,10 +68,32 @@ public class OAuthLoginService implements OAuthLoginUseCase {
         return new OAuthLoginResult(token, false, user.getId());
     }
 
+    /**
+     * 신규 사용자를 자동 회원가입한 뒤 로그인한다.
+     *
+     * <p>정책(보안): 조회는 (provider, oauthId)로 이뤄지므로 동일 계정의 재로그인은 위 경로에서
+     * 처리되어 여기에 도달하지 않는다. 따라서 이 경로에서 검증된 이메일이 이미 다른 계정에
+     * 존재한다면, 서로 다른 OAuth 신원이 같은 이메일을 주장하는 충돌 상황이다. 이때 두 계정을
+     * 자동 연결(link)하면 이메일 탈취로 인한 계정 병합 위험이 있으므로, 자동 연결하지 않고
+     * 명시적으로 거부한다(reject-not-link). DB 유니크 제약 위반은
+     * {@link com.cotalk.infrastructure.exception.GlobalExceptionHandler}에서 409로 위생 처리된다.</p>
+     *
+     * @param provider OAuth 제공자
+     * @param identity 검증된 식별 정보
+     * @return 로그인 결과
+     * @throws DuplicateEmailException 검증된 이메일이 이미 다른 계정에 존재하는 경우
+     */
     private OAuthLoginResult signUpAndLogin(User.OAuthProvider provider, VerifiedOAuthIdentity identity) {
+        Email email = resolveEmail(provider, identity);
+        if (userRepository.existsByEmail(email.value())) {
+            log.warn("OAuth 자동가입 거부: 이미 다른 계정에 존재하는 이메일 (provider={}, email={})",
+                    provider, maskEmail(email.value()));
+            throw new DuplicateEmailException();
+        }
+
         User newUser = User.builder()
                 .id(idGenerator.nextId())
-                .email(resolveEmail(provider, identity))
+                .email(email)
                 .nickname(resolveNickname(identity))
                 .avatarUrl(identity.avatarUrl())
                 .oauthProvider(provider)

--- a/src/main/java/com/cotalk/domain/exception/OAuthVerificationException.java
+++ b/src/main/java/com/cotalk/domain/exception/OAuthVerificationException.java
@@ -1,0 +1,32 @@
+package com.cotalk.domain.exception;
+
+/**
+ * OAuth 제공자 토큰 서버 검증에 실패했을 때 발생하는 예외.
+ *
+ * <p>토큰 만료/위조, 서명 불일치, {@code aud}/{@code iss} 불일치, 제공자 API 호출 실패 등
+ * 검증 단계의 모든 실패를 표현한다. {@link HttpStatusHint#UNAUTHORIZED 401}로 매핑되어
+ * 인증 실패로 응답된다.</p>
+ *
+ * @author seunggu.lee
+ */
+public class OAuthVerificationException extends DomainException {
+
+    /**
+     * 메시지를 지정하여 예외를 생성한다.
+     *
+     * @param message 실패 사유 메시지
+     */
+    public OAuthVerificationException(String message) {
+        super(message, "OAUTH_VERIFICATION_FAILED", HttpStatusHint.UNAUTHORIZED);
+    }
+
+    /**
+     * 메시지와 원인을 지정하여 예외를 생성한다.
+     *
+     * @param message 실패 사유 메시지
+     * @param cause   근본 원인 예외
+     */
+    public OAuthVerificationException(String message, Throwable cause) {
+        super(message, "OAUTH_VERIFICATION_FAILED", HttpStatusHint.UNAUTHORIZED, cause);
+    }
+}

--- a/src/main/java/com/cotalk/domain/model/VerifiedOAuthIdentity.java
+++ b/src/main/java/com/cotalk/domain/model/VerifiedOAuthIdentity.java
@@ -1,0 +1,42 @@
+package com.cotalk.domain.model;
+
+/**
+ * OAuth 제공자(카카오/구글/애플) 토큰을 서버에서 검증한 뒤 도출한 신뢰 가능한 사용자 식별 정보.
+ *
+ * <p>이 값 객체에 담긴 모든 필드는 클라이언트가 보낸 값이 아니라,
+ * 제공자 토큰(카카오 access token, 구글/애플 id_token)을 서버가 직접 검증하여
+ * 얻은 값이다. 따라서 인증·회원가입 로직은 클라이언트가 보낸 식별 정보 대신
+ * 반드시 이 객체의 값만 신뢰해야 한다.</p>
+ *
+ * <p>{@code oauthId}는 항상 존재해야 하며(불변식), {@code email}/{@code nickname}/
+ * {@code avatarUrl}은 제공자나 사용자 동의 범위에 따라 부재할 수 있다
+ * (예: 애플은 최초 로그인 이후 이메일을 내려주지 않을 수 있다).</p>
+ *
+ * @param oauthId   제공자가 발급한 사용자 고유 ID (카카오 {@code id}, 구글/애플 {@code sub}). 필수.
+ * @param email     검증된 이메일 (없을 수 있음)
+ * @param nickname  검증된 닉네임/표시 이름 (없을 수 있음)
+ * @param avatarUrl 검증된 프로필 이미지 URL (없을 수 있음)
+ * @author seunggu.lee
+ */
+public record VerifiedOAuthIdentity(
+        String oauthId,
+        String email,
+        String nickname,
+        String avatarUrl
+) {
+
+    /**
+     * 검증된 OAuth 식별 정보를 생성한다.
+     *
+     * @param oauthId   제공자가 발급한 사용자 고유 ID. 필수.
+     * @param email     검증된 이메일 (없을 수 있음)
+     * @param nickname  검증된 닉네임 (없을 수 있음)
+     * @param avatarUrl 검증된 프로필 이미지 URL (없을 수 있음)
+     * @throws IllegalArgumentException {@code oauthId}가 null이거나 공백인 경우
+     */
+    public VerifiedOAuthIdentity {
+        if (oauthId == null || oauthId.isBlank()) {
+            throw new IllegalArgumentException("검증된 oauthId는 비어 있을 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/com/cotalk/domain/port/inbound/auth/OAuthLoginUseCase.java
+++ b/src/main/java/com/cotalk/domain/port/inbound/auth/OAuthLoginUseCase.java
@@ -11,22 +11,16 @@ import com.cotalk.domain.entity.User;
 public interface OAuthLoginUseCase {
 
     /**
-     * OAuth 제공자를 통해 로그인한다.
-     * 신규 사용자인 경우 자동 회원가입 후 로그인한다.
+     * 제공자 토큰을 서버에서 검증한 뒤 OAuth 로그인을 처리한다.
      *
-     * @param provider  OAuth 제공자 (KAKAO, GOOGLE, APPLE)
-     * @param oauthId   OAuth 제공자가 제공한 사용자 고유 ID
-     * @param email     사용자 이메일
-     * @param nickname  사용자 닉네임
-     * @param avatarUrl 프로필 이미지 URL (선택)
+     * <p>식별 정보(oauthId/email/nickname/avatar)는 클라이언트 입력이 아니라
+     * 검증된 제공자 토큰에서만 도출한다. 신규 사용자인 경우 자동 회원가입 후 로그인한다.</p>
+     *
+     * @param provider      OAuth 제공자 (KAKAO, GOOGLE, APPLE)
+     * @param providerToken 제공자 토큰 (카카오: access token, 구글/애플: id_token)
      * @return 로그인 결과 (JWT 토큰, 신규 사용자 여부, 사용자 ID)
      */
-    OAuthLoginResult loginWithOAuth(
-            User.OAuthProvider provider,
-            String oauthId,
-            String email,
-            String nickname,
-            String avatarUrl);
+    OAuthLoginResult loginWithOAuth(User.OAuthProvider provider, String providerToken);
 
     /**
      * OAuth 로그인 결과.

--- a/src/main/java/com/cotalk/domain/port/outbound/OAuthIdentityVerifier.java
+++ b/src/main/java/com/cotalk/domain/port/outbound/OAuthIdentityVerifier.java
@@ -1,0 +1,32 @@
+package com.cotalk.domain.port.outbound;
+
+import com.cotalk.domain.entity.User;
+import com.cotalk.domain.exception.OAuthVerificationException;
+import com.cotalk.domain.model.VerifiedOAuthIdentity;
+
+/**
+ * OAuth 제공자(카카오/구글/애플)가 발급한 토큰을 서버에서 검증하여
+ * 신뢰 가능한 사용자 식별 정보를 도출하는 아웃바운드 포트.
+ *
+ * <p>이 포트의 존재 이유: 클라이언트가 보낸 {@code oauthId}/{@code email} 등을 그대로 신뢰하면
+ * 공격자가 피해자의 {@code oauthId}만 알아도 세션 토큰을 발급받는 계정 탈취가 가능하다.
+ * 따라서 인증 식별 정보는 반드시 제공자 토큰을 서버가 직접 검증해 도출해야 한다.</p>
+ *
+ * <p>구현 어댑터는 {@code infrastructure} 계층에 위치하며, 카카오는 userinfo API 호출,
+ * 구글/애플은 id_token JWT 서명을 제공자 JWKS로 검증하는 방식으로 식별 정보를 얻는다.</p>
+ *
+ * @author seunggu.lee
+ */
+public interface OAuthIdentityVerifier {
+
+    /**
+     * 제공자 토큰을 검증하여 신뢰 가능한 사용자 식별 정보를 반환한다.
+     *
+     * @param provider      OAuth 제공자 (KAKAO, GOOGLE, APPLE)
+     * @param providerToken 제공자 토큰 (카카오: access token, 구글/애플: id_token)
+     * @return 검증된 사용자 식별 정보 (제공자 토큰에서 도출, 클라이언트 입력 아님)
+     * @throws OAuthVerificationException 토큰이 유효하지 않거나(만료/서명/aud/iss 불일치),
+     *                                    네트워크 오류 등으로 검증에 실패한 경우
+     */
+    VerifiedOAuthIdentity verify(User.OAuthProvider provider, String providerToken);
+}

--- a/src/main/java/com/cotalk/infrastructure/config/properties/OAuthProperties.java
+++ b/src/main/java/com/cotalk/infrastructure/config/properties/OAuthProperties.java
@@ -1,0 +1,62 @@
+package com.cotalk.infrastructure.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * OAuth 제공자 토큰 검증 설정 프로퍼티.
+ *
+ * <p>구글/애플 id_token의 {@code aud}(audience) 검증에 사용할 클라이언트 ID를 보관한다.
+ * 프로덕션에서는 반드시 환경변수로 주입해야 하며, 미설정 시 해당 제공자 검증은
+ * fail-closed(거부)된다.</p>
+ *
+ * @param google 구글 OAuth 설정
+ * @param apple  애플 OAuth 설정
+ * @author seunggu.lee
+ */
+@ConfigurationProperties(prefix = "app.oauth")
+public record OAuthProperties(
+        Google google,
+        Apple apple
+) {
+
+    /**
+     * 누락된 하위 설정을 기본값(빈 client-id)으로 보정한다.
+     *
+     * @param google 구글 OAuth 설정
+     * @param apple  애플 OAuth 설정
+     */
+    public OAuthProperties {
+        if (google == null) {
+            google = new Google("");
+        }
+        if (apple == null) {
+            apple = new Apple("");
+        }
+    }
+
+    /**
+     * 구글 OAuth 설정.
+     *
+     * @param clientId 구글 OAuth 클라이언트 ID (id_token aud 검증용). 미설정 시 fail-closed.
+     */
+    public record Google(String clientId) {
+        public Google {
+            if (clientId == null) {
+                clientId = "";
+            }
+        }
+    }
+
+    /**
+     * 애플 OAuth 설정.
+     *
+     * @param clientId 애플 OAuth 클라이언트 ID(서비스 ID, id_token aud 검증용). 미설정 시 fail-closed.
+     */
+    public record Apple(String clientId) {
+        public Apple {
+            if (clientId == null) {
+                clientId = "";
+            }
+        }
+    }
+}

--- a/src/main/java/com/cotalk/infrastructure/config/properties/OAuthProperties.java
+++ b/src/main/java/com/cotalk/infrastructure/config/properties/OAuthProperties.java
@@ -5,25 +5,29 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 /**
  * OAuth 제공자 토큰 검증 설정 프로퍼티.
  *
- * <p>구글/애플 id_token의 {@code aud}(audience) 검증에 사용할 클라이언트 ID를 보관한다.
+ * <p>구글/애플 id_token의 {@code aud}(audience) 검증에 사용할 클라이언트 ID와,
+ * 카카오 access token이 우리 앱에 발급된 토큰인지 확인할 app-id를 보관한다.
  * 프로덕션에서는 반드시 환경변수로 주입해야 하며, 미설정 시 해당 제공자 검증은
  * fail-closed(거부)된다.</p>
  *
  * @param google 구글 OAuth 설정
  * @param apple  애플 OAuth 설정
+ * @param kakao  카카오 OAuth 설정
  * @author seunggu.lee
  */
 @ConfigurationProperties(prefix = "app.oauth")
 public record OAuthProperties(
         Google google,
-        Apple apple
+        Apple apple,
+        Kakao kakao
 ) {
 
     /**
-     * 누락된 하위 설정을 기본값(빈 client-id)으로 보정한다.
+     * 누락된 하위 설정을 기본값(빈 식별자)으로 보정한다.
      *
      * @param google 구글 OAuth 설정
      * @param apple  애플 OAuth 설정
+     * @param kakao  카카오 OAuth 설정
      */
     public OAuthProperties {
         if (google == null) {
@@ -31,6 +35,9 @@ public record OAuthProperties(
         }
         if (apple == null) {
             apple = new Apple("");
+        }
+        if (kakao == null) {
+            kakao = new Kakao("");
         }
     }
 
@@ -56,6 +63,24 @@ public record OAuthProperties(
         public Apple {
             if (clientId == null) {
                 clientId = "";
+            }
+        }
+    }
+
+    /**
+     * 카카오 OAuth 설정.
+     *
+     * <p>카카오 access token은 우리 앱에 발급된 것이 아니어도 {@code /v2/user/me}로
+     * 사용자 정보를 얻을 수 있어, 다른 앱에서 유출된 토큰이 리플레이될 수 있다.
+     * 이를 막기 위해 {@code /v1/user/access_token_info}로 토큰의 {@code app_id}를 조회해
+     * 이 설정값과 일치하는지 검증한다. 미설정 시 fail-closed(거부)된다.</p>
+     *
+     * @param appId 카카오 애플리케이션 ID(access token app_id 검증용). 미설정 시 fail-closed.
+     */
+    public record Kakao(String appId) {
+        public Kakao {
+            if (appId == null) {
+                appId = "";
             }
         }
     }

--- a/src/main/java/com/cotalk/infrastructure/config/properties/PropertiesConfig.java
+++ b/src/main/java/com/cotalk/infrastructure/config/properties/PropertiesConfig.java
@@ -15,7 +15,8 @@ import org.springframework.context.annotation.Configuration;
         MinioProperties.class,
         FirebaseProperties.class,
         SnowflakeProperties.class,
-        FileUploadProperties.class
+        FileUploadProperties.class,
+        OAuthProperties.class
 })
 public class PropertiesConfig {
 }

--- a/src/main/java/com/cotalk/infrastructure/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/cotalk/infrastructure/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import com.cotalk.domain.exception.RateLimitExceededException;
 import com.cotalk.infrastructure.lock.DistributedLockException;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -109,6 +110,23 @@ public class GlobalExceptionHandler {
         }
         return ResponseEntity.status(status)
                 .body(new ErrorResponse(e.getMessage(), e.getErrorCode(), LocalDateTime.now()));
+    }
+
+    /**
+     * 데이터 무결성 위반 예외를 처리한다.
+     *
+     * <p>유니크 제약(예: 이메일/닉네임 중복) 위반 등 DB 무결성 위반이 도메인 예외로
+     * 사전에 걸러지지 않고 영속 계층까지 도달한 경우를 위생 처리한다. 프레임워크/JDBC
+     * 내부 영문 메시지와 스택 정보를 노출하지 않고 고정 한국어 메시지로 409를 반환한다.</p>
+     *
+     * @param e 데이터 무결성 위반 예외
+     * @return 409 Conflict 응답 (위생 처리된 메시지)
+     */
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ErrorResponse> handleDataIntegrityViolation(DataIntegrityViolationException e) {
+        log.warn("데이터 무결성 위반: {}", e.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(new ErrorResponse("이미 존재하는 데이터와 충돌합니다.", "DATA_INTEGRITY_VIOLATION", LocalDateTime.now()));
     }
 
     /**

--- a/src/main/java/com/cotalk/infrastructure/oauth/AppleTokenVerifier.java
+++ b/src/main/java/com/cotalk/infrastructure/oauth/AppleTokenVerifier.java
@@ -1,0 +1,87 @@
+package com.cotalk.infrastructure.oauth;
+
+import com.cotalk.domain.entity.User;
+import com.cotalk.domain.exception.OAuthVerificationException;
+import com.cotalk.domain.model.VerifiedOAuthIdentity;
+import com.cotalk.infrastructure.config.properties.OAuthProperties;
+import io.jsonwebtoken.Claims;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.util.Set;
+
+/**
+ * 애플 id_token 검증 전략.
+ *
+ * <p>애플 JWKS(https://appleid.apple.com/auth/keys)로 서명을 검증하고,
+ * {@code iss}가 {@code https://appleid.apple.com}, {@code aud}가 설정된 애플 client-id(서비스 ID),
+ * {@code exp}가 만료되지 않았는지 검증한다. {@code sub}로 oauthId를 도출한다.
+ * 애플은 최초 로그인 이후 {@code email}을 내려주지 않을 수 있으므로 이메일 부재를 정상 처리한다.</p>
+ *
+ * @author seunggu.lee
+ */
+@Component
+public class AppleTokenVerifier extends IdTokenVerifier implements ProviderTokenVerifier {
+
+    private static final String JWKS_URL = "https://appleid.apple.com/auth/keys";
+    private static final String ISSUER = "https://appleid.apple.com";
+
+    private final String clientId;
+
+    /**
+     * 애플 검증 전략을 생성한다.
+     *
+     * @param restClient      OAuth 전용 RestClient
+     * @param oAuthProperties OAuth 설정 프로퍼티 (애플 client-id 포함)
+     */
+    public AppleTokenVerifier(
+            @Qualifier("oauthRestClient") RestClient restClient,
+            OAuthProperties oAuthProperties) {
+        super(new JwksKeyProvider(restClient, JWKS_URL, "Apple"));
+        this.clientId = oAuthProperties.apple().clientId();
+    }
+
+    @Override
+    public User.OAuthProvider provider() {
+        return User.OAuthProvider.APPLE;
+    }
+
+    /**
+     * 애플 id_token을 검증하여 식별 정보를 반환한다.
+     *
+     * @param providerToken 애플 id_token
+     * @return 검증된 식별 정보 (이메일은 없을 수 있음)
+     * @throws OAuthVerificationException 검증 실패 시
+     */
+    @Override
+    public VerifiedOAuthIdentity verify(String providerToken) {
+        return verifyIdToken(providerToken);
+    }
+
+    @Override
+    protected Set<String> allowedIssuers() {
+        return Set.of(ISSUER);
+    }
+
+    @Override
+    protected String configuredAudience() {
+        return clientId;
+    }
+
+    @Override
+    protected String providerName() {
+        return "Apple";
+    }
+
+    /**
+     * 애플 id_token은 표시 이름 claim을 제공하지 않는다(이름은 최초 동의 시 별도 페이로드로 전달).
+     *
+     * @param claims 검증된 토큰 claims
+     * @return 항상 null
+     */
+    @Override
+    protected String extractNickname(Claims claims) {
+        return null;
+    }
+}

--- a/src/main/java/com/cotalk/infrastructure/oauth/GoogleTokenVerifier.java
+++ b/src/main/java/com/cotalk/infrastructure/oauth/GoogleTokenVerifier.java
@@ -1,0 +1,91 @@
+package com.cotalk.infrastructure.oauth;
+
+import com.cotalk.domain.entity.User;
+import com.cotalk.domain.exception.OAuthVerificationException;
+import com.cotalk.domain.model.VerifiedOAuthIdentity;
+import com.cotalk.infrastructure.config.properties.OAuthProperties;
+import io.jsonwebtoken.Claims;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.util.Set;
+
+/**
+ * 구글 id_token 검증 전략.
+ *
+ * <p>구글 JWKS(https://www.googleapis.com/oauth2/v3/certs)로 서명을 검증하고,
+ * {@code iss}가 {@code accounts.google.com}, {@code aud}가 설정된 구글 client-id,
+ * {@code exp}가 만료되지 않았는지 검증한다. {@code sub}로 oauthId를, {@code email}로 이메일을 도출한다.</p>
+ *
+ * @author seunggu.lee
+ */
+@Component
+public class GoogleTokenVerifier extends IdTokenVerifier implements ProviderTokenVerifier {
+
+    private static final String JWKS_URL = "https://www.googleapis.com/oauth2/v3/certs";
+    private static final String ISSUER_HTTPS = "https://accounts.google.com";
+    private static final String ISSUER_BARE = "accounts.google.com";
+
+    private final String clientId;
+
+    /**
+     * 구글 검증 전략을 생성한다.
+     *
+     * @param restClient      OAuth 전용 RestClient
+     * @param oAuthProperties OAuth 설정 프로퍼티 (구글 client-id 포함)
+     */
+    public GoogleTokenVerifier(
+            @Qualifier("oauthRestClient") RestClient restClient,
+            OAuthProperties oAuthProperties) {
+        super(new JwksKeyProvider(restClient, JWKS_URL, "Google"));
+        this.clientId = oAuthProperties.google().clientId();
+    }
+
+    @Override
+    public User.OAuthProvider provider() {
+        return User.OAuthProvider.GOOGLE;
+    }
+
+    /**
+     * 구글 id_token을 검증하여 식별 정보를 반환한다.
+     *
+     * @param providerToken 구글 id_token
+     * @return 검증된 식별 정보
+     * @throws OAuthVerificationException 검증 실패 시
+     */
+    @Override
+    public VerifiedOAuthIdentity verify(String providerToken) {
+        return verifyIdToken(providerToken);
+    }
+
+    /**
+     * 구글은 {@code iss}로 {@code https://accounts.google.com}과 {@code accounts.google.com}을
+     * 모두 사용할 수 있어 둘 다 허용한다.
+     *
+     * @return 허용 발급자 집합
+     */
+    @Override
+    protected Set<String> allowedIssuers() {
+        return Set.of(ISSUER_HTTPS, ISSUER_BARE);
+    }
+
+    @Override
+    protected String configuredAudience() {
+        return clientId;
+    }
+
+    @Override
+    protected String providerName() {
+        return "Google";
+    }
+
+    @Override
+    protected String extractNickname(Claims claims) {
+        String name = claims.get("name", String.class);
+        if (name != null && !name.isBlank()) {
+            return name;
+        }
+        return claims.get("given_name", String.class);
+    }
+}

--- a/src/main/java/com/cotalk/infrastructure/oauth/IdTokenVerifier.java
+++ b/src/main/java/com/cotalk/infrastructure/oauth/IdTokenVerifier.java
@@ -1,0 +1,120 @@
+package com.cotalk.infrastructure.oauth;
+
+import com.cotalk.domain.exception.OAuthVerificationException;
+import com.cotalk.domain.model.VerifiedOAuthIdentity;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.LocatorAdapter;
+import io.jsonwebtoken.ProtectedHeader;
+import lombok.extern.slf4j.Slf4j;
+
+import java.security.Key;
+import java.util.Set;
+
+/**
+ * 구글/애플 id_token(JWT) 검증을 위한 공통 베이스.
+ *
+ * <p>JWKS로 서명을 검증하고, jjwt가 {@code exp} 만료를 자동 검증한다. 추가로 발급자({@code iss})와
+ * 대상({@code aud}=설정된 client-id)을 명시적으로 검증한다. client-id가 설정되지 않았으면
+ * fail-closed로 검증을 거부한다.</p>
+ *
+ * @author seunggu.lee
+ */
+@Slf4j
+abstract class IdTokenVerifier {
+
+    private final JwksKeyProvider keyProvider;
+
+    /**
+     * id_token 검증기를 생성한다.
+     *
+     * @param keyProvider 제공자 JWKS 키 제공자
+     */
+    protected IdTokenVerifier(JwksKeyProvider keyProvider) {
+        this.keyProvider = keyProvider;
+    }
+
+    /**
+     * 이 제공자의 신뢰 가능한 발급자({@code iss}) 값 집합.
+     * 구글처럼 https/bare 두 형태를 쓰는 제공자를 위해 집합으로 둔다.
+     *
+     * @return 허용 발급자 집합
+     */
+    protected abstract Set<String> allowedIssuers();
+
+    /**
+     * {@code aud} 검증에 사용할 설정된 client-id.
+     *
+     * @return client-id (미설정 시 빈 문자열)
+     */
+    protected abstract String configuredAudience();
+
+    /**
+     * 로그/예외 메시지용 제공자 이름.
+     *
+     * @return 제공자 이름
+     */
+    protected abstract String providerName();
+
+    /**
+     * id_token을 검증하고 claims에서 검증된 식별 정보를 도출한다.
+     *
+     * @param idToken 제공자 id_token (JWT)
+     * @return 검증된 식별 정보
+     * @throws OAuthVerificationException 서명/만료/iss/aud 검증 실패 또는 client-id 미설정 시
+     */
+    protected VerifiedOAuthIdentity verifyIdToken(String idToken) {
+        String audience = configuredAudience();
+        if (audience == null || audience.isBlank()) {
+            // fail-closed: client-id가 설정되지 않으면 aud 검증이 불가능하므로 거부한다.
+            log.error("{} client-id가 설정되지 않아 id_token 검증을 거부합니다(fail-closed).", providerName());
+            throw new OAuthVerificationException(providerName() + " 검증 설정(client-id)이 누락되었습니다.");
+        }
+
+        Claims claims;
+        try {
+            Jws<Claims> jws = Jwts.parser()
+                    .keyLocator(new LocatorAdapter<Key>() {
+                        @Override
+                        protected Key locate(ProtectedHeader header) {
+                            return keyProvider.getKey(header.getKeyId());
+                        }
+                    })
+                    .requireAudience(audience)
+                    .build()
+                    .parseSignedClaims(idToken);
+            claims = jws.getPayload();
+        } catch (OAuthVerificationException e) {
+            throw e;
+        } catch (JwtException | IllegalArgumentException e) {
+            log.warn("{} id_token 검증 실패: {}", providerName(), e.getMessage());
+            throw new OAuthVerificationException(providerName() + " 토큰 검증에 실패했습니다.", e);
+        }
+
+        String issuer = claims.getIssuer();
+        if (issuer == null || !allowedIssuers().contains(issuer)) {
+            log.warn("{} id_token 발급자(iss) 불일치: {}", providerName(), issuer);
+            throw new OAuthVerificationException(providerName() + " 토큰 발급자가 올바르지 않습니다.");
+        }
+
+        String sub = claims.getSubject();
+        if (sub == null || sub.isBlank()) {
+            throw new OAuthVerificationException(providerName() + " 토큰에 sub가 없습니다.");
+        }
+
+        String email = claims.get("email", String.class);
+        return new VerifiedOAuthIdentity(sub, email, extractNickname(claims), null);
+    }
+
+    /**
+     * claims에서 닉네임/표시 이름을 추출한다. 제공자별로 오버라이드할 수 있다.
+     *
+     * @param claims 검증된 토큰 claims
+     * @return 닉네임 또는 null
+     */
+    protected String extractNickname(Claims claims) {
+        return claims.get("name", String.class);
+    }
+}

--- a/src/main/java/com/cotalk/infrastructure/oauth/JwksKeyProvider.java
+++ b/src/main/java/com/cotalk/infrastructure/oauth/JwksKeyProvider.java
@@ -20,6 +20,11 @@ import java.util.Map;
  * <p>구글/애플 id_token 서명 검증에 필요한 공개키를 제공한다. 캐시는 TTL이 지났거나
  * 요청한 {@code kid}가 캐시에 없을 때(키 롤오버 대비) 다시 가져온다.</p>
  *
+ * <p>증폭 방어: 알 수 없는 {@code kid}가 들어올 때마다 매번 JWKS를 재조회하면, 무작위
+ * kid를 흘리는 공격으로 제공자 JWKS 엔드포인트를 향한 무한 재요청을 유발할 수 있다.
+ * 이를 막기 위해 캐시 미스로 인한 재조회는 {@link #MIN_REFRESH_INTERVAL} 간격으로만
+ * 허용한다(네거티브 캐시). 알 수 없는 kid는 여전히 거부하므로(fail-closed) 보안은 유지된다.</p>
+ *
  * @author seunggu.lee
  */
 @Slf4j
@@ -27,12 +32,19 @@ class JwksKeyProvider {
 
     private static final Duration CACHE_TTL = Duration.ofMinutes(10);
 
+    /**
+     * 캐시 미스(알 수 없는 kid)로 인한 JWKS 재조회 사이의 최소 간격.
+     * TTL 만료로 인한 정상 갱신에는 적용되지 않으며, 무작위 kid 플러딩 증폭만 차단한다.
+     */
+    private static final Duration MIN_REFRESH_INTERVAL = Duration.ofSeconds(30);
+
     private final RestClient restClient;
     private final String jwksUrl;
     private final String providerName;
 
     private volatile Map<String, Key> cachedKeys = Map.of();
     private volatile Instant expiresAt = Instant.EPOCH;
+    private volatile Instant nextMissRefreshAllowedAt = Instant.EPOCH;
 
     /**
      * JWKS 키 제공자를 생성한다.
@@ -61,7 +73,11 @@ class JwksKeyProvider {
         }
 
         Map<String, Key> keys = cachedKeys;
-        if (Instant.now().isAfter(expiresAt) || !keys.containsKey(kid)) {
+        Instant now = Instant.now();
+        boolean ttlExpired = now.isAfter(expiresAt);
+        // 캐시 미스 재조회는 최소 간격이 지났을 때에만 허용(무작위 kid 플러딩 증폭 방어).
+        boolean missRefreshAllowed = !keys.containsKey(kid) && !now.isBefore(nextMissRefreshAllowedAt);
+        if (ttlExpired || missRefreshAllowed) {
             keys = refresh();
         }
 
@@ -73,8 +89,10 @@ class JwksKeyProvider {
     }
 
     private synchronized Map<String, Key> refresh() {
-        // 다른 스레드가 방금 갱신했고 현재 키 셋으로 충분하면 재조회 생략
-        if (Instant.now().isBefore(expiresAt)) {
+        // 다른 스레드가 방금 갱신했고(TTL 내) 미스 재조회 최소 간격도 아직이면 재조회 생략.
+        // 미스 재조회 최소 간격이 지났다면(키 롤오버 대비) TTL 내라도 한 번은 재조회를 허용한다.
+        Instant now = Instant.now();
+        if (now.isBefore(expiresAt) && now.isBefore(nextMissRefreshAllowedAt)) {
             return cachedKeys;
         }
         String json;
@@ -102,7 +120,10 @@ class JwksKeyProvider {
                 }
             }
             this.cachedKeys = Map.copyOf(keys);
-            this.expiresAt = Instant.now().plus(CACHE_TTL);
+            Instant refreshedAt = Instant.now();
+            this.expiresAt = refreshedAt.plus(CACHE_TTL);
+            // 방금 갱신했으므로 다음 캐시-미스 재조회는 최소 간격 이후에만 허용한다.
+            this.nextMissRefreshAllowedAt = refreshedAt.plus(MIN_REFRESH_INTERVAL);
             return this.cachedKeys;
         } catch (RuntimeException e) {
             log.warn("{} JWKS 파싱 실패: {}", providerName, e.getMessage());

--- a/src/main/java/com/cotalk/infrastructure/oauth/JwksKeyProvider.java
+++ b/src/main/java/com/cotalk/infrastructure/oauth/JwksKeyProvider.java
@@ -1,0 +1,112 @@
+package com.cotalk.infrastructure.oauth;
+
+import com.cotalk.domain.exception.OAuthVerificationException;
+import io.jsonwebtoken.security.Jwk;
+import io.jsonwebtoken.security.JwkSet;
+import io.jsonwebtoken.security.Jwks;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+import java.security.Key;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 제공자 JWKS(JSON Web Key Set)를 가져와 {@code kid → 공개키} 매핑을 짧은 TTL로 캐싱하는 헬퍼.
+ *
+ * <p>구글/애플 id_token 서명 검증에 필요한 공개키를 제공한다. 캐시는 TTL이 지났거나
+ * 요청한 {@code kid}가 캐시에 없을 때(키 롤오버 대비) 다시 가져온다.</p>
+ *
+ * @author seunggu.lee
+ */
+@Slf4j
+class JwksKeyProvider {
+
+    private static final Duration CACHE_TTL = Duration.ofMinutes(10);
+
+    private final RestClient restClient;
+    private final String jwksUrl;
+    private final String providerName;
+
+    private volatile Map<String, Key> cachedKeys = Map.of();
+    private volatile Instant expiresAt = Instant.EPOCH;
+
+    /**
+     * JWKS 키 제공자를 생성한다.
+     *
+     * @param restClient   JWKS를 가져올 RestClient
+     * @param jwksUrl      제공자 JWKS 엔드포인트 URL
+     * @param providerName 로그용 제공자 이름
+     */
+    JwksKeyProvider(RestClient restClient, String jwksUrl, String providerName) {
+        this.restClient = restClient;
+        this.jwksUrl = jwksUrl;
+        this.providerName = providerName;
+    }
+
+    /**
+     * 주어진 {@code kid}에 해당하는 서명 검증용 공개키를 반환한다.
+     * 캐시 미스나 TTL 만료 시 JWKS를 다시 가져온다.
+     *
+     * @param kid id_token 헤더의 키 식별자
+     * @return 해당 키 (없으면 {@link OAuthVerificationException})
+     * @throws OAuthVerificationException 키를 찾을 수 없거나 JWKS 조회에 실패한 경우
+     */
+    Key getKey(String kid) {
+        if (kid == null || kid.isBlank()) {
+            throw new OAuthVerificationException(providerName + " id_token에 kid가 없습니다.");
+        }
+
+        Map<String, Key> keys = cachedKeys;
+        if (Instant.now().isAfter(expiresAt) || !keys.containsKey(kid)) {
+            keys = refresh();
+        }
+
+        Key key = keys.get(kid);
+        if (key == null) {
+            throw new OAuthVerificationException(providerName + " JWKS에서 kid=" + kid + " 키를 찾을 수 없습니다.");
+        }
+        return key;
+    }
+
+    private synchronized Map<String, Key> refresh() {
+        // 다른 스레드가 방금 갱신했고 현재 키 셋으로 충분하면 재조회 생략
+        if (Instant.now().isBefore(expiresAt)) {
+            return cachedKeys;
+        }
+        String json;
+        try {
+            json = restClient.get()
+                    .uri(jwksUrl)
+                    .retrieve()
+                    .body(String.class);
+        } catch (RestClientException e) {
+            log.warn("{} JWKS 조회 실패: {}", providerName, e.getMessage());
+            throw new OAuthVerificationException(providerName + " 공개키 조회에 실패했습니다.", e);
+        }
+
+        if (json == null || json.isBlank()) {
+            throw new OAuthVerificationException(providerName + " JWKS 응답이 비어 있습니다.");
+        }
+
+        try {
+            JwkSet jwkSet = Jwks.setParser().build().parse(json);
+            Map<String, Key> keys = new HashMap<>();
+            for (Jwk<?> jwk : jwkSet.getKeys()) {
+                String kid = jwk.getId();
+                if (kid != null) {
+                    keys.put(kid, jwk.toKey());
+                }
+            }
+            this.cachedKeys = Map.copyOf(keys);
+            this.expiresAt = Instant.now().plus(CACHE_TTL);
+            return this.cachedKeys;
+        } catch (RuntimeException e) {
+            log.warn("{} JWKS 파싱 실패: {}", providerName, e.getMessage());
+            throw new OAuthVerificationException(providerName + " 공개키 파싱에 실패했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/cotalk/infrastructure/oauth/KakaoTokenVerifier.java
+++ b/src/main/java/com/cotalk/infrastructure/oauth/KakaoTokenVerifier.java
@@ -1,0 +1,96 @@
+package com.cotalk.infrastructure.oauth;
+
+import com.cotalk.domain.entity.User;
+import com.cotalk.domain.exception.OAuthVerificationException;
+import com.cotalk.domain.model.VerifiedOAuthIdentity;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+/**
+ * 카카오 access token 검증 전략.
+ *
+ * <p>{@code GET https://kapi.kakao.com/v2/user/me}를 {@code Authorization: Bearer <access_token>}로
+ * 호출하여 응답의 {@code id}, {@code kakao_account.email},
+ * {@code kakao_account.profile.nickname}, {@code kakao_account.profile.profile_image_url}로부터
+ * 검증된 식별 정보를 도출한다. 토큰이 유효하지 않으면 카카오가 401을 반환하며 이를
+ * {@link OAuthVerificationException}으로 변환한다.</p>
+ *
+ * @author seunggu.lee
+ */
+@Slf4j
+@Component
+public class KakaoTokenVerifier implements ProviderTokenVerifier {
+
+    private static final String USERINFO_URL = "https://kapi.kakao.com/v2/user/me";
+
+    private final RestClient restClient;
+
+    /**
+     * 카카오 검증 전략을 생성한다.
+     *
+     * @param restClient OAuth 전용 RestClient
+     */
+    public KakaoTokenVerifier(@Qualifier("oauthRestClient") RestClient restClient) {
+        this.restClient = restClient;
+    }
+
+    @Override
+    public User.OAuthProvider provider() {
+        return User.OAuthProvider.KAKAO;
+    }
+
+    /**
+     * 카카오 access token으로 userinfo를 조회해 검증된 식별 정보를 반환한다.
+     *
+     * @param providerToken 카카오 access token
+     * @return 검증된 식별 정보
+     * @throws OAuthVerificationException 토큰이 유효하지 않거나 호출에 실패한 경우
+     */
+    @Override
+    public VerifiedOAuthIdentity verify(String providerToken) {
+        JsonNode body;
+        try {
+            body = restClient.get()
+                    .uri(USERINFO_URL)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + providerToken)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .retrieve()
+                    .body(JsonNode.class);
+        } catch (RestClientException e) {
+            log.warn("Kakao userinfo 호출 실패: {}", e.getMessage());
+            throw new OAuthVerificationException("카카오 토큰 검증에 실패했습니다.", e);
+        }
+
+        if (body == null || !body.hasNonNull("id")) {
+            throw new OAuthVerificationException("카카오 응답에 사용자 ID가 없습니다.");
+        }
+
+        String oauthId = body.get("id").asText();
+        JsonNode account = body.path("kakao_account");
+        JsonNode profile = account.path("profile");
+
+        String email = textOrNull(account, "email");
+        String nickname = textOrNull(profile, "nickname");
+        String avatarUrl = textOrNull(profile, "profile_image_url");
+
+        return new VerifiedOAuthIdentity(oauthId, email, nickname, avatarUrl);
+    }
+
+    /**
+     * 노드에서 텍스트 필드를 읽되, 없거나 null이면 null을 반환한다.
+     *
+     * @param node  대상 JSON 노드
+     * @param field 필드명
+     * @return 필드 값 또는 null
+     */
+    private String textOrNull(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        return value != null && !value.isNull() ? value.asText() : null;
+    }
+}

--- a/src/main/java/com/cotalk/infrastructure/oauth/KakaoTokenVerifier.java
+++ b/src/main/java/com/cotalk/infrastructure/oauth/KakaoTokenVerifier.java
@@ -3,6 +3,7 @@ package com.cotalk.infrastructure.oauth;
 import com.cotalk.domain.entity.User;
 import com.cotalk.domain.exception.OAuthVerificationException;
 import com.cotalk.domain.model.VerifiedOAuthIdentity;
+import com.cotalk.infrastructure.config.properties.OAuthProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -15,11 +16,18 @@ import org.springframework.web.client.RestClientException;
 /**
  * 카카오 access token 검증 전략.
  *
- * <p>{@code GET https://kapi.kakao.com/v2/user/me}를 {@code Authorization: Bearer <access_token>}로
+ * <p>먼저 {@code GET https://kapi.kakao.com/v1/user/access_token_info}로 토큰의
+ * {@code app_id}를 조회해 우리 앱에 발급된 토큰인지 확인한다. 카카오의
+ * {@code /v2/user/me}는 어떤 카카오 앱의 access token으로도 호출되므로, 다른 앱에서
+ * 유출된 토큰이 우리 서비스로 리플레이되는 cross-app 계정 탈취를 막으려면 이 바인딩
+ * 검증이 필수다. app_id가 설정값과 일치할 때에만
+ * {@code GET https://kapi.kakao.com/v2/user/me}를 {@code Authorization: Bearer <access_token>}로
  * 호출하여 응답의 {@code id}, {@code kakao_account.email},
  * {@code kakao_account.profile.nickname}, {@code kakao_account.profile.profile_image_url}로부터
  * 검증된 식별 정보를 도출한다. 토큰이 유효하지 않으면 카카오가 401을 반환하며 이를
  * {@link OAuthVerificationException}으로 변환한다.</p>
+ *
+ * <p>fail-closed: 설정된 app-id가 비어 있으면(미설정) 검증을 거부한다.</p>
  *
  * @author seunggu.lee
  */
@@ -28,16 +36,22 @@ import org.springframework.web.client.RestClientException;
 public class KakaoTokenVerifier implements ProviderTokenVerifier {
 
     private static final String USERINFO_URL = "https://kapi.kakao.com/v2/user/me";
+    private static final String TOKEN_INFO_URL = "https://kapi.kakao.com/v1/user/access_token_info";
 
     private final RestClient restClient;
+    private final String appId;
 
     /**
      * 카카오 검증 전략을 생성한다.
      *
-     * @param restClient OAuth 전용 RestClient
+     * @param restClient      OAuth 전용 RestClient
+     * @param oAuthProperties OAuth 설정 프로퍼티 (카카오 app-id 포함)
      */
-    public KakaoTokenVerifier(@Qualifier("oauthRestClient") RestClient restClient) {
+    public KakaoTokenVerifier(
+            @Qualifier("oauthRestClient") RestClient restClient,
+            OAuthProperties oAuthProperties) {
         this.restClient = restClient;
+        this.appId = oAuthProperties.kakao().appId();
     }
 
     @Override
@@ -54,6 +68,8 @@ public class KakaoTokenVerifier implements ProviderTokenVerifier {
      */
     @Override
     public VerifiedOAuthIdentity verify(String providerToken) {
+        verifyTokenBoundToOurApp(providerToken);
+
         JsonNode body;
         try {
             body = restClient.get()
@@ -80,6 +96,48 @@ public class KakaoTokenVerifier implements ProviderTokenVerifier {
         String avatarUrl = textOrNull(profile, "profile_image_url");
 
         return new VerifiedOAuthIdentity(oauthId, email, nickname, avatarUrl);
+    }
+
+    /**
+     * access token이 우리 카카오 앱에 발급된 토큰인지 검증한다.
+     *
+     * <p>{@code /v1/user/access_token_info}로 토큰의 {@code app_id}를 조회해 설정된
+     * app-id와 일치하는지 확인한다. 설정값이 비어 있거나(미설정), app_id가 응답에 없거나,
+     * 값이 일치하지 않으면 모두 거부한다(fail-closed). 메시지는 열거 단서를 주지 않도록
+     * 일반화한다.</p>
+     *
+     * @param providerToken 카카오 access token
+     * @throws OAuthVerificationException 설정 미비, 조회 실패, app_id 불일치 시
+     */
+    private void verifyTokenBoundToOurApp(String providerToken) {
+        if (appId == null || appId.isBlank()) {
+            log.warn("카카오 app-id가 설정되지 않아 토큰 검증을 거부한다(fail-closed).");
+            throw new OAuthVerificationException("카카오 토큰 검증에 실패했습니다.");
+        }
+
+        JsonNode info;
+        try {
+            info = restClient.get()
+                    .uri(TOKEN_INFO_URL)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + providerToken)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .retrieve()
+                    .body(JsonNode.class);
+        } catch (RestClientException e) {
+            log.warn("Kakao access_token_info 호출 실패: {}", e.getMessage());
+            throw new OAuthVerificationException("카카오 토큰 검증에 실패했습니다.", e);
+        }
+
+        if (info == null || !info.hasNonNull("app_id")) {
+            log.warn("Kakao access_token_info 응답에 app_id가 없습니다.");
+            throw new OAuthVerificationException("카카오 토큰 검증에 실패했습니다.");
+        }
+
+        String tokenAppId = info.get("app_id").asText();
+        if (!appId.equals(tokenAppId)) {
+            log.warn("카카오 토큰 app_id 불일치로 거부(cross-app 리플레이 방어).");
+            throw new OAuthVerificationException("카카오 토큰 검증에 실패했습니다.");
+        }
     }
 
     /**

--- a/src/main/java/com/cotalk/infrastructure/oauth/OAuthHttpConfig.java
+++ b/src/main/java/com/cotalk/infrastructure/oauth/OAuthHttpConfig.java
@@ -1,0 +1,38 @@
+package com.cotalk.infrastructure.oauth;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+import java.time.Duration;
+
+/**
+ * OAuth 제공자 API 호출용 {@link RestClient} 구성.
+ *
+ * <p>외부 제공자(카카오/구글/애플) 호출이 지연될 때 인증 스레드가 무한정 블로킹되지 않도록
+ * 짧은 연결/읽기 타임아웃을 적용한다.</p>
+ *
+ * @author seunggu.lee
+ */
+@Configuration
+public class OAuthHttpConfig {
+
+    private static final Duration CONNECT_TIMEOUT = Duration.ofSeconds(3);
+    private static final Duration READ_TIMEOUT = Duration.ofSeconds(5);
+
+    /**
+     * OAuth 어댑터가 공유하는 타임아웃이 적용된 RestClient 빈을 생성한다.
+     *
+     * @return 구성된 RestClient
+     */
+    @Bean("oauthRestClient")
+    public RestClient oauthRestClient() {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(CONNECT_TIMEOUT);
+        requestFactory.setReadTimeout(READ_TIMEOUT);
+        return RestClient.builder()
+                .requestFactory(requestFactory)
+                .build();
+    }
+}

--- a/src/main/java/com/cotalk/infrastructure/oauth/OAuthIdentityVerifierDispatcher.java
+++ b/src/main/java/com/cotalk/infrastructure/oauth/OAuthIdentityVerifierDispatcher.java
@@ -1,0 +1,60 @@
+package com.cotalk.infrastructure.oauth;
+
+import com.cotalk.domain.entity.User;
+import com.cotalk.domain.exception.OAuthVerificationException;
+import com.cotalk.domain.model.VerifiedOAuthIdentity;
+import com.cotalk.domain.port.outbound.OAuthIdentityVerifier;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 제공자별 {@link ProviderTokenVerifier} 전략으로 라우팅하는 {@link OAuthIdentityVerifier} 구현.
+ *
+ * <p>스프링이 주입한 모든 전략 빈을 {@link ProviderTokenVerifier#provider()} 키로 매핑하여
+ * 요청 제공자에 맞는 전략에 검증을 위임한다. 토큰이 null/공백이거나 지원하지 않는 제공자면
+ * fail-closed로 {@link OAuthVerificationException}을 던진다.</p>
+ *
+ * @author seunggu.lee
+ */
+@Slf4j
+@Component
+public class OAuthIdentityVerifierDispatcher implements OAuthIdentityVerifier {
+
+    private final Map<User.OAuthProvider, ProviderTokenVerifier> verifiers;
+
+    /**
+     * 전략 빈 목록으로 디스패처를 생성한다.
+     *
+     * @param providerVerifiers 제공자별 검증 전략 목록
+     */
+    public OAuthIdentityVerifierDispatcher(List<ProviderTokenVerifier> providerVerifiers) {
+        this.verifiers = new EnumMap<>(User.OAuthProvider.class);
+        for (ProviderTokenVerifier verifier : providerVerifiers) {
+            this.verifiers.put(verifier.provider(), verifier);
+        }
+    }
+
+    /**
+     * 제공자 토큰을 검증하여 신뢰 가능한 식별 정보를 반환한다.
+     *
+     * @param provider      OAuth 제공자
+     * @param providerToken 제공자 토큰
+     * @return 검증된 식별 정보
+     * @throws OAuthVerificationException 토큰 부재, 미지원 제공자, 검증 실패 시
+     */
+    @Override
+    public VerifiedOAuthIdentity verify(User.OAuthProvider provider, String providerToken) {
+        if (providerToken == null || providerToken.isBlank()) {
+            throw new OAuthVerificationException("제공자 토큰이 비어 있습니다.");
+        }
+        ProviderTokenVerifier verifier = verifiers.get(provider);
+        if (verifier == null) {
+            throw new OAuthVerificationException("지원하지 않는 OAuth 제공자입니다: " + provider);
+        }
+        return verifier.verify(providerToken);
+    }
+}

--- a/src/main/java/com/cotalk/infrastructure/oauth/ProviderTokenVerifier.java
+++ b/src/main/java/com/cotalk/infrastructure/oauth/ProviderTokenVerifier.java
@@ -1,0 +1,31 @@
+package com.cotalk.infrastructure.oauth;
+
+import com.cotalk.domain.entity.User;
+import com.cotalk.domain.exception.OAuthVerificationException;
+import com.cotalk.domain.model.VerifiedOAuthIdentity;
+
+/**
+ * 단일 OAuth 제공자에 대한 토큰 검증 전략.
+ *
+ * <p>{@link OAuthIdentityVerifierDispatcher}가 제공자별 구현을 {@link #provider()} 키로 라우팅한다.</p>
+ *
+ * @author seunggu.lee
+ */
+interface ProviderTokenVerifier {
+
+    /**
+     * 이 전략이 담당하는 OAuth 제공자.
+     *
+     * @return 담당 제공자
+     */
+    User.OAuthProvider provider();
+
+    /**
+     * 제공자 토큰을 검증하여 신뢰 가능한 식별 정보를 반환한다.
+     *
+     * @param providerToken 제공자 토큰 (카카오: access token, 구글/애플: id_token)
+     * @return 검증된 식별 정보
+     * @throws OAuthVerificationException 검증 실패 시
+     */
+    VerifiedOAuthIdentity verify(String providerToken);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -145,6 +145,15 @@ app:
   swagger:
     server-url: ${SWAGGER_SERVER_URL:http://localhost:8080}
     server-description: ${SWAGGER_SERVER_DESCRIPTION:Co-Talk API 서버}
+  oauth:
+    # 소셜 로그인 제공자 토큰을 서버에서 검증하기 위한 설정.
+    # 구글/애플 id_token의 aud(대상) 검증에 사용한다.
+    # 미설정 시 해당 제공자 검증은 fail-closed(거부)되므로, 사용하는 제공자는 반드시 설정해야 한다.
+    # (카카오는 access token으로 userinfo API를 호출하므로 별도 client-id가 필요 없다.)
+    google:
+      client-id: ${GOOGLE_OAUTH_CLIENT_ID:}   # 구글 OAuth 클라이언트 ID
+    apple:
+      client-id: ${APPLE_OAUTH_CLIENT_ID:}    # 애플 서비스 ID (Services ID)
   encryption:
     # AES-256 암호화 키 (32바이트, Base64 인코딩)
     # 프로덕션: 반드시 환경변수로 안전한 키 설정 필요

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -149,11 +149,13 @@ app:
     # 소셜 로그인 제공자 토큰을 서버에서 검증하기 위한 설정.
     # 구글/애플 id_token의 aud(대상) 검증에 사용한다.
     # 미설정 시 해당 제공자 검증은 fail-closed(거부)되므로, 사용하는 제공자는 반드시 설정해야 한다.
-    # (카카오는 access token으로 userinfo API를 호출하므로 별도 client-id가 필요 없다.)
+    # 카카오는 access token의 app_id를 access_token_info API로 조회해 우리 앱 토큰인지 검증한다(cross-app 리플레이 방어).
     google:
       client-id: ${GOOGLE_OAUTH_CLIENT_ID:}   # 구글 OAuth 클라이언트 ID
     apple:
       client-id: ${APPLE_OAUTH_CLIENT_ID:}    # 애플 서비스 ID (Services ID)
+    kakao:
+      app-id: ${KAKAO_OAUTH_APP_ID:}          # 카카오 애플리케이션 ID (access token app_id 검증용)
   encryption:
     # AES-256 암호화 키 (32바이트, Base64 인코딩)
     # 프로덕션: 반드시 환경변수로 안전한 키 설정 필요
@@ -200,6 +202,10 @@ app:
         per-user: false
       - path: "/api/v1/auth/signup"
         requests-per-minute: 3
+        per-user: false
+      # OAuth 소셜 로그인 - IP별 제한 (무차별 대입 / JWKS·카카오 증폭 방지)
+      - path: "/api/v1/auth/oauth/login"
+        requests-per-minute: 5
         per-user: false
       # 비밀번호 재설정 - IP별 제한 (이메일 스팸 방지)
       - path: "/api/v1/password/reset-request"

--- a/src/test/java/com/cotalk/adapter/inbound/rest/OAuthControllerTest.java
+++ b/src/test/java/com/cotalk/adapter/inbound/rest/OAuthControllerTest.java
@@ -44,23 +44,12 @@ class OAuthControllerTest {
     private JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Test
-    @DisplayName("카카오 로그인 성공 - 신규 사용자")
-    void should_returnCreatedStatus_when_newKakaoUser() throws Exception {
+    @DisplayName("카카오 로그인 성공 - 신규 사용자 (토큰만 전송)")
+    void should_returnOkStatus_when_newKakaoUser() throws Exception {
         // given
-        OAuthLoginRequest request = OAuthLoginRequest.of(
-                "KAKAO",
-                "kakao_12345",
-                "user@kakao.com",
-                "카카오유저",
-                "https://kakao.com/avatar.png"
-        );
+        OAuthLoginRequest request = OAuthLoginRequest.of("KAKAO", "kakao-access-token");
 
-        given(oAuthLoginService.loginWithOAuth(
-                eq(User.OAuthProvider.KAKAO),
-                eq("kakao_12345"),
-                eq("user@kakao.com"),
-                eq("카카오유저"),
-                eq("https://kakao.com/avatar.png")))
+        given(oAuthLoginService.loginWithOAuth(eq(User.OAuthProvider.KAKAO), eq("kakao-access-token")))
                 .willReturn(new OAuthLoginUseCase.OAuthLoginResult("jwt_token", true, 100L));
 
         // when & then
@@ -75,23 +64,12 @@ class OAuthControllerTest {
     }
 
     @Test
-    @DisplayName("구글 로그인 성공 - 기존 사용자")
+    @DisplayName("구글 로그인 성공 - 기존 사용자 (id_token 전송)")
     void should_returnOkStatus_when_existingGoogleUser() throws Exception {
         // given
-        OAuthLoginRequest request = OAuthLoginRequest.of(
-                "GOOGLE",
-                "google_12345",
-                "user@gmail.com",
-                "구글유저",
-                null
-        );
+        OAuthLoginRequest request = OAuthLoginRequest.of("GOOGLE", "google-id-token");
 
-        given(oAuthLoginService.loginWithOAuth(
-                eq(User.OAuthProvider.GOOGLE),
-                eq("google_12345"),
-                eq("user@gmail.com"),
-                eq("구글유저"),
-                eq(null)))
+        given(oAuthLoginService.loginWithOAuth(eq(User.OAuthProvider.GOOGLE), eq("google-id-token")))
                 .willReturn(new OAuthLoginUseCase.OAuthLoginResult("google_jwt_token", false, 200L));
 
         // when & then
@@ -105,23 +83,12 @@ class OAuthControllerTest {
     }
 
     @Test
-    @DisplayName("애플 로그인 성공")
+    @DisplayName("애플 로그인 성공 (id_token 전송)")
     void should_returnOkStatus_when_appleLogin() throws Exception {
         // given
-        OAuthLoginRequest request = OAuthLoginRequest.of(
-                "APPLE",
-                "apple_12345",
-                "user@icloud.com",
-                "애플유저",
-                null
-        );
+        OAuthLoginRequest request = OAuthLoginRequest.of("APPLE", "apple-id-token");
 
-        given(oAuthLoginService.loginWithOAuth(
-                eq(User.OAuthProvider.APPLE),
-                eq("apple_12345"),
-                eq("user@icloud.com"),
-                eq("애플유저"),
-                eq(null)))
+        given(oAuthLoginService.loginWithOAuth(eq(User.OAuthProvider.APPLE), eq("apple-id-token")))
                 .willReturn(new OAuthLoginUseCase.OAuthLoginResult("apple_jwt_token", true, 300L));
 
         // when & then
@@ -139,9 +106,7 @@ class OAuthControllerTest {
         // given
         String request = """
                 {
-                    "oauthId": "kakao_12345",
-                    "email": "user@kakao.com",
-                    "nickname": "카카오유저"
+                    "token": "some-token"
                 }
                 """;
 
@@ -153,14 +118,12 @@ class OAuthControllerTest {
     }
 
     @Test
-    @DisplayName("OAuth 로그인 실패 - oauthId가 없는 경우")
-    void should_returnBadRequest_when_oauthIdMissing() throws Exception {
+    @DisplayName("OAuth 로그인 실패 - token이 없는 경우")
+    void should_returnBadRequest_when_tokenMissing() throws Exception {
         // given
         String request = """
                 {
-                    "provider": "KAKAO",
-                    "email": "user@kakao.com",
-                    "nickname": "카카오유저"
+                    "provider": "KAKAO"
                 }
                 """;
 

--- a/src/test/java/com/cotalk/application/service/auth/OAuthLoginServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/auth/OAuthLoginServiceTest.java
@@ -1,12 +1,16 @@
 package com.cotalk.application.service.auth;
 
 import com.cotalk.domain.entity.User;
+import com.cotalk.domain.exception.InvalidCredentialsException;
+import com.cotalk.domain.exception.OAuthVerificationException;
 import com.cotalk.domain.model.Email;
+import com.cotalk.domain.model.VerifiedOAuthIdentity;
 import com.cotalk.domain.port.inbound.auth.OAuthLoginUseCase;
 import com.cotalk.domain.port.outbound.AuthTokenPort;
 import com.cotalk.domain.port.outbound.IdGenerator;
+import com.cotalk.domain.port.outbound.MetricsPort;
+import com.cotalk.domain.port.outbound.OAuthIdentityVerifier;
 import com.cotalk.domain.port.outbound.UserRepository;
-import com.cotalk.infrastructure.metrics.CustomMetrics;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,6 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
@@ -25,6 +30,8 @@ import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class OAuthLoginServiceTest {
+
+    private static final String TOKEN = "provider-token";
 
     @Mock
     private UserRepository userRepository;
@@ -36,21 +43,24 @@ class OAuthLoginServiceTest {
     private IdGenerator idGenerator;
 
     @Mock
-    private CustomMetrics customMetrics;
+    private MetricsPort metricsPort;
+
+    @Mock
+    private OAuthIdentityVerifier oAuthIdentityVerifier;
 
     @InjectMocks
     private OAuthLoginService oAuthLoginService;
 
     @Test
-    @DisplayName("새로운 소셜 로그인 사용자 - 자동 회원가입 후 로그인")
-    void should_signUpAndLogin_when_newOAuthUser() {
+    @DisplayName("검증된 식별 정보로 신규 사용자 자동 회원가입 후 로그인한다")
+    void should_signUpAndLogin_when_verifiedNewOAuthUser() {
         // given
         String oauthId = "kakao_12345";
         User.OAuthProvider provider = User.OAuthProvider.KAKAO;
-        String email = "oauth@kakao.com";
-        String nickname = "카카오유저";
-        String avatarUrl = "https://kakao.com/avatar.png";
+        VerifiedOAuthIdentity identity = new VerifiedOAuthIdentity(
+                oauthId, "oauth@kakao.com", "카카오유저", "https://kakao.com/avatar.png");
 
+        given(oAuthIdentityVerifier.verify(provider, TOKEN)).willReturn(identity);
         given(userRepository.findByOAuthProviderAndOAuthId(provider, oauthId))
                 .willReturn(Optional.empty());
         given(idGenerator.nextId()).willReturn(100L);
@@ -59,8 +69,7 @@ class OAuthLoginServiceTest {
         given(authTokenPort.generateAccessToken(any())).willReturn("jwt_token");
 
         // when
-        OAuthLoginUseCase.OAuthLoginResult result = oAuthLoginService.loginWithOAuth(
-                provider, oauthId, email, nickname, avatarUrl);
+        OAuthLoginUseCase.OAuthLoginResult result = oAuthLoginService.loginWithOAuth(provider, TOKEN);
 
         // then
         assertThat(result.token()).isEqualTo("jwt_token");
@@ -71,17 +80,19 @@ class OAuthLoginServiceTest {
         User savedUser = userCaptor.getValue();
         assertThat(savedUser.getOauthProvider()).isEqualTo(provider);
         assertThat(savedUser.getOauthId()).isEqualTo(oauthId);
-        assertThat(savedUser.getEmail()).isEqualTo(new Email(email));
-        assertThat(savedUser.getNickname()).isEqualTo(nickname);
+        assertThat(savedUser.getEmail()).isEqualTo(new Email("oauth@kakao.com"));
+        assertThat(savedUser.getNickname()).isEqualTo("카카오유저");
         assertThat(savedUser.getPasswordHash()).isNull();
     }
 
     @Test
-    @DisplayName("기존 소셜 로그인 사용자 - 바로 로그인")
-    void should_loginDirectly_when_existingOAuthUser() {
+    @DisplayName("검증된 식별 정보로 기존 사용자를 바로 로그인한다")
+    void should_loginDirectly_when_verifiedExistingOAuthUser() {
         // given
         String oauthId = "kakao_12345";
         User.OAuthProvider provider = User.OAuthProvider.KAKAO;
+        VerifiedOAuthIdentity identity = new VerifiedOAuthIdentity(
+                oauthId, "oauth@kakao.com", "카카오유저", null);
 
         User existingUser = User.builder()
                 .id(100L)
@@ -91,13 +102,13 @@ class OAuthLoginServiceTest {
                 .oauthId(oauthId)
                 .build();
 
+        given(oAuthIdentityVerifier.verify(provider, TOKEN)).willReturn(identity);
         given(userRepository.findByOAuthProviderAndOAuthId(provider, oauthId))
                 .willReturn(Optional.of(existingUser));
         given(authTokenPort.generateAccessToken(any())).willReturn("jwt_token");
 
         // when
-        OAuthLoginUseCase.OAuthLoginResult result = oAuthLoginService.loginWithOAuth(
-                provider, oauthId, "oauth@kakao.com", "카카오유저", null);
+        OAuthLoginUseCase.OAuthLoginResult result = oAuthLoginService.loginWithOAuth(provider, TOKEN);
 
         // then
         assertThat(result.token()).isEqualTo("jwt_token");
@@ -108,112 +119,77 @@ class OAuthLoginServiceTest {
     }
 
     @Test
-    @DisplayName("구글 로그인 성공")
-    void should_loginWithGoogle_when_validInput() {
+    @DisplayName("제공자 토큰 검증에 실패하면 OAuthVerificationException(401)을 던진다")
+    void should_throwOAuthVerificationException_when_tokenVerificationFails() {
         // given
-        String oauthId = "google_12345";
         User.OAuthProvider provider = User.OAuthProvider.GOOGLE;
-        String email = "user@gmail.com";
-        String nickname = "구글유저";
+        given(oAuthIdentityVerifier.verify(provider, TOKEN))
+                .willThrow(new OAuthVerificationException("구글 토큰 검증에 실패했습니다."));
 
-        given(userRepository.findByOAuthProviderAndOAuthId(provider, oauthId))
-                .willReturn(Optional.empty());
-        given(idGenerator.nextId()).willReturn(101L);
-        given(userRepository.save(any(User.class)))
-                .willAnswer(invocation -> invocation.getArgument(0));
-        given(authTokenPort.generateAccessToken(any())).willReturn("google_jwt_token");
+        // when & then
+        assertThatThrownBy(() -> oAuthLoginService.loginWithOAuth(provider, TOKEN))
+                .isInstanceOf(OAuthVerificationException.class);
 
-        // when
-        OAuthLoginUseCase.OAuthLoginResult result = oAuthLoginService.loginWithOAuth(
-                provider, oauthId, email, nickname, null);
-
-        // then
-        assertThat(result.token()).isEqualTo("google_jwt_token");
-        assertThat(result.isNewUser()).isTrue();
+        verify(userRepository, never()).findByOAuthProviderAndOAuthId(any(), any());
+        verify(authTokenPort, never()).generateAccessToken(any());
     }
 
     @Test
-    @DisplayName("애플 로그인 성공")
-    void should_loginWithApple_when_validInput() {
-        // given
-        String oauthId = "apple_12345";
-        User.OAuthProvider provider = User.OAuthProvider.APPLE;
-        String email = "user@icloud.com";
-        String nickname = "애플유저";
-
-        given(userRepository.findByOAuthProviderAndOAuthId(provider, oauthId))
-                .willReturn(Optional.empty());
-        given(idGenerator.nextId()).willReturn(102L);
-        given(userRepository.save(any(User.class)))
-                .willAnswer(invocation -> invocation.getArgument(0));
-        given(authTokenPort.generateAccessToken(any())).willReturn("apple_jwt_token");
-
-        // when
-        OAuthLoginUseCase.OAuthLoginResult result = oAuthLoginService.loginWithOAuth(
-                provider, oauthId, email, nickname, null);
-
-        // then
-        assertThat(result.token()).isEqualTo("apple_jwt_token");
-        assertThat(result.isNewUser()).isTrue();
-    }
-
-    @Test
-    @DisplayName("avatarUrl이 null인 경우에도 회원가입이 성공한다")
-    void should_signUp_when_avatarUrlIsNull() {
+    @DisplayName("비활성 계정이면 InvalidCredentialsException을 던진다")
+    void should_throwInvalidCredentials_when_accountInactive() {
         // given
         String oauthId = "kakao_12345";
         User.OAuthProvider provider = User.OAuthProvider.KAKAO;
-        String email = "oauth@kakao.com";
-        String nickname = "카카오유저";
+        VerifiedOAuthIdentity identity = new VerifiedOAuthIdentity(oauthId, "oauth@kakao.com", "카카오유저", null);
 
-        given(userRepository.findByOAuthProviderAndOAuthId(provider, oauthId))
-                .willReturn(Optional.empty());
-        given(idGenerator.nextId()).willReturn(100L);
-        given(userRepository.save(any(User.class)))
-                .willAnswer(invocation -> invocation.getArgument(0));
-        given(authTokenPort.generateAccessToken(any())).willReturn("jwt_token");
-
-        // when
-        OAuthLoginUseCase.OAuthLoginResult result = oAuthLoginService.loginWithOAuth(
-                provider, oauthId, email, nickname, null);
-
-        // then
-        assertThat(result.token()).isEqualTo("jwt_token");
-        assertThat(result.isNewUser()).isTrue();
-
-        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
-        verify(userRepository).save(userCaptor.capture());
-        User savedUser = userCaptor.getValue();
-        assertThat(savedUser.getAvatarUrl()).isNull();
-    }
-
-    @Test
-    @DisplayName("기존 사용자의 avatarUrl이 null이어도 로그인이 성공한다")
-    void should_login_when_existingUserAvatarUrlIsNull() {
-        // given
-        String oauthId = "kakao_12345";
-        User.OAuthProvider provider = User.OAuthProvider.KAKAO;
-
-        User existingUser = User.builder()
+        User inactiveUser = User.builder()
                 .id(100L)
                 .email(new Email("oauth@kakao.com"))
                 .nickname("카카오유저")
                 .oauthProvider(provider)
                 .oauthId(oauthId)
-                .avatarUrl(null)
+                .status(User.UserStatus.SUSPENDED)
                 .build();
 
+        given(oAuthIdentityVerifier.verify(provider, TOKEN)).willReturn(identity);
         given(userRepository.findByOAuthProviderAndOAuthId(provider, oauthId))
-                .willReturn(Optional.of(existingUser));
-        given(authTokenPort.generateAccessToken(any())).willReturn("jwt_token");
+                .willReturn(Optional.of(inactiveUser));
+
+        // when & then
+        assertThatThrownBy(() -> oAuthLoginService.loginWithOAuth(provider, TOKEN))
+                .isInstanceOf(InvalidCredentialsException.class);
+
+        verify(authTokenPort, never()).generateAccessToken(any());
+    }
+
+    @Test
+    @DisplayName("제공자가 이메일/닉네임을 주지 않아도 합성값으로 회원가입에 성공한다(애플 케이스)")
+    void should_signUp_when_emailAndNicknameAbsent() {
+        // given
+        String oauthId = "apple_sub_999";
+        User.OAuthProvider provider = User.OAuthProvider.APPLE;
+        VerifiedOAuthIdentity identity = new VerifiedOAuthIdentity(oauthId, null, null, null);
+
+        given(oAuthIdentityVerifier.verify(provider, TOKEN)).willReturn(identity);
+        given(userRepository.findByOAuthProviderAndOAuthId(provider, oauthId))
+                .willReturn(Optional.empty());
+        given(idGenerator.nextId()).willReturn(101L);
+        given(userRepository.save(any(User.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+        given(authTokenPort.generateAccessToken(any())).willReturn("apple_jwt_token");
 
         // when
-        OAuthLoginUseCase.OAuthLoginResult result = oAuthLoginService.loginWithOAuth(
-                provider, oauthId, "oauth@kakao.com", "카카오유저", null);
+        OAuthLoginUseCase.OAuthLoginResult result = oAuthLoginService.loginWithOAuth(provider, TOKEN);
 
         // then
-        assertThat(result.token()).isEqualTo("jwt_token");
-        assertThat(result.isNewUser()).isFalse();
-        assertThat(result.userId()).isEqualTo(100L);
+        assertThat(result.token()).isEqualTo("apple_jwt_token");
+        assertThat(result.isNewUser()).isTrue();
+
+        ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(userCaptor.capture());
+        User savedUser = userCaptor.getValue();
+        assertThat(savedUser.getOauthId()).isEqualTo(oauthId);
+        assertThat(savedUser.getNickname()).isNotBlank();
+        assertThat(savedUser.getEmail()).isNotNull();
     }
 }

--- a/src/test/java/com/cotalk/application/service/auth/OAuthLoginServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/auth/OAuthLoginServiceTest.java
@@ -1,6 +1,7 @@
 package com.cotalk.application.service.auth;
 
 import com.cotalk.domain.entity.User;
+import com.cotalk.domain.exception.DuplicateEmailException;
 import com.cotalk.domain.exception.InvalidCredentialsException;
 import com.cotalk.domain.exception.OAuthVerificationException;
 import com.cotalk.domain.model.Email;
@@ -191,5 +192,27 @@ class OAuthLoginServiceTest {
         assertThat(savedUser.getOauthId()).isEqualTo(oauthId);
         assertThat(savedUser.getNickname()).isNotBlank();
         assertThat(savedUser.getEmail()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("자동가입 시 검증된 이메일이 다른 계정에 이미 존재하면 DuplicateEmailException으로 거부한다(자동연결 금지)")
+    void should_throwDuplicateEmail_when_signUpEmailAlreadyExists() {
+        // given
+        String oauthId = "kakao_67890";
+        User.OAuthProvider provider = User.OAuthProvider.KAKAO;
+        VerifiedOAuthIdentity identity = new VerifiedOAuthIdentity(
+                oauthId, "taken@kakao.com", "카카오유저", null);
+
+        given(oAuthIdentityVerifier.verify(provider, TOKEN)).willReturn(identity);
+        given(userRepository.findByOAuthProviderAndOAuthId(provider, oauthId))
+                .willReturn(Optional.empty());
+        given(userRepository.existsByEmail("taken@kakao.com")).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> oAuthLoginService.loginWithOAuth(provider, TOKEN))
+                .isInstanceOf(DuplicateEmailException.class);
+
+        verify(userRepository, never()).save(any());
+        verify(authTokenPort, never()).generateAccessToken(any());
     }
 }

--- a/src/test/java/com/cotalk/infrastructure/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/cotalk/infrastructure/exception/GlobalExceptionHandlerTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.MethodParameter;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -758,6 +759,31 @@ class GlobalExceptionHandlerTest {
             assertThat(response.getBody().error()).isEqualTo("요청 값이 올바르지 않습니다.");
             assertThat(response.getBody().error()).doesNotContain("must be greater");
             assertThat(response.getBody().error()).doesNotContain("getChatRoomMembers");
+        }
+    }
+
+    @Nested
+    @DisplayName("DataIntegrityViolationException 처리")
+    class HandleDataIntegrityViolationException {
+
+        @Test
+        @DisplayName("DataIntegrityViolationException은 409 CONFLICT 위생 처리 응답 반환")
+        void should_returnConflictSanitized_when_dataIntegrityViolation() {
+            // given: 프레임워크/JDBC 영문 상세가 섞인 메시지
+            DataIntegrityViolationException exception =
+                    new DataIntegrityViolationException(
+                            "could not execute statement [ERROR: duplicate key value violates unique constraint \"uk_users_email\"]");
+
+            // when
+            ResponseEntity<GlobalExceptionHandler.ErrorResponse> response = handler.handleDataIntegrityViolation(exception);
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().code()).isEqualTo("DATA_INTEGRITY_VIOLATION");
+            assertThat(response.getBody().error()).isEqualTo("이미 존재하는 데이터와 충돌합니다.");
+            assertThat(response.getBody().error()).doesNotContain("constraint");
+            assertThat(response.getBody().error()).doesNotContain("duplicate key");
         }
     }
 

--- a/src/test/java/com/cotalk/infrastructure/oauth/GoogleTokenVerifierTest.java
+++ b/src/test/java/com/cotalk/infrastructure/oauth/GoogleTokenVerifierTest.java
@@ -1,0 +1,134 @@
+package com.cotalk.infrastructure.oauth;
+
+import com.cotalk.domain.exception.OAuthVerificationException;
+import com.cotalk.domain.model.VerifiedOAuthIdentity;
+import com.cotalk.infrastructure.config.properties.OAuthProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.client.ExpectedCount;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class GoogleTokenVerifierTest {
+
+    private static final String JWKS_URL = "https://www.googleapis.com/oauth2/v3/certs";
+    private static final String ISSUER = "https://accounts.google.com";
+    private static final String CLIENT_ID = "test-google-client-id.apps.googleusercontent.com";
+
+    private OAuthTestTokens tokens;
+    private MockRestServiceServer mockServer;
+    private GoogleTokenVerifier verifier;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        tokens = OAuthTestTokens.create();
+
+        RestClient.Builder builder = RestClient.builder();
+        mockServer = MockRestServiceServer.bindTo(builder).build();
+        RestClient restClient = builder.build();
+
+        OAuthProperties props = new OAuthProperties(
+                new OAuthProperties.Google(CLIENT_ID), new OAuthProperties.Apple(""));
+        verifier = new GoogleTokenVerifier(restClient, props);
+    }
+
+    private void expectJwks(String jwksJson) {
+        mockServer.expect(ExpectedCount.manyTimes(), requestTo(JWKS_URL))
+                .andRespond(withSuccess(jwksJson, org.springframework.http.MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    @DisplayName("유효한 구글 id_token을 검증하면 sub/email로 식별 정보를 도출한다")
+    void should_returnIdentity_when_validToken() {
+        // given
+        expectJwks(tokens.jwksJson());
+        String token = tokens.signToken(ISSUER, CLIENT_ID, "google-sub-123",
+                Instant.now().plusSeconds(600),
+                Map.of("email", "user@gmail.com", "name", "구글유저"));
+
+        // when
+        VerifiedOAuthIdentity identity = verifier.verify(token);
+
+        // then
+        assertThat(identity.oauthId()).isEqualTo("google-sub-123");
+        assertThat(identity.email()).isEqualTo("user@gmail.com");
+        assertThat(identity.nickname()).isEqualTo("구글유저");
+    }
+
+    @Test
+    @DisplayName("aud가 설정된 client-id와 다르면 검증을 거부한다")
+    void should_reject_when_audMismatch() {
+        // given
+        expectJwks(tokens.jwksJson());
+        String token = tokens.signToken(ISSUER, "attacker-client-id", "google-sub-123",
+                Instant.now().plusSeconds(600), Map.of("email", "user@gmail.com"));
+
+        // when & then
+        assertThatThrownBy(() -> verifier.verify(token))
+                .isInstanceOf(OAuthVerificationException.class);
+    }
+
+    @Test
+    @DisplayName("만료된 id_token은 검증을 거부한다")
+    void should_reject_when_expired() {
+        // given
+        expectJwks(tokens.jwksJson());
+        String token = tokens.signToken(ISSUER, CLIENT_ID, "google-sub-123",
+                Instant.now().minusSeconds(60), Map.of("email", "user@gmail.com"));
+
+        // when & then
+        assertThatThrownBy(() -> verifier.verify(token))
+                .isInstanceOf(OAuthVerificationException.class);
+    }
+
+    @Test
+    @DisplayName("iss가 구글이 아니면 검증을 거부한다")
+    void should_reject_when_issuerMismatch() {
+        // given
+        expectJwks(tokens.jwksJson());
+        String token = tokens.signToken("https://evil.example.com", CLIENT_ID, "google-sub-123",
+                Instant.now().plusSeconds(600), Map.of("email", "user@gmail.com"));
+
+        // when & then
+        assertThatThrownBy(() -> verifier.verify(token))
+                .isInstanceOf(OAuthVerificationException.class);
+    }
+
+    @Test
+    @DisplayName("다른 키로 서명된 토큰은 서명 불일치로 거부한다")
+    void should_reject_when_signatureMismatch() throws Exception {
+        // given: JWKS는 우리 키를 주지만 토큰은 외부 키로 서명
+        expectJwks(tokens.jwksJson());
+        OAuthTestTokens foreign = OAuthTestTokens.create();
+        String token = foreign.signToken(ISSUER, CLIENT_ID, "google-sub-123",
+                Instant.now().plusSeconds(600), Map.of("email", "user@gmail.com"));
+
+        // when & then
+        assertThatThrownBy(() -> verifier.verify(token))
+                .isInstanceOf(OAuthVerificationException.class);
+    }
+
+    @Test
+    @DisplayName("client-id가 미설정이면 fail-closed로 검증을 거부한다")
+    void should_failClosed_when_clientIdUnset() {
+        // given
+        OAuthProperties emptyProps = new OAuthProperties(
+                new OAuthProperties.Google(""), new OAuthProperties.Apple(""));
+        GoogleTokenVerifier unconfigured = new GoogleTokenVerifier(RestClient.builder().build(), emptyProps);
+        String token = tokens.signToken(ISSUER, CLIENT_ID, "google-sub-123",
+                Instant.now().plusSeconds(600), Map.of("email", "user@gmail.com"));
+
+        // when & then
+        assertThatThrownBy(() -> unconfigured.verify(token))
+                .isInstanceOf(OAuthVerificationException.class);
+    }
+}

--- a/src/test/java/com/cotalk/infrastructure/oauth/GoogleTokenVerifierTest.java
+++ b/src/test/java/com/cotalk/infrastructure/oauth/GoogleTokenVerifierTest.java
@@ -37,7 +37,7 @@ class GoogleTokenVerifierTest {
         RestClient restClient = builder.build();
 
         OAuthProperties props = new OAuthProperties(
-                new OAuthProperties.Google(CLIENT_ID), new OAuthProperties.Apple(""));
+                new OAuthProperties.Google(CLIENT_ID), new OAuthProperties.Apple(""), null);
         verifier = new GoogleTokenVerifier(restClient, props);
     }
 
@@ -122,7 +122,7 @@ class GoogleTokenVerifierTest {
     void should_failClosed_when_clientIdUnset() {
         // given
         OAuthProperties emptyProps = new OAuthProperties(
-                new OAuthProperties.Google(""), new OAuthProperties.Apple(""));
+                new OAuthProperties.Google(""), new OAuthProperties.Apple(""), null);
         GoogleTokenVerifier unconfigured = new GoogleTokenVerifier(RestClient.builder().build(), emptyProps);
         String token = tokens.signToken(ISSUER, CLIENT_ID, "google-sub-123",
                 Instant.now().plusSeconds(600), Map.of("email", "user@gmail.com"));

--- a/src/test/java/com/cotalk/infrastructure/oauth/KakaoTokenVerifierTest.java
+++ b/src/test/java/com/cotalk/infrastructure/oauth/KakaoTokenVerifierTest.java
@@ -1,0 +1,94 @@
+package com.cotalk.infrastructure.oauth;
+
+import com.cotalk.domain.exception.OAuthVerificationException;
+import com.cotalk.domain.model.VerifiedOAuthIdentity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class KakaoTokenVerifierTest {
+
+    private static final String USERINFO_URL = "https://kapi.kakao.com/v2/user/me";
+
+    private MockRestServiceServer mockServer;
+    private KakaoTokenVerifier verifier;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder();
+        mockServer = MockRestServiceServer.bindTo(builder).build();
+        verifier = new KakaoTokenVerifier(builder.build());
+    }
+
+    @Test
+    @DisplayName("카카오 userinfo 응답을 식별 정보로 매핑한다")
+    void should_mapUserinfo_when_validAccessToken() {
+        // given
+        String json = """
+                {
+                  "id": 1234567890,
+                  "kakao_account": {
+                    "email": "user@kakao.com",
+                    "profile": {
+                      "nickname": "카카오유저",
+                      "profile_image_url": "https://k.kakaocdn.net/avatar.png"
+                    }
+                  }
+                }
+                """;
+        mockServer.expect(requestTo(USERINFO_URL))
+                .andExpect(header("Authorization", "Bearer kakao-access-token"))
+                .andRespond(withSuccess(json, MediaType.APPLICATION_JSON));
+
+        // when
+        VerifiedOAuthIdentity identity = verifier.verify("kakao-access-token");
+
+        // then
+        assertThat(identity.oauthId()).isEqualTo("1234567890");
+        assertThat(identity.email()).isEqualTo("user@kakao.com");
+        assertThat(identity.nickname()).isEqualTo("카카오유저");
+        assertThat(identity.avatarUrl()).isEqualTo("https://k.kakaocdn.net/avatar.png");
+    }
+
+    @Test
+    @DisplayName("이메일/프로필이 없어도 id만 있으면 매핑한다")
+    void should_mapMinimal_when_onlyIdPresent() {
+        // given
+        String json = """
+                { "id": 999 }
+                """;
+        mockServer.expect(requestTo(USERINFO_URL))
+                .andRespond(withSuccess(json, MediaType.APPLICATION_JSON));
+
+        // when
+        VerifiedOAuthIdentity identity = verifier.verify("kakao-access-token");
+
+        // then
+        assertThat(identity.oauthId()).isEqualTo("999");
+        assertThat(identity.email()).isNull();
+        assertThat(identity.nickname()).isNull();
+    }
+
+    @Test
+    @DisplayName("카카오가 401을 반환하면(토큰 무효) 검증을 거부한다")
+    void should_reject_when_kakaoReturnsUnauthorized() {
+        // given
+        mockServer.expect(requestTo(USERINFO_URL))
+                .andRespond(withStatus(HttpStatus.UNAUTHORIZED));
+
+        // when & then
+        assertThatThrownBy(() -> verifier.verify("invalid-token"))
+                .isInstanceOf(OAuthVerificationException.class);
+    }
+}

--- a/src/test/java/com/cotalk/infrastructure/oauth/KakaoTokenVerifierTest.java
+++ b/src/test/java/com/cotalk/infrastructure/oauth/KakaoTokenVerifierTest.java
@@ -2,6 +2,7 @@ package com.cotalk.infrastructure.oauth;
 
 import com.cotalk.domain.exception.OAuthVerificationException;
 import com.cotalk.domain.model.VerifiedOAuthIdentity;
+import com.cotalk.infrastructure.config.properties.OAuthProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,6 +21,8 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 class KakaoTokenVerifierTest {
 
     private static final String USERINFO_URL = "https://kapi.kakao.com/v2/user/me";
+    private static final String TOKEN_INFO_URL = "https://kapi.kakao.com/v1/user/access_token_info";
+    private static final String APP_ID = "123456";
 
     private MockRestServiceServer mockServer;
     private KakaoTokenVerifier verifier;
@@ -28,13 +31,28 @@ class KakaoTokenVerifierTest {
     void setUp() {
         RestClient.Builder builder = RestClient.builder();
         mockServer = MockRestServiceServer.bindTo(builder).build();
-        verifier = new KakaoTokenVerifier(builder.build());
+        verifier = newVerifier(builder.build(), APP_ID);
+    }
+
+    private KakaoTokenVerifier newVerifier(RestClient restClient, String appId) {
+        OAuthProperties properties = new OAuthProperties(null, null, new OAuthProperties.Kakao(appId));
+        return new KakaoTokenVerifier(restClient, properties);
+    }
+
+    /**
+     * access_token_info 응답(app_id 일치)을 먼저 모킹한다.
+     */
+    private void expectTokenInfo(String appId) {
+        mockServer.expect(requestTo(TOKEN_INFO_URL))
+                .andExpect(header("Authorization", "Bearer kakao-access-token"))
+                .andRespond(withSuccess("{\"app_id\": " + appId + "}", MediaType.APPLICATION_JSON));
     }
 
     @Test
-    @DisplayName("카카오 userinfo 응답을 식별 정보로 매핑한다")
-    void should_mapUserinfo_when_validAccessToken() {
+    @DisplayName("app_id가 일치하면 카카오 userinfo 응답을 식별 정보로 매핑한다")
+    void should_mapUserinfo_when_appIdMatches() {
         // given
+        expectTokenInfo(APP_ID);
         String json = """
                 {
                   "id": 1234567890,
@@ -65,6 +83,7 @@ class KakaoTokenVerifierTest {
     @DisplayName("이메일/프로필이 없어도 id만 있으면 매핑한다")
     void should_mapMinimal_when_onlyIdPresent() {
         // given
+        expectTokenInfo(APP_ID);
         String json = """
                 { "id": 999 }
                 """;
@@ -81,10 +100,35 @@ class KakaoTokenVerifierTest {
     }
 
     @Test
+    @DisplayName("토큰 app_id가 설정 app-id와 다르면 검증을 거부한다(cross-app 리플레이 방어)")
+    void should_reject_when_appIdMismatch() {
+        // given
+        expectTokenInfo("999999");
+
+        // when & then
+        assertThatThrownBy(() -> verifier.verify("kakao-access-token"))
+                .isInstanceOf(OAuthVerificationException.class);
+    }
+
+    @Test
+    @DisplayName("설정 app-id가 비어 있으면 검증을 거부한다(fail-closed)")
+    void should_reject_when_appIdBlank() {
+        // given: app-id 미설정. token_info를 호출하기 전에 거부되어야 한다.
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        KakaoTokenVerifier blankVerifier = newVerifier(builder.build(), "");
+
+        // when & then
+        assertThatThrownBy(() -> blankVerifier.verify("kakao-access-token"))
+                .isInstanceOf(OAuthVerificationException.class);
+        server.verify(); // 어떤 HTTP 호출도 없었음을 확인
+    }
+
+    @Test
     @DisplayName("카카오가 401을 반환하면(토큰 무효) 검증을 거부한다")
     void should_reject_when_kakaoReturnsUnauthorized() {
-        // given
-        mockServer.expect(requestTo(USERINFO_URL))
+        // given: access_token_info 단계에서 401
+        mockServer.expect(requestTo(TOKEN_INFO_URL))
                 .andRespond(withStatus(HttpStatus.UNAUTHORIZED));
 
         // when & then

--- a/src/test/java/com/cotalk/infrastructure/oauth/OAuthTestTokens.java
+++ b/src/test/java/com/cotalk/infrastructure/oauth/OAuthTestTokens.java
@@ -1,0 +1,94 @@
+package com.cotalk.infrastructure.oauth;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Jwks;
+import io.jsonwebtoken.security.PublicJwk;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+
+/**
+ * OAuth id_token 검증 어댑터 테스트용 헬퍼.
+ * RSA 키쌍으로 서명된 id_token과 그에 대응하는 JWKS JSON을 생성한다.
+ *
+ * @author seunggu.lee
+ */
+final class OAuthTestTokens {
+
+    static final String KID = "test-kid-1";
+
+    private final KeyPair keyPair;
+
+    private OAuthTestTokens(KeyPair keyPair) {
+        this.keyPair = keyPair;
+    }
+
+    /**
+     * 2048비트 RSA 키쌍으로 헬퍼를 생성한다.
+     *
+     * @return 토큰/ JWKS 생성기
+     * @throws Exception 키 생성 실패 시
+     */
+    static OAuthTestTokens create() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        return new OAuthTestTokens(generator.generateKeyPair());
+    }
+
+    /**
+     * 이 키쌍의 공개키를 담은 JWKS({@code {"keys":[...]}}) JSON을 반환한다.
+     *
+     * @return JWKS JSON 문자열
+     */
+    String jwksJson() {
+        RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
+        PublicJwk<?> jwk = Jwks.builder().key(publicKey).id(KID).build();
+        return "{\"keys\":[" + Jwks.json(jwk) + "]}";
+    }
+
+    /**
+     * 잘못된(다른) 키로 서명된 JWKS를 반환한다. 서명 불일치 테스트용.
+     *
+     * @return 다른 키의 JWKS JSON
+     * @throws Exception 키 생성 실패 시
+     */
+    static String foreignJwksJson() throws Exception {
+        return create().jwksJson();
+    }
+
+    /**
+     * 지정한 claim으로 서명된 RS256 id_token을 생성한다.
+     *
+     * @param issuer    iss
+     * @param audience  aud
+     * @param subject   sub
+     * @param expiresAt 만료 시각
+     * @param extra     추가 claim (email/name 등)
+     * @return 서명된 JWT 문자열
+     */
+    String signToken(String issuer, String audience, String subject, Instant expiresAt, Map<String, Object> extra) {
+        var builder = Jwts.builder()
+                .header().keyId(KID).and()
+                .issuer(issuer)
+                .audience().add(audience).and()
+                .subject(subject)
+                .issuedAt(Date.from(Instant.now().minusSeconds(60)))
+                .expiration(Date.from(expiresAt));
+        extra.forEach(builder::claim);
+        return builder.signWith(keyPair.getPrivate(), Jwts.SIG.RS256).compact();
+    }
+
+    /**
+     * 키쌍의 공개키를 반환한다.
+     *
+     * @return 공개키
+     */
+    PublicKey publicKey() {
+        return keyPair.getPublic();
+    }
+}


### PR DESCRIPTION
## 취약점 (C-1, Critical: 계정 탈취)

기존 OAuth 로그인은 클라이언트 JSON 바디의 `oauthId`/`email`/`nickname`/`avatarUrl`을 그대로 신뢰했다. `OAuthLoginService`는 `findByOAuthProviderAndOAuthId(provider, oauthId)`로 사용자를 찾아 **제공자 토큰 검증 없이** 즉시 JWT를 발급했고, 라우트 `/api/v1/auth/oauth/**`는 `permitAll`이었다.

결과: 공격자가 피해자의 `oauthId`만 알거나 추측하면 유효한 세션 JWT를 발급받아 **계정을 완전히 탈취**할 수 있었다.

## 수정

제공자 토큰을 **서버에서 직접 검증**하고, 식별 정보(oauthId/email/nickname/avatar)는 **오직 검증된 토큰에서만** 도출한다. 클라이언트가 보낸 식별 정보는 더 이상 신뢰하지 않는다.

- **도메인(순수 Java)**: `OAuthIdentityVerifier` 아웃바운드 포트 + `VerifiedOAuthIdentity` record + `OAuthVerificationException`(→401)
- **인프라(`infrastructure/oauth`)**: 제공자별 전략(EnumMap 디스패처)
  - **Kakao**: `RestClient`로 `GET /v2/user/me` 호출 후 `id`/이메일/닉네임/아바타 매핑
  - **Google**: 구글 JWKS로 `id_token` 서명 검증 + `iss`(accounts.google.com) / `aud`(client-id) / `exp` 검증, `sub`→oauthId
  - **Apple**: 애플 JWKS로 `id_token` 검증, 재로그인 시 이메일 부재를 정상 처리
  - JWKS는 짧은 TTL로 캐싱. **client-id 미설정 시 fail-closed(거부)**
- **유스케이스**: `loginWithOAuth(provider, providerToken)`로 시그니처 변경
- **DTO**: `OAuthLoginRequest`를 `{ provider, token }`으로 축소 (응답 DTO는 동일)

## 신규 환경 변수

| 변수 | 용도 |
|------|------|
| `GOOGLE_OAUTH_CLIENT_ID` | 구글 `id_token`의 `aud` 검증 |
| `APPLE_OAUTH_CLIENT_ID` | 애플 `id_token`의 `aud` 검증 (서비스 ID) |

미설정 시 해당 제공자 검증은 거부된다(fail-closed). 카카오는 별도 client-id가 필요 없다.

## 클라이언트 계약 변경 (Breaking)

클라이언트는 더 이상 `oauthId/email/nickname/avatarUrl`을 보내지 않고, **제공자 토큰만** 보낸다:
- 카카오: access token
- 구글/애플: `id_token`

요청 바디: `{ "provider": "GOOGLE", "token": "<id_token>" }`

> Flutter 클라이언트는 이 PR 범위 밖이며 별도 PR(PR4)에서 토큰 전송 방식으로 갱신 필요.

## 테스트

`./gradlew test` 전체 GREEN (ArchUnit 레이어 검증 포함).
- 서비스 단위: 검증된 식별 정보로 신규가입/기존로그인, 검증 실패→401, 비활성 계정 예외
- Google 어댑터: 해피패스, aud 불일치/만료/iss 불일치/서명 불일치/client-id 미설정(fail-closed)
- Kakao 어댑터: userinfo 매핑, 401 거부

🤖 Generated with [Claude Code](https://claude.com/claude-code)