### PR TITLE
fix(security): 채팅 첨부파일 비공개화 + 멤버십 게이트 presigned URL (H-1)

### DIFF
--- a/src/main/java/com/cotalk/adapter/inbound/rest/ChatMessageController.java
+++ b/src/main/java/com/cotalk/adapter/inbound/rest/ChatMessageController.java
@@ -136,7 +136,9 @@ public class ChatMessageController {
                         enriched.message(),
                         enriched.unreadCount(),
                         enriched.senderNickname(),
-                        enriched.senderAvatarUrl()))
+                        enriched.senderAvatarUrl(),
+                        enriched.fileUrl(),
+                        enriched.thumbnailUrl()))
                 .toList();
 
         return ResponseEntity.ok(MessageHistoryResponse.of(messageDtos, result.nextCursor(), result.hasMore()));

--- a/src/main/java/com/cotalk/adapter/inbound/rest/ChatMessageController.java
+++ b/src/main/java/com/cotalk/adapter/inbound/rest/ChatMessageController.java
@@ -18,11 +18,12 @@ import com.cotalk.domain.port.inbound.message.GetMessageHistoryUseCase;
 import com.cotalk.domain.port.inbound.message.MessageReplyForwardUseCase;
 import com.cotalk.domain.port.inbound.message.SendMessageUseCase;
 import com.cotalk.domain.port.inbound.message.UpdateMessageUseCase;
+import com.cotalk.domain.port.outbound.FileStorage;
 import com.cotalk.infrastructure.security.CustomUserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -51,7 +52,6 @@ import java.util.List;
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/chat/messages")
-@RequiredArgsConstructor
 @Tag(name = "채팅 메시지", description = "채팅 메시지 API")
 public class ChatMessageController {
 
@@ -61,6 +61,52 @@ public class ChatMessageController {
     private final DeleteMessageUseCase deleteMessageUseCase;
     private final MessageReplyForwardUseCase messageReplyForwardUseCase;
     private final GetMediaGalleryUseCase getMediaGalleryUseCase;
+    private final FileStorage fileStorage;
+    private final int presignedUrlExpiryMinutes;
+
+    /**
+     * ChatMessageController를 생성합니다.
+     *
+     * @param sendMessageUseCase          메시지 전송 유스케이스
+     * @param getMessageHistoryUseCase    메시지 히스토리 조회 유스케이스
+     * @param updateMessageUseCase        메시지 수정 유스케이스
+     * @param deleteMessageUseCase        메시지 삭제 유스케이스
+     * @param messageReplyForwardUseCase  메시지 답장/전달 유스케이스
+     * @param getMediaGalleryUseCase      미디어 갤러리 조회 유스케이스
+     * @param fileStorage                 파일 저장소 포트(첨부파일 Pre-signed URL 재발급용)
+     * @param presignedUrlExpiryMinutes   첨부파일 Pre-signed URL 만료 시간(분)
+     */
+    public ChatMessageController(
+            SendMessageUseCase sendMessageUseCase,
+            GetMessageHistoryUseCase getMessageHistoryUseCase,
+            UpdateMessageUseCase updateMessageUseCase,
+            DeleteMessageUseCase deleteMessageUseCase,
+            MessageReplyForwardUseCase messageReplyForwardUseCase,
+            GetMediaGalleryUseCase getMediaGalleryUseCase,
+            FileStorage fileStorage,
+            @Value("${minio.presigned-url-expiry-minutes:10}") int presignedUrlExpiryMinutes) {
+        this.sendMessageUseCase = sendMessageUseCase;
+        this.getMessageHistoryUseCase = getMessageHistoryUseCase;
+        this.updateMessageUseCase = updateMessageUseCase;
+        this.deleteMessageUseCase = deleteMessageUseCase;
+        this.messageReplyForwardUseCase = messageReplyForwardUseCase;
+        this.getMediaGalleryUseCase = getMediaGalleryUseCase;
+        this.fileStorage = fileStorage;
+        this.presignedUrlExpiryMinutes = presignedUrlExpiryMinutes;
+    }
+
+    /**
+     * 메시지 엔티티의 첨부파일 URL을 멤버십이 검증된 본인에게 노출할 단기 Pre-signed URL로 재발급하여
+     * 응답 DTO를 생성합니다(H-1). 비-파일 메시지의 null/blank URL은 그대로 통과됩니다.
+     *
+     * @param message 응답으로 변환할 메시지 엔티티
+     * @return 단기 Pre-signed URL이 적용된 응답 DTO
+     */
+    private SendMessageResponse toPresignedResponse(Message message) {
+        String fileUrl = fileStorage.presignAttachmentUrl(message.getFileUrl(), presignedUrlExpiryMinutes);
+        String thumbnailUrl = fileStorage.presignAttachmentUrl(message.getThumbnailUrl(), presignedUrlExpiryMinutes);
+        return SendMessageResponse.from(message, fileUrl, thumbnailUrl);
+    }
 
     /**
      * 채팅방에 텍스트 메시지를 전송합니다.
@@ -76,7 +122,7 @@ public class ChatMessageController {
             @Valid @RequestBody SendMessageRequest request) {
         Message message = sendMessageUseCase.sendTextMessageAndBroadcast(request.chatRoomId(), principal.getUserId(), request.content());
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(SendMessageResponse.from(message));
+                .body(toPresignedResponse(message));
     }
 
     /**
@@ -109,7 +155,7 @@ public class ChatMessageController {
                 request.chatRoomId(), principal.getUserId(), command);
 
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(SendMessageResponse.from(message));
+                .body(toPresignedResponse(message));
     }
 
     /**
@@ -240,7 +286,7 @@ public class ChatMessageController {
         Message message = messageReplyForwardUseCase.replyToMessage(
                 principal.getUserId(), messageId, request.content());
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(SendMessageResponse.from(message));
+                .body(toPresignedResponse(message));
     }
 
     /**
@@ -260,6 +306,6 @@ public class ChatMessageController {
         Message message = messageReplyForwardUseCase.forwardMessage(
                 principal.getUserId(), messageId, request.targetChatRoomId());
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(SendMessageResponse.from(message));
+                .body(toPresignedResponse(message));
     }
 }

--- a/src/main/java/com/cotalk/adapter/inbound/rest/dto/message/MessageDto.java
+++ b/src/main/java/com/cotalk/adapter/inbound/rest/dto/message/MessageDto.java
@@ -53,6 +53,10 @@ public record MessageDto(
 
     /**
      * Message 엔티티로부터 DTO를 생성합니다. (unreadCount, senderNickname, senderAvatarUrl 포함)
+     * <p>
+     * 첨부파일 URL은 엔티티에 저장된 원본 값을 사용합니다. 멤버십 검증 후 재발급된 단기 Pre-signed URL을
+     * 노출하려면 {@link #from(Message, Integer, String, String, String, String)}을 사용하세요(H-1).
+     * </p>
      *
      * @param message         Message 엔티티
      * @param unreadCount     읽지 않은 멤버 수
@@ -61,6 +65,27 @@ public record MessageDto(
      * @return MessageDto 인스턴스
      */
     public static MessageDto from(Message message, Integer unreadCount, String senderNickname, String senderAvatarUrl) {
+        return from(message, unreadCount, senderNickname, senderAvatarUrl,
+                message.getFileUrl(), message.getThumbnailUrl());
+    }
+
+    /**
+     * Message 엔티티로부터 DTO를 생성합니다. (첨부파일 URL을 명시적으로 지정)
+     * <p>
+     * 멤버십이 검증된 읽기 경로에서 재발급한 단기 Pre-signed URL({@code fileUrl}/{@code thumbnailUrl})을
+     * 엔티티에 저장된 원본 URL 대신 클라이언트에 노출하기 위해 사용합니다(H-1).
+     * </p>
+     *
+     * @param message         Message 엔티티
+     * @param unreadCount     읽지 않은 멤버 수
+     * @param senderNickname  발신자 닉네임
+     * @param senderAvatarUrl 발신자 프로필 이미지 URL
+     * @param fileUrl         클라이언트에 노출할 파일 URL (단기 Pre-signed URL)
+     * @param thumbnailUrl    클라이언트에 노출할 썸네일 URL (단기 Pre-signed URL)
+     * @return MessageDto 인스턴스
+     */
+    public static MessageDto from(Message message, Integer unreadCount, String senderNickname, String senderAvatarUrl,
+                                  String fileUrl, String thumbnailUrl) {
         return new MessageDto(
                 message.getId(),
                 message.getSenderId(),
@@ -70,11 +95,11 @@ public record MessageDto(
                 HtmlSanitizer.unescape(message.getContent()),
                 message.getType().name(),
                 message.getCreatedAt(),
-                message.getFileUrl(),
+                fileUrl,
                 message.getFileName(),
                 message.getFileSize(),
                 message.getFileContentType(),
-                message.getThumbnailUrl(),
+                thumbnailUrl,
                 message.getReplyToMessageId(),
                 message.getForwardedFromMessageId(),
                 unreadCount,

--- a/src/main/java/com/cotalk/adapter/inbound/rest/dto/message/SendMessageResponse.java
+++ b/src/main/java/com/cotalk/adapter/inbound/rest/dto/message/SendMessageResponse.java
@@ -44,21 +44,41 @@ public record SendMessageResponse(
 
     /**
      * Message 엔티티로부터 응답 DTO를 생성합니다.
+     * <p>
+     * 첨부파일 URL은 엔티티에 저장된 원본 값을 사용합니다. 멤버십이 검증된 생성 경로에서 재발급한
+     * 단기 Pre-signed URL을 노출하려면 {@link #from(Message, String, String)}을 사용하세요(H-1).
+     * </p>
      *
      * @param message Message 엔티티
      * @return SendMessageResponse 인스턴스
      */
     public static SendMessageResponse from(Message message) {
+        return from(message, message.getFileUrl(), message.getThumbnailUrl());
+    }
+
+    /**
+     * Message 엔티티로부터 응답 DTO를 생성합니다. (첨부파일 URL을 명시적으로 지정)
+     * <p>
+     * 메시지 생성 직후 본인에게 응답을 돌려줄 때, 엔티티에 저장된 원본 URL 대신 재발급한 단기
+     * Pre-signed URL({@code fileUrl}/{@code thumbnailUrl})을 클라이언트에 노출하기 위해 사용합니다(H-1).
+     * </p>
+     *
+     * @param message      Message 엔티티
+     * @param fileUrl      클라이언트에 노출할 파일 URL (단기 Pre-signed URL)
+     * @param thumbnailUrl 클라이언트에 노출할 썸네일 URL (단기 Pre-signed URL)
+     * @return SendMessageResponse 인스턴스
+     */
+    public static SendMessageResponse from(Message message, String fileUrl, String thumbnailUrl) {
         return new SendMessageResponse(
                 message.getId(),
                 message.getContent(),
                 message.getType().name(),
                 message.getCreatedAt(),
-                message.getFileUrl(),
+                fileUrl,
                 message.getFileName(),
                 message.getFileSize(),
                 message.getFileContentType(),
-                message.getThumbnailUrl(),
+                thumbnailUrl,
                 message.getReplyToMessageId(),
                 message.getForwardedFromMessageId(),
                 message.getLinkPreviewUrl(),

--- a/src/main/java/com/cotalk/application/service/chat/BroadcastChatMessageService.java
+++ b/src/main/java/com/cotalk/application/service/chat/BroadcastChatMessageService.java
@@ -5,8 +5,9 @@ import com.cotalk.domain.entity.Message;
 import com.cotalk.domain.port.inbound.chat.BroadcastChatMessageUseCase;
 import com.cotalk.domain.port.outbound.ChatMessageBroker;
 import com.cotalk.domain.port.outbound.ChatMessageBroker.ChatBroadcastMessage;
-import lombok.RequiredArgsConstructor;
+import com.cotalk.domain.port.outbound.FileStorage;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.time.ZoneOffset;
@@ -23,10 +24,27 @@ import java.util.List;
  */
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class BroadcastChatMessageService implements BroadcastChatMessageUseCase {
 
     private final ChatMessageBroker chatMessageBroker;
+    private final FileStorage fileStorage;
+    private final int presignedUrlExpiryMinutes;
+
+    /**
+     * BroadcastChatMessageService를 생성한다.
+     *
+     * @param chatMessageBroker          채팅 메시지 브로커 포트
+     * @param fileStorage                파일 저장소 포트(첨부파일 Pre-signed URL 재발급용)
+     * @param presignedUrlExpiryMinutes  첨부파일 Pre-signed URL 만료 시간(분)
+     */
+    public BroadcastChatMessageService(
+            ChatMessageBroker chatMessageBroker,
+            FileStorage fileStorage,
+            @Value("${minio.presigned-url-expiry-minutes:10}") int presignedUrlExpiryMinutes) {
+        this.chatMessageBroker = chatMessageBroker;
+        this.fileStorage = fileStorage;
+        this.presignedUrlExpiryMinutes = presignedUrlExpiryMinutes;
+    }
 
     /**
      * {@inheritDoc}
@@ -42,6 +60,11 @@ public class BroadcastChatMessageService implements BroadcastChatMessageUseCase 
                 message.getChatRoomId(), message.getId(), message.getSenderId(),
                 senderNickname, members.size(), unreadCount);
 
+        // 첨부파일 URL은 단기 Pre-signed URL로 재발급해 브로드캐스트한다(H-1).
+        // 수신자는 WebSocket 구독이 멤버십으로 게이트된 채팅방 멤버다.
+        String fileUrl = fileStorage.presignAttachmentUrl(message.getFileUrl(), presignedUrlExpiryMinutes);
+        String thumbnailUrl = fileStorage.presignAttachmentUrl(message.getThumbnailUrl(), presignedUrlExpiryMinutes);
+
         ChatBroadcastMessage broadcastMessage = new ChatBroadcastMessage(
                 message.getId(),
                 message.getSenderId(),
@@ -51,11 +74,11 @@ public class BroadcastChatMessageService implements BroadcastChatMessageUseCase 
                 message.getContent(),
                 message.getType().name(),
                 message.getCreatedAt().atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
-                message.getFileUrl(),
+                fileUrl,
                 message.getFileName(),
                 message.getFileSize(),
                 message.getFileContentType(),
-                message.getThumbnailUrl(),
+                thumbnailUrl,
                 unreadCount,
                 null,  // eventType (일반 메시지)
                 null,  // relatedUserId

--- a/src/main/java/com/cotalk/application/service/message/GetMediaGalleryService.java
+++ b/src/main/java/com/cotalk/application/service/message/GetMediaGalleryService.java
@@ -3,11 +3,12 @@ package com.cotalk.application.service.message;
 import com.cotalk.domain.entity.Message;
 import com.cotalk.domain.entity.User;
 import com.cotalk.domain.port.inbound.message.GetMediaGalleryUseCase;
+import com.cotalk.domain.port.outbound.FileStorage;
 import com.cotalk.domain.port.outbound.MessageRepository;
 import com.cotalk.domain.port.outbound.UserRepository;
 import com.cotalk.domain.validator.ChatRoomMemberValidator;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -27,13 +28,36 @@ import java.util.stream.Collectors;
  */
 @Slf4j
 @Service
-@RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class GetMediaGalleryService implements GetMediaGalleryUseCase {
 
     private final MessageRepository messageRepository;
     private final UserRepository userRepository;
     private final ChatRoomMemberValidator chatRoomMemberValidator;
+    private final FileStorage fileStorage;
+    private final int presignedUrlExpiryMinutes;
+
+    /**
+     * GetMediaGalleryService를 생성한다.
+     *
+     * @param messageRepository          메시지 저장소 포트
+     * @param userRepository             사용자 저장소 포트
+     * @param chatRoomMemberValidator    채팅방 멤버십 검증기
+     * @param fileStorage                파일 저장소 포트(첨부파일 Pre-signed URL 재발급용)
+     * @param presignedUrlExpiryMinutes  첨부파일 Pre-signed URL 만료 시간(분)
+     */
+    public GetMediaGalleryService(
+            MessageRepository messageRepository,
+            UserRepository userRepository,
+            ChatRoomMemberValidator chatRoomMemberValidator,
+            FileStorage fileStorage,
+            @Value("${minio.presigned-url-expiry-minutes:10}") int presignedUrlExpiryMinutes) {
+        this.messageRepository = messageRepository;
+        this.userRepository = userRepository;
+        this.chatRoomMemberValidator = chatRoomMemberValidator;
+        this.fileStorage = fileStorage;
+        this.presignedUrlExpiryMinutes = presignedUrlExpiryMinutes;
+    }
 
     /**
      * 채팅방의 미디어 갤러리를 조회한다.
@@ -70,17 +94,19 @@ public class GetMediaGalleryService implements GetMediaGalleryUseCase {
         Map<Long, User> senderMap = userRepository.findAllById(senderIds).stream()
                 .collect(Collectors.toMap(User::getId, user -> user));
 
+        // 멤버십이 검증된 멤버에게만, 저장된 첨부파일 URL을 단기 Pre-signed URL로 재발급한다(H-1).
+        // 페이지 전체에 대해 방 단위로 멤버십을 1회만 검증했으므로 첨부파일별 재검증은 하지 않는다.
         List<MediaGalleryItem> items = messages.stream()
                 .map(message -> {
                     User sender = senderMap.get(message.getSenderId());
                     return new MediaGalleryItem(
                             message.getId(),
                             message.getType().name(),
-                            message.getFileUrl(),
+                            fileStorage.presignAttachmentUrl(message.getFileUrl(), presignedUrlExpiryMinutes),
                             message.getFileName(),
                             message.getFileSize(),
                             message.getFileContentType(),
-                            message.getThumbnailUrl(),
+                            fileStorage.presignAttachmentUrl(message.getThumbnailUrl(), presignedUrlExpiryMinutes),
                             message.getLinkPreviewUrl(),
                             message.getLinkPreviewTitle(),
                             message.getLinkPreviewDescription(),

--- a/src/main/java/com/cotalk/application/service/message/GetMessageHistoryService.java
+++ b/src/main/java/com/cotalk/application/service/message/GetMessageHistoryService.java
@@ -4,11 +4,12 @@ import com.cotalk.domain.entity.Message;
 import com.cotalk.domain.entity.User;
 import com.cotalk.domain.port.inbound.message.GetMessageHistoryUseCase;
 import com.cotalk.domain.port.outbound.ChatRoomMemberRepository;
+import com.cotalk.domain.port.outbound.FileStorage;
 import com.cotalk.domain.port.outbound.MessageRepository;
 import com.cotalk.domain.port.outbound.UserRepository;
 import com.cotalk.domain.validator.ChatRoomMemberValidator;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,7 +26,6 @@ import java.util.stream.Collectors;
  */
 @Slf4j
 @Service
-@RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class GetMessageHistoryService implements GetMessageHistoryUseCase {
 
@@ -33,6 +33,33 @@ public class GetMessageHistoryService implements GetMessageHistoryUseCase {
     private final ChatRoomMemberRepository chatRoomMemberRepository;
     private final UserRepository userRepository;
     private final ChatRoomMemberValidator chatRoomMemberValidator;
+    private final FileStorage fileStorage;
+    private final int presignedUrlExpiryMinutes;
+
+    /**
+     * GetMessageHistoryService를 생성한다.
+     *
+     * @param messageRepository          메시지 저장소 포트
+     * @param chatRoomMemberRepository   채팅방 멤버 저장소 포트
+     * @param userRepository             사용자 저장소 포트
+     * @param chatRoomMemberValidator    채팅방 멤버십 검증기
+     * @param fileStorage                파일 저장소 포트(첨부파일 Pre-signed URL 재발급용)
+     * @param presignedUrlExpiryMinutes  첨부파일 Pre-signed URL 만료 시간(분)
+     */
+    public GetMessageHistoryService(
+            MessageRepository messageRepository,
+            ChatRoomMemberRepository chatRoomMemberRepository,
+            UserRepository userRepository,
+            ChatRoomMemberValidator chatRoomMemberValidator,
+            FileStorage fileStorage,
+            @Value("${minio.presigned-url-expiry-minutes:10}") int presignedUrlExpiryMinutes) {
+        this.messageRepository = messageRepository;
+        this.chatRoomMemberRepository = chatRoomMemberRepository;
+        this.userRepository = userRepository;
+        this.chatRoomMemberValidator = chatRoomMemberValidator;
+        this.fileStorage = fileStorage;
+        this.presignedUrlExpiryMinutes = presignedUrlExpiryMinutes;
+    }
 
     /**
      * 채팅방의 메시지 히스토리를 조회한다.
@@ -80,13 +107,17 @@ public class GetMessageHistoryService implements GetMessageHistoryUseCase {
         Map<Long, User> senderMap = userRepository.findAllById(senderIds).stream()
                 .collect(Collectors.toMap(User::getId, user -> user));
 
+        // 멤버십이 검증된 멤버에게만, 저장된 첨부파일 URL을 단기 Pre-signed URL로 재발급한다(H-1).
+        // 방 단위로 멤버십을 1회만 검증했으므로 첨부파일별 재검증은 하지 않는다.
         List<EnrichedMessage> enrichedMessages = messages.stream()
                 .map(message -> {
                     int unreadCount = unreadCountMap.getOrDefault(message.getId(), 0);
                     User sender = senderMap.get(message.getSenderId());
                     String senderNickname = sender != null ? sender.getNickname() : null;
                     String senderAvatarUrl = sender != null ? sender.getAvatarUrl() : null;
-                    return new EnrichedMessage(message, unreadCount, senderNickname, senderAvatarUrl);
+                    String fileUrl = fileStorage.presignAttachmentUrl(message.getFileUrl(), presignedUrlExpiryMinutes);
+                    String thumbnailUrl = fileStorage.presignAttachmentUrl(message.getThumbnailUrl(), presignedUrlExpiryMinutes);
+                    return new EnrichedMessage(message, unreadCount, senderNickname, senderAvatarUrl, fileUrl, thumbnailUrl);
                 })
                 .toList();
 

--- a/src/main/java/com/cotalk/application/service/message/MessageBroadcastService.java
+++ b/src/main/java/com/cotalk/application/service/message/MessageBroadcastService.java
@@ -4,11 +4,12 @@ import com.cotalk.domain.entity.ChatRoomMember;
 import com.cotalk.domain.entity.Message;
 import com.cotalk.domain.port.outbound.ChatMessageBroker;
 import com.cotalk.domain.port.outbound.ChatMessageBroker.ChatBroadcastMessage;
+import com.cotalk.domain.port.outbound.FileStorage;
 import com.cotalk.domain.port.outbound.MessageRepository;
 import com.cotalk.domain.port.outbound.UserEventBroker;
 import com.cotalk.domain.port.outbound.UserEventBroker.ChatListUpdateEvent;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.time.ZoneOffset;
@@ -22,12 +23,35 @@ import java.util.List;
  */
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class MessageBroadcastService {
 
     private final ChatMessageBroker chatMessageBroker;
     private final UserEventBroker userEventBroker;
     private final MessageRepository messageRepository;
+    private final FileStorage fileStorage;
+    private final int presignedUrlExpiryMinutes;
+
+    /**
+     * MessageBroadcastService를 생성한다.
+     *
+     * @param chatMessageBroker          채팅 메시지 브로커 포트
+     * @param userEventBroker            사용자 이벤트 브로커 포트
+     * @param messageRepository          메시지 저장소 포트
+     * @param fileStorage                파일 저장소 포트(첨부파일 Pre-signed URL 재발급용)
+     * @param presignedUrlExpiryMinutes  첨부파일 Pre-signed URL 만료 시간(분)
+     */
+    public MessageBroadcastService(
+            ChatMessageBroker chatMessageBroker,
+            UserEventBroker userEventBroker,
+            MessageRepository messageRepository,
+            FileStorage fileStorage,
+            @Value("${minio.presigned-url-expiry-minutes:10}") int presignedUrlExpiryMinutes) {
+        this.chatMessageBroker = chatMessageBroker;
+        this.userEventBroker = userEventBroker;
+        this.messageRepository = messageRepository;
+        this.fileStorage = fileStorage;
+        this.presignedUrlExpiryMinutes = presignedUrlExpiryMinutes;
+    }
 
     /**
      * 메시지를 Redis Pub/Sub으로 브로드캐스트한다.
@@ -45,6 +69,11 @@ public class MessageBroadcastService {
         log.info("[MessageBroadcastService] broadcastToRedis roomId={}, messageId={}, senderId={}, type={}",
                 message.getChatRoomId(), message.getId(), message.getSenderId(), message.getType());
 
+        // 첨부파일 URL은 단기 Pre-signed URL로 재발급해 브로드캐스트한다(H-1). 수신자는 채팅방 멤버로,
+        // WebSocket 구독 자체가 멤버십으로 게이트되어 있으므로 검증된 멤버에게만 전달된다.
+        String fileUrl = fileStorage.presignAttachmentUrl(message.getFileUrl(), presignedUrlExpiryMinutes);
+        String thumbnailUrl = fileStorage.presignAttachmentUrl(message.getThumbnailUrl(), presignedUrlExpiryMinutes);
+
         ChatBroadcastMessage broadcastMessage = new ChatBroadcastMessage(
                 message.getId(),
                 message.getSenderId(),
@@ -54,11 +83,11 @@ public class MessageBroadcastService {
                 message.getContent(),
                 message.getType().name(),
                 message.getCreatedAt().atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
-                message.getFileUrl(),
+                fileUrl,
                 message.getFileName(),
                 message.getFileSize(),
                 message.getFileContentType(),
-                message.getThumbnailUrl(),
+                thumbnailUrl,
                 unreadCount,
                 null, null, null
         );

--- a/src/main/java/com/cotalk/application/service/message/MessageReplyForwardService.java
+++ b/src/main/java/com/cotalk/application/service/message/MessageReplyForwardService.java
@@ -10,13 +10,14 @@ import com.cotalk.domain.port.inbound.message.MessageReplyForwardUseCase;
 import com.cotalk.domain.port.outbound.ChatMessageBroker;
 import com.cotalk.domain.port.outbound.ChatMessageBroker.ChatBroadcastMessage;
 import com.cotalk.domain.port.outbound.ChatRoomMemberRepository;
+import com.cotalk.domain.port.outbound.FileStorage;
 import com.cotalk.domain.port.outbound.IdGenerator;
 import com.cotalk.domain.port.outbound.MessageRepository;
 import com.cotalk.domain.port.outbound.UserEventBroker;
 import com.cotalk.domain.port.outbound.UserEventBroker.ChatListUpdateEvent;
 import com.cotalk.domain.port.outbound.UserRepository;
 import com.cotalk.domain.util.HtmlSanitizer;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,7 +31,6 @@ import java.util.List;
  * @author seunggu.lee
  */
 @Service
-@RequiredArgsConstructor
 @Transactional
 public class MessageReplyForwardService implements MessageReplyForwardUseCase {
 
@@ -40,6 +40,39 @@ public class MessageReplyForwardService implements MessageReplyForwardUseCase {
     private final ChatMessageBroker chatMessageBroker;
     private final UserRepository userRepository;
     private final UserEventBroker userEventBroker;
+    private final FileStorage fileStorage;
+    private final int presignedUrlExpiryMinutes;
+
+    /**
+     * MessageReplyForwardService를 생성한다.
+     *
+     * @param messageRepository         메시지 저장소 포트
+     * @param chatRoomMemberRepository  채팅방 멤버 저장소 포트
+     * @param idGenerator               ID 생성기 포트
+     * @param chatMessageBroker         채팅 메시지 브로커 포트
+     * @param userRepository            사용자 저장소 포트
+     * @param userEventBroker           사용자 이벤트 브로커 포트
+     * @param fileStorage               파일 저장소 포트(첨부파일 Pre-signed URL 재발급용)
+     * @param presignedUrlExpiryMinutes 첨부파일 Pre-signed URL 만료 시간(분)
+     */
+    public MessageReplyForwardService(
+            MessageRepository messageRepository,
+            ChatRoomMemberRepository chatRoomMemberRepository,
+            IdGenerator idGenerator,
+            ChatMessageBroker chatMessageBroker,
+            UserRepository userRepository,
+            UserEventBroker userEventBroker,
+            FileStorage fileStorage,
+            @Value("${minio.presigned-url-expiry-minutes:10}") int presignedUrlExpiryMinutes) {
+        this.messageRepository = messageRepository;
+        this.chatRoomMemberRepository = chatRoomMemberRepository;
+        this.idGenerator = idGenerator;
+        this.chatMessageBroker = chatMessageBroker;
+        this.userRepository = userRepository;
+        this.userEventBroker = userEventBroker;
+        this.fileStorage = fileStorage;
+        this.presignedUrlExpiryMinutes = presignedUrlExpiryMinutes;
+    }
 
     /**
      * 메시지에 답장한다.
@@ -138,12 +171,18 @@ public class MessageReplyForwardService implements MessageReplyForwardUseCase {
         String senderAvatarUrl = sender != null ? sender.getAvatarUrl() : null;
         int unreadCount = Math.max(0, members.size() - 1);
 
+        // 첨부파일 URL은 단기 Pre-signed URL로 재발급해 브로드캐스트한다(H-1). 수신자는 채팅방 멤버로,
+        // WebSocket 구독 자체가 멤버십으로 게이트되어 있으므로 검증된 멤버에게만 전달된다.
+        // presignAttachmentUrl은 null/blank/외부 URL을 그대로 통과시키므로 비-파일 메시지도 안전하다.
+        String fileUrl = fileStorage.presignAttachmentUrl(message.getFileUrl(), presignedUrlExpiryMinutes);
+        String thumbnailUrl = fileStorage.presignAttachmentUrl(message.getThumbnailUrl(), presignedUrlExpiryMinutes);
+
         ChatBroadcastMessage broadcastMsg = new ChatBroadcastMessage(
                 message.getId(), message.getSenderId(), senderNickname, senderAvatarUrl,
                 message.getChatRoomId(), message.getContent(), message.getType().name(),
                 message.getCreatedAt().atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
-                message.getFileUrl(), message.getFileName(), message.getFileSize(),
-                message.getFileContentType(), message.getThumbnailUrl(),
+                fileUrl, message.getFileName(), message.getFileSize(),
+                message.getFileContentType(), thumbnailUrl,
                 unreadCount, null, null, null);
 
         chatMessageBroker.publish(chatRoomId, broadcastMsg);

--- a/src/main/java/com/cotalk/domain/port/inbound/message/GetMessageHistoryUseCase.java
+++ b/src/main/java/com/cotalk/domain/port/inbound/message/GetMessageHistoryUseCase.java
@@ -37,17 +37,25 @@ public interface GetMessageHistoryUseCase {
 
     /**
      * 메시지 히스토리 조회 결과에 포함되는 개별 메시지 정보.
+     * <p>
+     * {@code fileUrl}/{@code thumbnailUrl}은 멤버십 검증 후 재발급된 단기 Pre-signed URL이다(H-1).
+     * 첨부파일이 없는 메시지는 {@code null}이다. 엔티티에 저장된 원본 URL 대신 이 값을 클라이언트에 노출한다.
+     * </p>
      *
      * @param message 메시지 엔티티
      * @param unreadCount 읽지 않은 멤버 수
      * @param senderNickname 발신자 닉네임
      * @param senderAvatarUrl 발신자 프로필 이미지 URL
+     * @param fileUrl 멤버십 검증 후 재발급된 단기 첨부파일 Pre-signed URL (없으면 null)
+     * @param thumbnailUrl 멤버십 검증 후 재발급된 단기 썸네일 Pre-signed URL (없으면 null)
      */
     record EnrichedMessage(
             Message message,
             int unreadCount,
             String senderNickname,
-            String senderAvatarUrl
+            String senderAvatarUrl,
+            String fileUrl,
+            String thumbnailUrl
     ) {}
 
     /**

--- a/src/main/java/com/cotalk/domain/port/outbound/FileStorage.java
+++ b/src/main/java/com/cotalk/domain/port/outbound/FileStorage.java
@@ -62,6 +62,25 @@ public interface FileStorage {
     String resolveUrl(String objectKey);
 
     /**
+     * 저장된 첨부파일 URL을 짧은 만료시간의 Pre-signed GET URL로 재발급한다.
+     * <p>
+     * 메시지에 저장된 {@code fileUrl}/{@code thumbnailUrl}은 업로드 시점에 발급된 값(공개 직접 URL
+     * 또는 만료된 Pre-signed URL)일 수 있다. 채팅방 멤버십이 검증된 읽기 경로에서 이 메서드로
+     * 저장 URL을 다시 서명하여, 인증된 멤버에게만 짧은 시간 동안 유효한 접근 URL을 제공한다.
+     * 멤버십 검증은 호출하는 애플리케이션 서비스의 책임이며, 이 어댑터는 검증을 수행하지 않는다.
+     * </p>
+     * <p>
+     * 저장 URL에서 저장 객체 키를 추출할 수 없거나(외부 URL 등) 입력이 비어 있으면, 입력값을
+     * 그대로 반환한다(링크 미리보기 이미지 등 첨부파일이 아닌 URL은 변형하지 않는다).
+     * </p>
+     *
+     * @param storedUrl         메시지에 저장된 첨부파일 URL
+     * @param expirationMinutes Pre-signed URL 유효 시간(분)
+     * @return 짧은 만료시간의 Pre-signed URL. 객체 키를 추출할 수 없으면 {@code storedUrl} 원본
+     */
+    String presignAttachmentUrl(String storedUrl, int expirationMinutes);
+
+    /**
      * 저장된 객체의 메타데이터(MIME 타입·크기)를 조회한다.
      * <p>
      * object-id 기반 전송 시 클라이언트가 보낸 contentType/size를 신뢰하지 않고

--- a/src/main/java/com/cotalk/infrastructure/config/properties/MinioProperties.java
+++ b/src/main/java/com/cotalk/infrastructure/config/properties/MinioProperties.java
@@ -15,7 +15,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @param publicReadPolicy 버킷 공개 읽기 정책 설정 여부.
  *                         {@code true}이면 버킷에 공개 읽기 정책을 적용하여 인증 없이 파일에 접근 가능하다.
  *                         {@code false}이면 공개 읽기 정책을 적용하지 않으며,
- *                         파일 접근 시 Pre-signed URL이 필요하다. (기본값: true)
+ *                         파일 접근 시 Pre-signed URL이 필요하다. (기본값: false)
+ * @param presignedUrlExpiryMinutes 첨부파일 읽기용 Pre-signed URL 만료 시간(분).
+ *                         멤버십 검증 후 발급되는 단기 접근 URL의 유효 시간이다. (기본값: 10분)
  * @author seunggu.lee
  */
 @ConfigurationProperties(prefix = "minio")
@@ -27,14 +29,23 @@ public record MinioProperties(
         String bucket,
         String publicUrl,
         String region,
-        boolean publicReadPolicy
+        boolean publicReadPolicy,
+        int presignedUrlExpiryMinutes
 ) {
+    /**
+     * 첨부파일 Pre-signed URL의 기본 만료 시간(분).
+     */
+    public static final int DEFAULT_PRESIGNED_URL_EXPIRY_MINUTES = 10;
+
     public MinioProperties {
         if (region == null || region.isBlank()) {
             region = "us-east-1";
         }
         if (bucket == null || bucket.isBlank()) {
             bucket = "cotalk";
+        }
+        if (presignedUrlExpiryMinutes <= 0) {
+            presignedUrlExpiryMinutes = DEFAULT_PRESIGNED_URL_EXPIRY_MINUTES;
         }
     }
 }

--- a/src/main/java/com/cotalk/infrastructure/storage/InMemoryFileStorage.java
+++ b/src/main/java/com/cotalk/infrastructure/storage/InMemoryFileStorage.java
@@ -131,6 +131,39 @@ public class InMemoryFileStorage implements FileStorage {
     }
 
     /**
+     * 저장된 첨부파일 URL을 단기 만료시간 표기가 포함된 URL로 재발급한다.
+     * <p>
+     * 인메모리 저장소는 실제 서명을 수행하지 않으므로, {@code baseUrl} 기준으로 객체 키를 추출해
+     * {@link #generatePresignedUrl(String, int)} 형태로 재구성한다. {@code baseUrl} 경계를 찾을 수 없으면
+     * 입력값을 그대로 반환한다.
+     * </p>
+     *
+     * @param storedUrl         저장된 첨부파일 URL
+     * @param expirationMinutes URL 만료 시간(분)
+     * @return 만료시간 표기가 포함된 URL. 객체 키를 추출할 수 없으면 {@code storedUrl} 원본
+     */
+    @Override
+    public String presignAttachmentUrl(String storedUrl, int expirationMinutes) {
+        if (storedUrl == null || storedUrl.isBlank()) {
+            return storedUrl;
+        }
+        String marker = baseUrl + "/";
+        int idx = storedUrl.indexOf(marker);
+        if (idx < 0) {
+            return storedUrl;
+        }
+        String afterBase = storedUrl.substring(idx + marker.length());
+        int queryIdx = afterBase.indexOf('?');
+        if (queryIdx >= 0) {
+            afterBase = afterBase.substring(0, queryIdx);
+        }
+        if (afterBase.isBlank()) {
+            return storedUrl;
+        }
+        return generatePresignedUrl(afterBase, expirationMinutes);
+    }
+
+    /**
      * 저장된 파일의 바이트 배열을 반환한다.
      * 테스트 목적으로 제공되는 메서드이다.
      *

--- a/src/main/java/com/cotalk/infrastructure/storage/MinioFileStorage.java
+++ b/src/main/java/com/cotalk/infrastructure/storage/MinioFileStorage.java
@@ -47,6 +47,7 @@ public class MinioFileStorage implements FileStorage {
     private final String bucketName;
     private final String publicUrl;
     private final boolean publicReadPolicy;
+    private final int presignedUrlExpiryMinutes;
 
     /**
      * MinioFileStorage를 생성한다.
@@ -64,6 +65,7 @@ public class MinioFileStorage implements FileStorage {
         this.bucketName = minioProperties.bucket();
         this.publicUrl = minioProperties.publicUrl();
         this.publicReadPolicy = minioProperties.publicReadPolicy();
+        this.presignedUrlExpiryMinutes = minioProperties.presignedUrlExpiryMinutes();
 
         try {
             ensureBucketExists();
@@ -135,7 +137,7 @@ public class MinioFileStorage implements FileStorage {
      * 파일을 MinIO에 업로드한다.
      *
      * <p>공개 URL({@code minio.public-url})이 설정되어 있으면 {@code publicUrl/bucket/fileName} 형태의 직접 URL을 반환한다.
-     * 공개 URL이 없으면 7일 유효기간의 Pre-signed URL을 생성하여 반환한다.
+     * 공개 URL이 없으면 {@code minio.presigned-url-expiry-minutes} 유효기간의 Pre-signed URL을 생성하여 반환한다.
      *
      * <p>공개 읽기 정책({@code minio.public-read-policy})이 {@code false}인 경우 직접 URL로는 파일에 접근할 수 없으며,
      * {@link #generatePresignedUrl(String, int)}을 통해 서명된 URL을 별도로 발급해야 한다.
@@ -171,7 +173,7 @@ public class MinioFileStorage implements FileStorage {
     /**
      * 저장 객체 키로부터 접근 URL을 재구성한다.
      * 공개 URL이 설정되어 있으면 {@code publicUrl/bucket/objectKey} 직접 URL을,
-     * 없으면 7일 유효기간의 Pre-signed URL을 반환한다.
+     * 없으면 설정된 만료시간({@code minio.presigned-url-expiry-minutes})의 Pre-signed URL을 반환한다.
      * 업로드 시 반환하는 URL과 동일한 규칙을 사용한다.
      *
      * @param objectKey 저장 객체 키
@@ -182,7 +184,53 @@ public class MinioFileStorage implements FileStorage {
         if (publicUrl != null && !publicUrl.isEmpty()) {
             return publicUrl + "/" + bucketName + "/" + objectKey;
         }
-        return generatePresignedUrl(objectKey, 60 * 24 * 7); // 7 days default
+        return generatePresignedUrl(objectKey, presignedUrlExpiryMinutes);
+    }
+
+    /**
+     * 저장된 첨부파일 URL을 단기 만료시간의 Pre-signed GET URL로 재발급한다.
+     * <p>
+     * 저장 URL({@code publicUrl/bucket/objectKey} 또는 만료된 Pre-signed URL)에서 버킷 경계를 기준으로
+     * 저장 객체 키를 추출한 뒤, {@link #generatePresignedUrl(String, int)}으로 새 서명 URL을 만든다.
+     * 객체 키를 추출할 수 없으면(버킷 세그먼트 부재 등) 입력값을 그대로 반환한다.
+     * </p>
+     *
+     * @param storedUrl         메시지에 저장된 첨부파일 URL
+     * @param expirationMinutes Pre-signed URL 유효 시간(분)
+     * @return 단기 Pre-signed URL. 객체 키를 추출할 수 없으면 {@code storedUrl} 원본
+     */
+    @Override
+    public String presignAttachmentUrl(String storedUrl, int expirationMinutes) {
+        if (storedUrl == null || storedUrl.isBlank()) {
+            return storedUrl;
+        }
+        String objectKey = extractObjectKey(storedUrl);
+        if (objectKey == null) {
+            // 버킷 경계를 식별할 수 없는 URL(외부 링크 등)은 변형하지 않는다.
+            return storedUrl;
+        }
+        return generatePresignedUrl(objectKey, expirationMinutes);
+    }
+
+    /**
+     * 저장 URL에서 {@code /bucket/} 경계를 찾아 저장 객체 키를 추출한다.
+     * 쿼리 문자열(만료된 Pre-signed 서명 등)은 제거한다.
+     *
+     * @param storedUrl 저장된 첨부파일 URL
+     * @return 추출된 객체 키. 버킷 경계를 찾지 못하면 {@code null}
+     */
+    private String extractObjectKey(String storedUrl) {
+        String marker = "/" + bucketName + "/";
+        int idx = storedUrl.indexOf(marker);
+        if (idx < 0) {
+            return null;
+        }
+        String afterBucket = storedUrl.substring(idx + marker.length());
+        int queryIdx = afterBucket.indexOf('?');
+        if (queryIdx >= 0) {
+            afterBucket = afterBucket.substring(0, queryIdx);
+        }
+        return afterBucket.isBlank() ? null : afterBucket;
     }
 
     /**

--- a/src/main/java/com/cotalk/infrastructure/storage/MinioFileStorage.java
+++ b/src/main/java/com/cotalk/infrastructure/storage/MinioFileStorage.java
@@ -15,6 +15,7 @@ import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 
 import java.io.InputStream;
+import java.net.URI;
 import java.time.Duration;
 import java.util.Optional;
 
@@ -213,24 +214,33 @@ public class MinioFileStorage implements FileStorage {
     }
 
     /**
-     * 저장 URL에서 {@code /bucket/} 경계를 찾아 저장 객체 키를 추출한다.
-     * 쿼리 문자열(만료된 Pre-signed 서명 등)은 제거한다.
+     * 저장 URL의 경로(path)를 파싱하여 선행 {@code /{bucket}/} 접두사를 제거해 저장 객체 키를 추출한다.
+     * <p>
+     * URL을 파싱하여 경로 부분만 사용하므로, 쿼리 문자열(만료된 Pre-signed 서명 등)이나 객체 키에
+     * 우연히 버킷명과 동일한 세그먼트가 포함되어도 영향을 받지 않는다. 경로가 {@code /{bucket}/}로
+     * 시작하는 path-style URL(현재 {@code publicUrl/bucket/objectKey} 및 Pre-signed URL)에서만
+     * 키를 추출하며, 그 외(외부 URL 등)에는 {@code null}을 반환해 변형하지 않는다.
+     * </p>
      *
      * @param storedUrl 저장된 첨부파일 URL
-     * @return 추출된 객체 키. 버킷 경계를 찾지 못하면 {@code null}
+     * @return 추출된 객체 키. 버킷 경계를 찾지 못하거나 URL을 파싱할 수 없으면 {@code null}
      */
     private String extractObjectKey(String storedUrl) {
-        String marker = "/" + bucketName + "/";
-        int idx = storedUrl.indexOf(marker);
-        if (idx < 0) {
+        String path;
+        try {
+            path = URI.create(storedUrl).getPath();
+        } catch (IllegalArgumentException e) {
             return null;
         }
-        String afterBucket = storedUrl.substring(idx + marker.length());
-        int queryIdx = afterBucket.indexOf('?');
-        if (queryIdx >= 0) {
-            afterBucket = afterBucket.substring(0, queryIdx);
+        if (path == null || path.isBlank()) {
+            return null;
         }
-        return afterBucket.isBlank() ? null : afterBucket;
+        String prefix = "/" + bucketName + "/";
+        if (!path.startsWith(prefix)) {
+            return null;
+        }
+        String objectKey = path.substring(prefix.length());
+        return objectKey.isBlank() ? null : objectKey;
     }
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -116,8 +116,11 @@ minio:
   public-url: ${MINIO_PUBLIC_URL:http://localhost:9000}
   region: ${MINIO_REGION:us-east-1}
   # 공개 읽기 정책 설정 여부. true이면 버킷에 공개 읽기 정책 적용(인증 없이 접근 가능).
-  # false로 설정 시 Pre-signed URL을 통해서만 파일에 접근 가능. (기본값: true - 기존 동작 유지)
-  public-read-policy: ${MINIO_PUBLIC_READ_POLICY:true}
+  # false로 설정 시 Pre-signed URL을 통해서만 파일에 접근 가능. (기본값: false - 채팅 첨부파일 비공개)
+  # 보안(H-1): 채팅 첨부파일은 멤버십 검증 후 단기 Pre-signed URL로만 접근해야 하므로 기본 비공개.
+  public-read-policy: ${MINIO_PUBLIC_READ_POLICY:false}
+  # 첨부파일 읽기용 Pre-signed URL 만료 시간(분). 멤버십 검증 후 발급되는 단기 접근 URL의 유효 시간. (기본값: 10분)
+  presigned-url-expiry-minutes: ${MINIO_PRESIGNED_URL_EXPIRY_MINUTES:10}
 
 # 파일 업로드 설정
 file:

--- a/src/test/java/com/cotalk/adapter/inbound/rest/ChatMessageControllerTest.java
+++ b/src/test/java/com/cotalk/adapter/inbound/rest/ChatMessageControllerTest.java
@@ -13,10 +13,12 @@ import com.cotalk.domain.port.inbound.message.GetMessageHistoryUseCase;
 import com.cotalk.domain.port.inbound.message.MessageReplyForwardUseCase;
 import com.cotalk.domain.port.inbound.message.SendMessageUseCase;
 import com.cotalk.domain.port.inbound.message.UpdateMessageUseCase;
+import com.cotalk.domain.port.outbound.FileStorage;
 import com.cotalk.infrastructure.ratelimit.RateLimitTestConfiguration;
 import com.cotalk.infrastructure.security.JwtAuthenticationFilter;
 import com.cotalk.infrastructure.security.JwtTokenProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -33,12 +35,14 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.lenient;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -76,10 +80,21 @@ class ChatMessageControllerTest {
     private GetMediaGalleryUseCase getMediaGalleryUseCase;
 
     @MockitoBean
+    private FileStorage fileStorage;
+
+    @MockitoBean
     private JwtTokenProvider jwtTokenProvider;
 
     @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @BeforeEach
+    void setUpPresignStub() {
+        // 기본적으로 첨부파일 URL을 그대로 통과시켜 기존 검증을 유지한다(실제로는 단기 Pre-signed URL로 재발급).
+        lenient().when(fileStorage.presignAttachmentUrl(anyString(), anyInt()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        lenient().when(fileStorage.presignAttachmentUrl(isNull(), anyInt())).thenReturn(null);
+    }
 
     @Nested
     @DisplayName("메시지 전송 API")
@@ -196,6 +211,46 @@ class ChatMessageControllerTest {
                     .andExpect(jsonPath("$.messageId").value(500L))
                     .andExpect(jsonPath("$.type").value("FILE"))
                     .andExpect(jsonPath("$.fileUrl").value("https://example.com/file.pdf"));
+        }
+
+        @Test
+        @DisplayName("응답의 첨부파일 URL은 저장 원본이 아닌 단기 Pre-signed URL이다 (H-1)")
+        @WithMockCustomUser(userId = 1L)
+        void should_returnPresignedAttachmentUrl_when_sendFileMessage() throws Exception {
+            // given
+            String storedFileUrl = "https://minio.example.com/cotalk/uploads/1/image.png";
+            String storedThumbnailUrl = "https://minio.example.com/cotalk/uploads/1/thumb.png";
+            String presignedFileUrl = "https://minio.example.com/cotalk/uploads/1/image.png?X-Amz-Signature=file";
+            String presignedThumbnailUrl = "https://minio.example.com/cotalk/uploads/1/thumb.png?X-Amz-Signature=thumb";
+
+            SendFileMessageRequest request = SendFileMessageRequest.of(
+                    100L, storedFileUrl, "image.png", 1024L, "image/png", storedThumbnailUrl);
+
+            Message message = Message.builder()
+                    .id(500L)
+                    .senderId(1L)
+                    .chatRoomId(100L)
+                    .type(Message.MessageType.IMAGE)
+                    .fileUrl(storedFileUrl)
+                    .fileName("image.png")
+                    .fileSize(1024L)
+                    .fileContentType("image/png")
+                    .thumbnailUrl(storedThumbnailUrl)
+                    .build();
+            ReflectionTestUtils.setField(message, "createdAt", LocalDateTime.now());
+
+            given(sendMessageUseCase.sendFileMessageAndBroadcast(anyLong(), anyLong(), any()))
+                    .willReturn(message);
+            given(fileStorage.presignAttachmentUrl(eq(storedFileUrl), anyInt())).willReturn(presignedFileUrl);
+            given(fileStorage.presignAttachmentUrl(eq(storedThumbnailUrl), anyInt())).willReturn(presignedThumbnailUrl);
+
+            // when & then: 응답에는 저장 원본이 아니라 단기 Pre-signed URL이 노출되어야 한다
+            mockMvc.perform(post("/api/v1/chat/messages/file")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.fileUrl").value(presignedFileUrl))
+                    .andExpect(jsonPath("$.thumbnailUrl").value(presignedThumbnailUrl));
         }
     }
 

--- a/src/test/java/com/cotalk/adapter/inbound/rest/ChatMessageControllerTest.java
+++ b/src/test/java/com/cotalk/adapter/inbound/rest/ChatMessageControllerTest.java
@@ -217,8 +217,8 @@ class ChatMessageControllerTest {
                     .id(999L).senderId(2L).chatRoomId(roomId).content("이전 메시지").build();
 
             List<GetMessageHistoryUseCase.EnrichedMessage> enriched = List.of(
-                    new GetMessageHistoryUseCase.EnrichedMessage(msg1, 0, "사용자1", null),
-                    new GetMessageHistoryUseCase.EnrichedMessage(msg2, 1, "사용자2", null)
+                    new GetMessageHistoryUseCase.EnrichedMessage(msg1, 0, "사용자1", null, null, null),
+                    new GetMessageHistoryUseCase.EnrichedMessage(msg2, 1, "사용자2", null, null, null)
             );
 
             GetMessageHistoryUseCase.EnrichedMessageHistoryResult result =
@@ -255,8 +255,8 @@ class ChatMessageControllerTest {
                     .id(998L).senderId(1L).chatRoomId(roomId).content("이전 메시지 2").build();
 
             List<GetMessageHistoryUseCase.EnrichedMessage> enriched = List.of(
-                    new GetMessageHistoryUseCase.EnrichedMessage(msg1, 0, "사용자2", null),
-                    new GetMessageHistoryUseCase.EnrichedMessage(msg2, 0, "사용자1", null)
+                    new GetMessageHistoryUseCase.EnrichedMessage(msg1, 0, "사용자2", null, null, null),
+                    new GetMessageHistoryUseCase.EnrichedMessage(msg2, 0, "사용자1", null, null, null)
             );
 
             GetMessageHistoryUseCase.EnrichedMessageHistoryResult result =
@@ -293,8 +293,8 @@ class ChatMessageControllerTest {
                     .id(999L).senderId(2L).chatRoomId(roomId).content("메시지 2").build();
 
             List<GetMessageHistoryUseCase.EnrichedMessage> enriched = List.of(
-                    new GetMessageHistoryUseCase.EnrichedMessage(msg1, 0, "사용자1", null),
-                    new GetMessageHistoryUseCase.EnrichedMessage(msg2, 0, "사용자2", null)
+                    new GetMessageHistoryUseCase.EnrichedMessage(msg1, 0, "사용자1", null, null, null),
+                    new GetMessageHistoryUseCase.EnrichedMessage(msg2, 0, "사용자2", null, null, null)
             );
 
             GetMessageHistoryUseCase.EnrichedMessageHistoryResult result =

--- a/src/test/java/com/cotalk/application/service/chat/BroadcastChatMessageServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/chat/BroadcastChatMessageServiceTest.java
@@ -6,10 +6,11 @@ import com.cotalk.domain.entity.ChatRoomMember;
 import com.cotalk.domain.entity.Message;
 import com.cotalk.domain.port.outbound.ChatMessageBroker;
 import com.cotalk.domain.port.outbound.ChatMessageBroker.ChatBroadcastMessage;
+import com.cotalk.domain.port.outbound.FileStorage;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -17,7 +18,10 @@ import java.time.ZoneOffset;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -32,8 +36,19 @@ class BroadcastChatMessageServiceTest {
     @Mock
     private ChatMessageBroker chatMessageBroker;
 
-    @InjectMocks
+    @Mock
+    private FileStorage fileStorage;
+
     private BroadcastChatMessageService broadcastChatMessageService;
+
+    @BeforeEach
+    void setUp() {
+        broadcastChatMessageService = new BroadcastChatMessageService(chatMessageBroker, fileStorage, 10);
+        // 첨부파일 URL은 그대로 통과시켜 기존 검증을 유지한다(실제로는 단기 Pre-signed URL로 재발급).
+        lenient().when(fileStorage.presignAttachmentUrl(anyString(), anyInt()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        lenient().when(fileStorage.presignAttachmentUrl(eq(null), anyInt())).thenReturn(null);
+    }
 
     @Test
     void should_broadcastMessageWithCorrectUnreadCount_when_multipleMembers() {

--- a/src/test/java/com/cotalk/application/service/message/GetMediaGalleryServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/message/GetMediaGalleryServiceTest.java
@@ -5,12 +5,14 @@ import com.cotalk.domain.entity.Message;
 import com.cotalk.domain.entity.User;
 import com.cotalk.domain.exception.ChatRoomAccessDeniedException;
 import com.cotalk.domain.port.inbound.message.GetMediaGalleryUseCase;
+import com.cotalk.domain.port.outbound.FileStorage;
 import com.cotalk.domain.port.outbound.MessageRepository;
 import com.cotalk.domain.port.outbound.UserRepository;
 import com.cotalk.domain.validator.ChatRoomMemberValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageRequest;
@@ -22,9 +24,13 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -45,8 +51,23 @@ class GetMediaGalleryServiceTest {
     @Mock
     private ChatRoomMemberValidator chatRoomMemberValidator;
 
-    @InjectMocks
+    @Mock
+    private FileStorage fileStorage;
+
     private GetMediaGalleryService getMediaGalleryService;
+
+    private static final int PRESIGN_EXPIRY_MINUTES = 10;
+
+    @BeforeEach
+    void setUp() {
+        getMediaGalleryService = new GetMediaGalleryService(
+                messageRepository, userRepository, chatRoomMemberValidator,
+                fileStorage, PRESIGN_EXPIRY_MINUTES);
+        // 기본 동작: 첨부파일 URL은 그대로 통과시켜 기존 검증을 유지한다.
+        // 실제 운영에서는 멤버십 검증 후 단기 Pre-signed URL로 재발급된다(H-1).
+        lenient().when(fileStorage.presignAttachmentUrl(anyString(), anyInt()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+    }
 
     @Test
     void should_returnPhotoGallery_when_typeIsPhoto() {
@@ -202,6 +223,41 @@ class GetMediaGalleryServiceTest {
         assertThatThrownBy(() -> getMediaGalleryService.getMediaGallery(chatRoomId, userId, type, 0, 20))
                 .isInstanceOf(ChatRoomAccessDeniedException.class)
                 .hasMessage("채팅방 멤버가 아닙니다.");
+
+        // 멤버십 검증 실패 시 Pre-signed URL을 발급하지 않는다(H-1).
+        verify(fileStorage, never()).presignAttachmentUrl(anyString(), anyInt());
+    }
+
+    @Test
+    @DisplayName("멤버 조회 시 첨부파일은 영구 공개 URL이 아닌 단기 Pre-signed URL로 재발급된다")
+    void should_returnPresignedAttachmentUrl_when_memberFetchesGallery() {
+        // given
+        Long chatRoomId = 10L;
+        Long userId = 1L;
+        String type = "PHOTO";
+        int page = 0;
+        int size = 20;
+
+        String storedUrl = "http://minio.example.com/cotalk/uploads/1/abc.png";
+        Message image = MessageTestFixture.createImageMessage(101L, chatRoomId, userId, storedUrl);
+        User user = User.builder().id(userId).nickname("사용자1").build();
+        Pageable pageable = PageRequest.of(page, size);
+
+        given(messageRepository.findByTypeInChatRoom(eq(chatRoomId), eq(List.of(Message.MessageType.IMAGE)), eq(pageable)))
+                .willReturn(List.of(image));
+        given(userRepository.findAllById(any())).willReturn(List.of(user));
+        given(fileStorage.presignAttachmentUrl(eq(storedUrl), eq(PRESIGN_EXPIRY_MINUTES)))
+                .willReturn(storedUrl + "?X-Amz-Signature=signed");
+
+        // when
+        GetMediaGalleryUseCase.MediaGalleryResult result =
+                getMediaGalleryService.getMediaGallery(chatRoomId, userId, type, page, size);
+
+        // then
+        verify(chatRoomMemberValidator).validateMembership(chatRoomId, userId);
+        assertThat(result.items().get(0).fileUrl()).contains("X-Amz-Signature");
+        assertThat(result.items().get(0).fileUrl()).isNotEqualTo(storedUrl);
+        verify(fileStorage).presignAttachmentUrl(storedUrl, PRESIGN_EXPIRY_MINUTES);
     }
 
     @Test

--- a/src/test/java/com/cotalk/application/service/message/GetMessageHistoryServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/message/GetMessageHistoryServiceTest.java
@@ -2,8 +2,11 @@ package com.cotalk.application.service.message;
 
 import com.cotalk.domain.entity.ChatRoomMember;
 import com.cotalk.domain.entity.Message;
+import com.cotalk.domain.entity.User;
 import com.cotalk.domain.exception.ChatRoomAccessDeniedException;
+import com.cotalk.domain.port.inbound.message.GetMessageHistoryUseCase.EnrichedMessageHistoryResult;
 import com.cotalk.domain.port.outbound.ChatRoomMemberRepository;
+import com.cotalk.domain.port.outbound.FileStorage;
 import com.cotalk.domain.port.outbound.MessageRepository;
 import com.cotalk.domain.port.outbound.UserRepository;
 import com.cotalk.domain.validator.ChatRoomMemberValidator;
@@ -19,7 +22,11 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class GetMessageHistoryServiceTest {
@@ -33,14 +40,21 @@ class GetMessageHistoryServiceTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private FileStorage fileStorage;
+
     private ChatRoomMemberValidator chatRoomMemberValidator;
 
     private GetMessageHistoryService getMessageHistoryService;
 
+    private static final int PRESIGN_EXPIRY_MINUTES = 10;
+
     @BeforeEach
     void setUp() {
         chatRoomMemberValidator = new ChatRoomMemberValidator(chatRoomMemberRepository);
-        getMessageHistoryService = new GetMessageHistoryService(messageRepository, chatRoomMemberRepository, userRepository, chatRoomMemberValidator);
+        getMessageHistoryService = new GetMessageHistoryService(
+                messageRepository, chatRoomMemberRepository, userRepository, chatRoomMemberValidator,
+                fileStorage, PRESIGN_EXPIRY_MINUTES);
     }
 
     @Test
@@ -196,5 +210,67 @@ class GetMessageHistoryServiceTest {
 
         // then
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("멤버가 히스토리 조회 시 첨부파일은 단기 Pre-signed URL로 재발급된다")
+    void should_returnPresignedAttachmentUrl_when_memberFetchesEnrichedHistory() {
+        // given
+        Long chatRoomId = 100L;
+        Long userId = 1L;
+        int size = 20;
+
+        ChatRoomMember member = ChatRoomMember.builder()
+                .id(1L).chatRoomId(chatRoomId).userId(userId).build();
+
+        Message fileMessage = Message.builder()
+                .id(1000L)
+                .chatRoomId(chatRoomId)
+                .senderId(userId)
+                .type(Message.MessageType.IMAGE)
+                .content("photo.png")
+                .fileUrl("http://minio.example.com/cotalk/uploads/1/abc.png")
+                .thumbnailUrl("http://minio.example.com/cotalk/uploads/1/abc-thumb.png")
+                .build();
+
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(chatRoomId, userId))
+                .willReturn(Optional.of(member));
+        given(messageRepository.findByChatRoomIdBeforeMessageId(chatRoomId, null, size))
+                .willReturn(List.of(fileMessage));
+        given(chatRoomMemberRepository.batchCountUnreadMembersByMessageIds(eq(chatRoomId), org.mockito.ArgumentMatchers.anyList()))
+                .willReturn(java.util.Map.of());
+        given(userRepository.findAllById(org.mockito.ArgumentMatchers.anySet()))
+                .willReturn(List.of(User.builder().id(userId).nickname("나").build()));
+        given(fileStorage.presignAttachmentUrl(eq(fileMessage.getFileUrl()), eq(PRESIGN_EXPIRY_MINUTES)))
+                .willReturn("http://minio.example.com/cotalk/uploads/1/abc.png?X-Amz-Signature=signed");
+        given(fileStorage.presignAttachmentUrl(eq(fileMessage.getThumbnailUrl()), eq(PRESIGN_EXPIRY_MINUTES)))
+                .willReturn("http://minio.example.com/cotalk/uploads/1/abc-thumb.png?X-Amz-Signature=signed");
+
+        // when
+        EnrichedMessageHistoryResult result =
+                getMessageHistoryService.getEnrichedMessageHistory(chatRoomId, userId, null, size);
+
+        // then: 영구 공개 URL이 아니라 서명된 단기 URL이 노출된다
+        assertThat(result.messages()).hasSize(1);
+        assertThat(result.messages().get(0).fileUrl()).contains("X-Amz-Signature");
+        assertThat(result.messages().get(0).thumbnailUrl()).contains("X-Amz-Signature");
+        verify(fileStorage).presignAttachmentUrl(fileMessage.getFileUrl(), PRESIGN_EXPIRY_MINUTES);
+    }
+
+    @Test
+    @DisplayName("멤버가 아니면 히스토리(첨부파일) 조회가 거부되고 Pre-signed URL을 발급하지 않는다")
+    void should_rejectAndNotPresign_when_nonMemberFetchesEnrichedHistory() {
+        // given
+        Long chatRoomId = 100L;
+        Long userId = 999L;
+        int size = 20;
+
+        given(chatRoomMemberRepository.findByChatRoomIdAndUserId(chatRoomId, userId))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> getMessageHistoryService.getEnrichedMessageHistory(chatRoomId, userId, null, size))
+                .isInstanceOf(ChatRoomAccessDeniedException.class);
+        verify(fileStorage, never()).presignAttachmentUrl(org.mockito.ArgumentMatchers.anyString(), anyInt());
     }
 }

--- a/src/test/java/com/cotalk/application/service/message/MessageBroadcastServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/message/MessageBroadcastServiceTest.java
@@ -5,12 +5,13 @@ import com.cotalk.common.fixture.MessageTestFixture;
 import com.cotalk.domain.entity.ChatRoomMember;
 import com.cotalk.domain.entity.Message;
 import com.cotalk.domain.port.outbound.ChatMessageBroker;
+import com.cotalk.domain.port.outbound.FileStorage;
 import com.cotalk.domain.port.outbound.MessageRepository;
 import com.cotalk.domain.port.outbound.UserEventBroker;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -19,8 +20,11 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -42,8 +46,20 @@ class MessageBroadcastServiceTest {
     @Mock
     private MessageRepository messageRepository;
 
-    @InjectMocks
+    @Mock
+    private FileStorage fileStorage;
+
     private MessageBroadcastService messageBroadcastService;
+
+    @BeforeEach
+    void setUp() {
+        messageBroadcastService = new MessageBroadcastService(
+                chatMessageBroker, userEventBroker, messageRepository, fileStorage, 10);
+        // 첨부파일 URL은 그대로 통과시켜 기존 검증을 유지한다(실제로는 단기 Pre-signed URL로 재발급).
+        lenient().when(fileStorage.presignAttachmentUrl(anyString(), anyInt()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        lenient().when(fileStorage.presignAttachmentUrl(eq(null), anyInt())).thenReturn(null);
+    }
 
     @Test
     void should_publishMessageAndChatListUpdate_when_broadcastToRedisCalled() {

--- a/src/test/java/com/cotalk/application/service/message/MessageReplyForwardServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/message/MessageReplyForwardServiceTest.java
@@ -6,6 +6,7 @@ import com.cotalk.domain.exception.ChatRoomAccessDeniedException;
 import com.cotalk.domain.exception.MessageNotFoundException;
 import com.cotalk.domain.port.outbound.ChatMessageBroker;
 import com.cotalk.domain.port.outbound.ChatRoomMemberRepository;
+import com.cotalk.domain.port.outbound.FileStorage;
 import com.cotalk.domain.port.outbound.MessageRepository;
 import com.cotalk.domain.port.outbound.UserEventBroker;
 import com.cotalk.domain.port.outbound.UserRepository;
@@ -15,7 +16,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -27,9 +28,13 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -53,7 +58,9 @@ class MessageReplyForwardServiceTest {
     @Mock
     private UserEventBroker userEventBroker;
 
-    @InjectMocks
+    @Mock
+    private FileStorage fileStorage;
+
     private MessageReplyForwardService messageReplyForwardService;
 
     private Long senderId;
@@ -66,6 +73,15 @@ class MessageReplyForwardServiceTest {
         senderId = 100L;
         chatRoomId = 1L;
         originalMessageId = 500L;
+
+        messageReplyForwardService = new MessageReplyForwardService(
+                messageRepository, chatRoomMemberRepository, idGenerator, chatMessageBroker,
+                userRepository, userEventBroker, fileStorage, 10);
+
+        // 첨부파일 URL은 기본적으로 그대로 통과시켜 기존 검증을 유지한다(실제로는 단기 Pre-signed URL로 재발급).
+        lenient().when(fileStorage.presignAttachmentUrl(anyString(), anyInt()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        lenient().when(fileStorage.presignAttachmentUrl(eq(null), anyInt())).thenReturn(null);
 
         originalMessage = Message.builder()
                 .id(originalMessageId)
@@ -297,6 +313,56 @@ class MessageReplyForwardServiceTest {
             assertThat(forwardedMessage.getFileSize()).isEqualTo(2048L);
             assertThat(forwardedMessage.getFileContentType()).isEqualTo("application/pdf");
             assertThat(forwardedMessage.getForwardedFromMessageId()).isEqualTo(originalMessageId);
+        }
+
+        @Test
+        @DisplayName("이미지 메시지를 전달할 때 브로드캐스트 첨부파일 URL은 원본이 아닌 단기 Pre-signed URL이다 (H-1)")
+        void should_broadcastPresignedAttachmentUrl_when_forwardImageMessage() {
+            // given
+            Long targetChatRoomId = 2L;
+            Long newMessageId = 700L;
+            String storedFileUrl = "https://minio.example.com/cotalk/uploads/1/image.png";
+            String storedThumbnailUrl = "https://minio.example.com/cotalk/uploads/1/thumb.png";
+            String presignedFileUrl = "https://minio.example.com/cotalk/uploads/1/image.png?X-Amz-Signature=file";
+            String presignedThumbnailUrl = "https://minio.example.com/cotalk/uploads/1/thumb.png?X-Amz-Signature=thumb";
+
+            Message imageMessage = Message.builder()
+                    .id(originalMessageId)
+                    .chatRoomId(chatRoomId)
+                    .senderId(200L)
+                    .content("이미지 설명")
+                    .type(Message.MessageType.IMAGE)
+                    .fileUrl(storedFileUrl)
+                    .fileName("image.png")
+                    .fileSize(1024L)
+                    .fileContentType("image/png")
+                    .thumbnailUrl(storedThumbnailUrl)
+                    .build();
+
+            given(messageRepository.findById(originalMessageId)).willReturn(Optional.of(imageMessage));
+            given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(chatRoomId, senderId)).willReturn(true);
+            given(chatRoomMemberRepository.existsByChatRoomIdAndUserId(targetChatRoomId, senderId)).willReturn(true);
+            given(idGenerator.nextId()).willReturn(newMessageId);
+            given(messageRepository.save(any(Message.class))).willAnswer(invocation -> {
+                Message msg = invocation.getArgument(0);
+                ReflectionTestUtils.setField(msg, "createdAt", LocalDateTime.now());
+                return msg;
+            });
+            given(fileStorage.presignAttachmentUrl(storedFileUrl, 10)).willReturn(presignedFileUrl);
+            given(fileStorage.presignAttachmentUrl(storedThumbnailUrl, 10)).willReturn(presignedThumbnailUrl);
+
+            // when
+            messageReplyForwardService.forwardMessage(senderId, originalMessageId, targetChatRoomId);
+
+            // then: 브로드캐스트된 첨부파일 URL은 저장 원본이 아니라 단기 Pre-signed URL이어야 한다
+            ArgumentCaptor<ChatMessageBroker.ChatBroadcastMessage> broadcastCaptor =
+                    ArgumentCaptor.forClass(ChatMessageBroker.ChatBroadcastMessage.class);
+            verify(chatMessageBroker, times(1)).publish(eq(targetChatRoomId), broadcastCaptor.capture());
+
+            ChatMessageBroker.ChatBroadcastMessage broadcast = broadcastCaptor.getValue();
+            assertThat(broadcast.fileUrl()).isEqualTo(presignedFileUrl);
+            assertThat(broadcast.thumbnailUrl()).isEqualTo(presignedThumbnailUrl);
+            assertThat(broadcast.fileUrl()).isNotEqualTo(storedFileUrl);
         }
     }
 }

--- a/src/test/java/com/cotalk/domain/service/FileObjectResolverTest.java
+++ b/src/test/java/com/cotalk/domain/service/FileObjectResolverTest.java
@@ -183,6 +183,11 @@ class FileObjectResolverTest {
         }
 
         @Override
+        public String presignAttachmentUrl(String storedUrl, int expirationMinutes) {
+            return storedUrl;
+        }
+
+        @Override
         public Optional<StoredObjectMetadata> getMetadata(String objectKey) {
             return Optional.ofNullable(objects.get(objectKey));
         }

--- a/src/test/java/com/cotalk/infrastructure/storage/MinioFileStorageTest.java
+++ b/src/test/java/com/cotalk/infrastructure/storage/MinioFileStorageTest.java
@@ -69,7 +69,8 @@ class MinioFileStorageTest {
                 bucket,
                 publicUrl,
                 "us-east-1",
-                publicReadPolicy
+                publicReadPolicy,
+                10
         );
     }
 
@@ -255,6 +256,42 @@ class MinioFileStorageTest {
 
         // then
         verify(newS3Client).putBucketPolicy(any(PutBucketPolicyRequest.class));
+    }
+
+    @Test
+    @DisplayName("저장된 공개 첨부파일 URL을 단기 Pre-signed URL로 재발급")
+    void should_presignFromStoredPublicUrl_when_presignAttachmentUrl() throws Exception {
+        // given: 영구 공개 URL(publicUrl/bucket/objectKey)
+        String storedUrl = PUBLIC_URL + "/" + BUCKET_NAME + "/uploads/1/abc.png";
+        String presignedUrl = "http://minio.example.com/cotalk/uploads/1/abc.png?X-Amz-Signature=signed";
+
+        PresignedGetObjectRequest presignedRequest = mock(PresignedGetObjectRequest.class);
+        given(presignedRequest.url()).willReturn(URI.create(presignedUrl).toURL());
+        given(s3Presigner.presignGetObject(any(GetObjectPresignRequest.class)))
+                .willReturn(presignedRequest);
+
+        // when
+        String result = fileStorage.presignAttachmentUrl(storedUrl, 10);
+
+        // then: 영구 URL이 아니라 서명된 단기 URL을 반환하고, 객체 키로 presign을 호출한다
+        assertEquals(presignedUrl, result);
+        verify(s3Presigner).presignGetObject(argThat((GetObjectPresignRequest req) ->
+                req.getObjectRequest().key().equals("uploads/1/abc.png")
+                        && req.getObjectRequest().bucket().equals(BUCKET_NAME)));
+    }
+
+    @Test
+    @DisplayName("버킷 경계가 없는 외부 URL은 변형하지 않고 그대로 반환")
+    void should_returnInputUnchanged_when_presignAttachmentUrlHasNoBucketSegment() {
+        // given: 버킷 세그먼트가 없는 외부 URL(링크 미리보기 이미지 등)
+        String externalUrl = "https://external.example.com/some/image.png";
+
+        // when
+        String result = fileStorage.presignAttachmentUrl(externalUrl, 10);
+
+        // then
+        assertEquals(externalUrl, result);
+        verify(s3Presigner, never()).presignGetObject(any(GetObjectPresignRequest.class));
     }
 
     @Test

--- a/src/test/java/com/cotalk/infrastructure/storage/MinioFileStorageTest.java
+++ b/src/test/java/com/cotalk/infrastructure/storage/MinioFileStorageTest.java
@@ -281,6 +281,29 @@ class MinioFileStorageTest {
     }
 
     @Test
+    @DisplayName("객체 키에 버킷명과 동일한 세그먼트가 포함되어도 선행 /bucket/ 접두사만 제거해 키를 추출")
+    void should_extractKeyByLeadingPrefix_when_objectKeyContainsBucketName() throws Exception {
+        // given: 객체 키 내부에 버킷명(test-bucket)과 동일한 세그먼트가 포함된 URL.
+        // 첫 번째 출현 위치 기반 추출(indexOf)이면 잘못된 키가 추출되지만, 경로 파싱은 선행 접두사만 제거한다.
+        String storedUrl = PUBLIC_URL + "/" + BUCKET_NAME + "/uploads/1/" + BUCKET_NAME + "/abc.png";
+        String presignedUrl = "http://minio.example.com/cotalk/uploads/1/test-bucket/abc.png?X-Amz-Signature=signed";
+
+        PresignedGetObjectRequest presignedRequest = mock(PresignedGetObjectRequest.class);
+        given(presignedRequest.url()).willReturn(URI.create(presignedUrl).toURL());
+        given(s3Presigner.presignGetObject(any(GetObjectPresignRequest.class)))
+                .willReturn(presignedRequest);
+
+        // when
+        String result = fileStorage.presignAttachmentUrl(storedUrl, 10);
+
+        // then: 선행 /test-bucket/ 만 제거된 전체 객체 키로 presign을 호출해야 한다
+        assertEquals(presignedUrl, result);
+        verify(s3Presigner).presignGetObject(argThat((GetObjectPresignRequest req) ->
+                req.getObjectRequest().key().equals("uploads/1/" + BUCKET_NAME + "/abc.png")
+                        && req.getObjectRequest().bucket().equals(BUCKET_NAME)));
+    }
+
+    @Test
     @DisplayName("버킷 경계가 없는 외부 URL은 변형하지 않고 그대로 반환")
     void should_returnInputUnchanged_when_presignAttachmentUrlHasNoBucketSegment() {
         // given: 버킷 세그먼트가 없는 외부 URL(링크 미리보기 이미지 등)


### PR DESCRIPTION
## 취약점 (H-1, HIGH)
채팅 첨부파일이 사실상 전역 공개 상태였다.
- `application.yml`의 `MINIO_PUBLIC_READ_POLICY` 기본값이 `true`라 `MinioFileStorage`가 버킷 전체에 `Principal:"*"` `s3:GetObject` 정책을 적용
- `resolveUrl`이 영구 직접 공개 URL(`publicUrl/bucket/uploads/{userId}/{uuid}.ext`)을 반환
- 유일한 기밀성 통제가 추측 불가 UUID뿐, 요청자가 해당 채팅방 멤버인지 검증 없음
- 결과적으로 1:1/그룹 채팅의 비공개 이미지/파일이 Referer·크롤러·푸시 페이로드·로그로 유출 가능. AES 메시지 암호화 설계와 모순.

## 수정
첨부파일을 기본 비공개로 전환하고, **멤버십 검증 후 발급되는 단기 presigned URL**로만 접근하도록 변경.

1. **버킷 기본 비공개**: `minio.public-read-policy: ${MINIO_PUBLIC_READ_POLICY:false}`. `MinioFileStorage`는 `false`일 때 공개 정책을 적용하지 않음(기존 분기 유지·테스트로 보강).
2. **읽기 경로 멤버십 게이트 + presigned 재발급**: 메시지 히스토리, 미디어 갤러리, 실시간 브로드캐스트(REST/WS 경로)에서 `chatRoomMemberValidator.validateMembership(roomId, userId)` 통과 후에만, 저장된 첨부 URL을 단기 presigned GET URL로 재발급. 방 단위로 1회만 검증하고 첨부별 재검증은 하지 않음(효율).
3. **presign TTL 단축**: 기존 7일(`60*24*7`) → 설정 프로퍼티 `minio.presigned-url-expiry-minutes`(기본 10분).
4. **헥사고날 유지**: 신규 포트 메서드 `FileStorage.presignAttachmentUrl(storedUrl, ttl)`는 저장 URL에서 객체 키만 추출해 재서명(미식별 시 원본 반환). 멤버십 검증/재발급은 application 서비스에 위치, 어댑터·포트는 무상태. `@Value`로 TTL 주입(application→infrastructure 의존 없음, ArchUnit 통과).

## 설정 변경 / 클라이언트 영향
- 신규/변경 환경변수:
  - `MINIO_PUBLIC_READ_POLICY` 기본값 `true` → **`false`** (기존 공개 동작을 유지하려면 명시적으로 `true` 설정)
  - `MINIO_PRESIGNED_URL_EXPIRY_MINUTES` (기본 `10`)
- **Flutter 클라이언트 영향(코드 변경은 이 PR 범위 아님)**: 첨부 URL이 이제 단기 만료 presigned URL이므로, 클라이언트는 (a) 응답에서 받은 URL을 영구 캐싱/하드코딩하지 말고, (b) 만료된 URL은 히스토리/갤러리 재조회로 갱신해야 함. 이미지 캐시 키를 객체 경로 기준으로 잡고 서명 쿼리스트링은 무시 권장.

## 검증
- `./gradlew test --tests "*Minio*" --tests "*FileStorage*" --tests "*Message*" --tests "*HexagonalArchitecture*"` 그린
- `./gradlew test` 전체 그린 (JaCoCo 60% 게이트 통과)

## 잔여 리스크/가정
- 기존에 저장된 메시지의 `fileUrl`(영구 공개 URL 형태)도 객체 키 추출로 재서명되어 정상 동작. `MINIO_PUBLIC_URL`이 설정된 상태에서도 읽기 경로는 presigned로 대체되므로 비공개 객체 접근에 문제 없음.
- 운영 전환 시 실제 MinIO 버킷의 기존 공개 정책은 별도로 제거 필요(앱은 신규/재기동 시 정책을 새로 적용하지 않을 뿐, 기존 정책을 능동 삭제하지 않음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)