### PR TITLE
fix(security): 백엔드 보안 하드닝 배치 (H-2, M-1~M-4, L-1, L-3)

### DIFF
--- a/src/main/java/com/cotalk/application/service/chatroom/LeaveChatRoomService.java
+++ b/src/main/java/com/cotalk/application/service/chatroom/LeaveChatRoomService.java
@@ -160,8 +160,8 @@ public class LeaveChatRoomService implements LeaveChatRoomUseCase {
 
         // 메시지 저장
         Message savedMessage = messageRepository.save(systemMessage);
-        log.info("System message created for user leave: chatRoomId={}, messageId={}, content={}",
-                chatRoomId, savedMessage.getId(), systemMessageContent);
+        log.info("System message created for user leave: chatRoomId={}, messageId={}",
+                chatRoomId, savedMessage.getId());
 
         // WebSocket으로 브로드캐스트
         ChatBroadcastMessage broadcastMessage = new ChatBroadcastMessage(

--- a/src/main/java/com/cotalk/application/service/chatroom/ReinviteDirectChatMemberService.java
+++ b/src/main/java/com/cotalk/application/service/chatroom/ReinviteDirectChatMemberService.java
@@ -120,8 +120,8 @@ public class ReinviteDirectChatMemberService implements ReinviteDirectChatMember
 
         // 메시지 저장
         Message savedMessage = messageRepository.save(systemMessage);
-        log.info("System message created for user reinvite: chatRoomId={}, messageId={}, content={}",
-                chatRoomId, savedMessage.getId(), systemMessageContent);
+        log.info("System message created for user reinvite: chatRoomId={}, messageId={}",
+                chatRoomId, savedMessage.getId());
 
         // 현재 멤버 목록 조회 (재초대된 사용자 포함)
         List<ChatRoomMember> members = chatRoomMemberRepository.findByChatRoomId(chatRoomId);

--- a/src/main/java/com/cotalk/application/service/message/MarkAsReadService.java
+++ b/src/main/java/com/cotalk/application/service/message/MarkAsReadService.java
@@ -219,8 +219,8 @@ public class MarkAsReadService implements MarkAsReadUseCase {
             return;
         }
 
-        log.debug("Found last message in chat room {}: messageId={}, content={}",
-                chatRoomId, lastMessage.getId(), lastMessage.getContent());
+        log.debug("Found last message in chat room {}: messageId={}",
+                chatRoomId, lastMessage.getId());
 
         // 발신자 닉네임 조회
         String senderNickname = userRepository.findById(lastMessage.getSenderId())

--- a/src/main/java/com/cotalk/infrastructure/crypto/EncryptionService.java
+++ b/src/main/java/com/cotalk/infrastructure/crypto/EncryptionService.java
@@ -1,6 +1,10 @@
 package com.cotalk.infrastructure.crypto;
 
 import com.cotalk.infrastructure.config.properties.AppProperties;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.Cipher;
@@ -10,6 +14,7 @@ import javax.crypto.spec.SecretKeySpec;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
+import java.util.Arrays;
 import java.util.Base64;
 
 /**
@@ -23,6 +28,7 @@ import java.util.Base64;
  *
  * @author seunggu.lee
  */
+@Slf4j
 @Component
 public class EncryptionService {
 
@@ -32,13 +38,16 @@ public class EncryptionService {
 
     private final SecretKey secretKey;
     private final boolean enabled;
+    private final Environment environment;
 
     /**
      * EncryptionService 생성자.
      *
      * @param appProperties 앱 설정 프로퍼티
+     * @param environment 활성 프로파일 확인용 스프링 환경
      */
-    public EncryptionService(AppProperties appProperties) {
+    public EncryptionService(AppProperties appProperties, Environment environment) {
+        this.environment = environment;
         this.enabled = appProperties.encryption().enabled();
         if (this.enabled) {
             String encryptionKey = appProperties.encryption().key();
@@ -49,6 +58,37 @@ public class EncryptionService {
             this.secretKey = new SecretKeySpec(keyBytes, "AES");
         } else {
             this.secretKey = null;
+        }
+    }
+
+    /**
+     * EncryptionService 생성자 (Environment 미지정).
+     * 단위 테스트 등 프로파일 확인이 불필요한 경우에 사용한다.
+     *
+     * @param appProperties 앱 설정 프로퍼티
+     */
+    public EncryptionService(AppProperties appProperties) {
+        this(appProperties, null);
+    }
+
+    /**
+     * 암호화가 비활성화된 상태로 비-test 프로파일이 활성화되면 시작 시점에 WARN 로그를 남긴다.
+     *
+     * <p>{@code enabled=false}이면 평문이 그대로 저장/반환되므로(fail-open),
+     * 프로파일/환경변수 설정 실수로 운영 데이터가 평문 노출되는 상황을 가시화한다.
+     * 운영(prod)은 {@code enabled=true}를 강제하므로 영향받지 않는다.</p>
+     */
+    @PostConstruct
+    void warnIfDisabled() {
+        if (enabled || environment == null) {
+            return;
+        }
+        boolean testProfile = environment.acceptsProfiles(Profiles.of("test"));
+        if (!testProfile) {
+            log.warn("암호화(app.encryption.enabled)가 비활성화되어 있습니다. "
+                    + "메시지 등 민감 데이터가 평문으로 저장됩니다. "
+                    + "운영/스테이징 환경이라면 즉시 설정을 점검하세요. activeProfiles={}",
+                    Arrays.toString(environment.getActiveProfiles()));
         }
     }
 

--- a/src/main/java/com/cotalk/infrastructure/crypto/EncryptionService.java
+++ b/src/main/java/com/cotalk/infrastructure/crypto/EncryptionService.java
@@ -3,6 +3,7 @@ package com.cotalk.infrastructure.crypto;
 import com.cotalk.infrastructure.config.properties.AppProperties;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.Profiles;
 import org.springframework.stereotype.Component;
@@ -46,6 +47,7 @@ public class EncryptionService {
      * @param appProperties 앱 설정 프로퍼티
      * @param environment 활성 프로파일 확인용 스프링 환경
      */
+    @Autowired
     public EncryptionService(AppProperties appProperties, Environment environment) {
         this.environment = environment;
         this.enabled = appProperties.encryption().enabled();

--- a/src/main/java/com/cotalk/infrastructure/ratelimit/RateLimitInterceptor.java
+++ b/src/main/java/com/cotalk/infrastructure/ratelimit/RateLimitInterceptor.java
@@ -11,8 +11,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.Profiles;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.HandlerMapping;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -41,8 +45,10 @@ public class RateLimitInterceptor implements HandlerInterceptor {
     private final RateLimitProperties rateLimitProperties;
     private final ProxyManager<byte[]> proxyManager;
     private final JwtTokenProvider jwtTokenProvider;
+    private final Environment environment;
     private final Counter allowedCounter;
     private final Counter blockedCounter;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
     /**
      * RateLimitInterceptor 생성자.
@@ -50,15 +56,18 @@ public class RateLimitInterceptor implements HandlerInterceptor {
      * @param rateLimitProperties Rate Limit 설정
      * @param proxyManager Bucket4j Redis ProxyManager
      * @param jwtTokenProvider JWT 토큰 프로바이더
+     * @param environment 활성 프로파일 확인용 스프링 환경
      * @param meterRegistry Micrometer 메트릭 레지스트리
      */
     public RateLimitInterceptor(RateLimitProperties rateLimitProperties,
                                  ProxyManager<byte[]> proxyManager,
                                  JwtTokenProvider jwtTokenProvider,
+                                 Environment environment,
                                  MeterRegistry meterRegistry) {
         this.rateLimitProperties = rateLimitProperties;
         this.proxyManager = proxyManager;
         this.jwtTokenProvider = jwtTokenProvider;
+        this.environment = environment;
         this.allowedCounter = Counter.builder("cotalk.ratelimit.requests")
                 .tag("result", "allowed")
                 .description("Rate limit 허용된 요청 수")
@@ -84,16 +93,19 @@ public class RateLimitInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        // k6 부하 테스트 우회: X-K6-Token 헤더가 설정된 토큰과 일치하면 rate limit 미적용
-        String bypassToken = rateLimitProperties.getK6BypassToken();
-        if (bypassToken != null && !bypassToken.isBlank()) {
-            String requestToken = request.getHeader("X-K6-Token");
-            if (bypassToken.equals(requestToken)) {
-                return true;
+        // k6 부하 테스트 우회: X-K6-Token 헤더가 설정된 토큰과 일치하면 rate limit 미적용.
+        // prod 프로파일에서는 설정과 무관하게 헤더를 무시하여 fail-closed 보장 (운영 우회 불가).
+        if (!isProdProfile()) {
+            String bypassToken = rateLimitProperties.getK6BypassToken();
+            if (bypassToken != null && !bypassToken.isBlank()) {
+                String requestToken = request.getHeader("X-K6-Token");
+                if (bypassToken.equals(requestToken)) {
+                    return true;
+                }
             }
         }
 
-        String path = request.getRequestURI();
+        String path = resolveMatchPath(request);
         RateLimitProperties.EndpointRateLimit limit = findRateLimit(path);
 
         if (limit == null) {
@@ -143,16 +155,96 @@ public class RateLimitInterceptor implements HandlerInterceptor {
     }
 
     /**
+     * 현재 prod 프로파일이 활성화되어 있는지 확인한다.
+     *
+     * @return prod 프로파일이 활성화되어 있으면 true
+     */
+    private boolean isProdProfile() {
+        return environment != null && environment.acceptsProfiles(Profiles.of("prod"));
+    }
+
+    /**
+     * Rate Limit 매칭에 사용할 정규화된 경로를 결정한다.
+     *
+     * <p>Spring MVC가 핸들러 매핑 시 결정한 best-matching 패턴
+     * ({@link HandlerMapping#BEST_MATCHING_PATTERN_ATTRIBUTE})이 있으면 이를 사용한다.
+     * 이 패턴은 트레일링 슬래시/매트릭스 변수 등 우회 변형을 흡수한 정규 패턴이므로
+     * prefix 매칭으로 인한 우회를 차단한다. 속성이 없으면(필터/테스트 등)
+     * 요청 URI를 정규화({@link #normalizeUri(String)})하여 대체한다.</p>
+     *
+     * @param request HTTP 요청
+     * @return Rate Limit 매칭에 사용할 경로
+     */
+    private String resolveMatchPath(HttpServletRequest request) {
+        Object bestMatch = request.getAttribute(HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE);
+        if (bestMatch instanceof String pattern && !pattern.isBlank()) {
+            return pattern;
+        }
+        return normalizeUri(request.getRequestURI());
+    }
+
+    /**
+     * 요청 URI를 매칭 가능한 형태로 정규화한다.
+     *
+     * <p>매트릭스 변수(";"), 트레일링 슬래시를 제거하여
+     * {@code /api/v1/auth/login/}, {@code /api/v1/auth/login;jsessionid=...} 같은
+     * 변형이 limiter를 우회하지 못하도록 한다.</p>
+     *
+     * @param uri 원본 요청 URI
+     * @return 정규화된 경로
+     */
+    private String normalizeUri(String uri) {
+        if (uri == null) {
+            return null;
+        }
+        String normalized = uri;
+        int semicolon = normalized.indexOf(';');
+        if (semicolon >= 0) {
+            normalized = normalized.substring(0, semicolon);
+        }
+        while (normalized.length() > 1 && normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        return normalized;
+    }
+
+    /**
      * 요청 경로에 해당하는 Rate Limit 설정을 찾는다.
      *
-     * @param path 요청 경로
+     * <p>설정된 엔드포인트 경로를 Ant 패턴으로 보고 {@link AntPathMatcher}로 매칭한다.
+     * 경로가 정확히 일치하거나, 엔드포인트 하위 경로({@code endpoint + "/**"})에
+     * 해당하면 매칭으로 간주한다. 트레일링 슬래시 등으로 정규화된 경로를 매칭하므로
+     * 기존 prefix(startsWith) 방식의 브루트포스 우회를 차단하면서도
+     * 하위 경로(예: {@code /api/v1/chat/messages/123}) 커버리지는 유지한다.</p>
+     *
+     * @param path 매칭 대상 경로(정규화된 URI 또는 resolved 패턴)
      * @return Rate Limit 설정, 없으면 null
      */
     private RateLimitProperties.EndpointRateLimit findRateLimit(String path) {
+        if (path == null) {
+            return null;
+        }
         return rateLimitProperties.getEndpoints().stream()
-                .filter(endpoint -> endpoint.getPath() != null && path.startsWith(endpoint.getPath()))
+                .filter(endpoint -> endpoint.getPath() != null && matchesEndpoint(endpoint.getPath(), path))
                 .findFirst()
                 .orElse(null);
+    }
+
+    /**
+     * 엔드포인트 경로와 요청 경로가 매칭되는지 판별한다.
+     *
+     * @param endpointPath 설정된 엔드포인트 경로(Ant 패턴)
+     * @param path 매칭 대상 경로
+     * @return 매칭되면 true
+     */
+    private boolean matchesEndpoint(String endpointPath, String path) {
+        if (pathMatcher.match(endpointPath, path)) {
+            return true;
+        }
+        String normalized = endpointPath.endsWith("/")
+                ? endpointPath.substring(0, endpointPath.length() - 1)
+                : endpointPath;
+        return pathMatcher.match(normalized + "/**", path);
     }
 
     /**

--- a/src/main/java/com/cotalk/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/cotalk/infrastructure/security/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.cotalk.infrastructure.security;
 
 import com.cotalk.infrastructure.config.properties.AppProperties;
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -54,6 +55,29 @@ public class SecurityConfig {
             AppProperties appProperties) {
         this.jwtAuthenticationFilter = jwtAuthenticationFilter;
         this.allowedOrigins = appProperties.cors().allowedOrigins().split(",");
+    }
+
+    /**
+     * CORS 설정의 fail-open 위험을 시작 시점에 차단한다.
+     *
+     * <p>{@code allowCredentials=true} 상태에서 허용 오리진에 와일드카드("*")나
+     * "null"이 포함되면 브라우저 보안 모델상 자격증명 포함 요청이 임의 오리진으로
+     * 허용될 수 있다. 배포 설정 오타로 CORS가 조용히 약화되는 것을 막기 위해
+     * 위반 시 즉시 예외를 던져 애플리케이션 기동을 실패시킨다.</p>
+     *
+     * @throws IllegalStateException 허용 오리진에 "*" 또는 "null"이 포함된 경우
+     */
+    @PostConstruct
+    void validateCorsConfiguration() {
+        for (String origin : allowedOrigins) {
+            String normalized = origin == null ? null : origin.trim();
+            if (normalized == null || normalized.equals("*") || normalized.equalsIgnoreCase("null")) {
+                throw new IllegalStateException(
+                        "CORS allowCredentials=true 상태에서 허용 오리진에 와일드카드(\"*\") 또는 \"null\"을 "
+                                + "사용할 수 없습니다. app.cors.allowed-origins에 명시적 오리진을 지정하세요. "
+                                + "현재 값: " + Arrays.toString(allowedOrigins));
+            }
+        }
     }
 
     /**
@@ -128,9 +152,10 @@ public class SecurityConfig {
                         ).permitAll()
                         .requestMatchers("/ws/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
-                        .requestMatchers("/actuator/health", "/actuator/health/**", "/actuator/info", "/actuator/prometheus").permitAll()
+                        .requestMatchers("/actuator/health", "/actuator/health/**", "/actuator/info").permitAll()
                         // 관리자 전용 엔드포인트
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
+                        // /actuator/prometheus 포함 그 외 모든 actuator 엔드포인트는 ADMIN 전용 (메트릭 노출 차단)
                         .requestMatchers("/actuator/**").hasRole("ADMIN")
                         // 그 외 모든 요청은 인증 필요
                         .anyRequest().authenticated())

--- a/src/main/java/com/cotalk/infrastructure/websocket/WebSocketAuthInterceptor.java
+++ b/src/main/java/com/cotalk/infrastructure/websocket/WebSocketAuthInterceptor.java
@@ -95,6 +95,12 @@ public class WebSocketAuthInterceptor implements ChannelInterceptor {
             throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
         }
 
+        // ACCESS 토큰만 허용 (REFRESH 등 다른 토큰 타입으로 인증 우회 차단, HTTP 필터와 동일한 불변식 유지)
+        if (!jwtTokenProvider.isAccessToken(token)) {
+            log.warn("WebSocket connection attempt with non-access token");
+            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+        }
+
         Long userId = jwtTokenProvider.getUserIdFromToken(token);
         accessor.setUser(new StompPrincipal(userId.toString()));
 

--- a/src/test/java/com/cotalk/infrastructure/crypto/EncryptionServiceTest.java
+++ b/src/test/java/com/cotalk/infrastructure/crypto/EncryptionServiceTest.java
@@ -143,4 +143,45 @@ class EncryptionServiceTest {
         // then
         assertThat(decrypted).isEqualTo(withEmoji);
     }
+
+    @Test
+    @DisplayName("should_평문_그대로_반환_when_암호화_비활성화")
+    void should_returnPlaintext_when_disabled() {
+        // given: 암호화 비활성화
+        AppProperties appProperties = createTestAppProperties(TEST_KEY, false);
+        EncryptionService disabled = new EncryptionService(appProperties);
+
+        // when & then: fail-open으로 평문 그대로 반환 (운영 prod는 enabled=true 강제이므로 영향 없음)
+        assertThat(disabled.isEnabled()).isFalse();
+        assertThat(disabled.encrypt("평문 메시지")).isEqualTo("평문 메시지");
+        assertThat(disabled.decrypt("평문 메시지")).isEqualTo("평문 메시지");
+    }
+
+    @Test
+    @DisplayName("should_경고없이_정상_when_비활성화_test_프로파일")
+    void should_notFail_when_disabledInTestProfile() {
+        // given: 비활성화 + test 프로파일
+        AppProperties appProperties = createTestAppProperties(TEST_KEY, false);
+        org.springframework.mock.env.MockEnvironment env = new org.springframework.mock.env.MockEnvironment();
+        env.setActiveProfiles("test");
+        EncryptionService service = new EncryptionService(appProperties, env);
+
+        // when & then: warnIfDisabled가 test 프로파일에서는 조용히 통과
+        org.assertj.core.api.Assertions.assertThatCode(service::warnIfDisabled)
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("should_경고로그_조건_충족_when_비활성화_비test_프로파일")
+    void should_warn_when_disabledInNonTestProfile() {
+        // given: 비활성화 + dev(비-test) 프로파일
+        AppProperties appProperties = createTestAppProperties(TEST_KEY, false);
+        org.springframework.mock.env.MockEnvironment env = new org.springframework.mock.env.MockEnvironment();
+        env.setActiveProfiles("dev");
+        EncryptionService service = new EncryptionService(appProperties, env);
+
+        // when & then: 비-test 프로파일에서도 예외 없이 WARN 경로를 수행
+        org.assertj.core.api.Assertions.assertThatCode(service::warnIfDisabled)
+                .doesNotThrowAnyException();
+    }
 }

--- a/src/test/java/com/cotalk/infrastructure/ratelimit/RateLimitInterceptorTest.java
+++ b/src/test/java/com/cotalk/infrastructure/ratelimit/RateLimitInterceptorTest.java
@@ -6,6 +6,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.mock.env.MockEnvironment;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -50,12 +51,15 @@ class RateLimitInterceptorTest {
 
     private MeterRegistry meterRegistry;
 
+    private MockEnvironment environment;
+
     private RateLimitInterceptor interceptor;
 
     @BeforeEach
     void setUp() {
         meterRegistry = new SimpleMeterRegistry();
-        interceptor = new RateLimitInterceptor(rateLimitProperties, proxyManager, jwtTokenProvider, meterRegistry);
+        environment = new MockEnvironment();
+        interceptor = new RateLimitInterceptor(rateLimitProperties, proxyManager, jwtTokenProvider, environment, meterRegistry);
     }
 
     @Nested
@@ -127,6 +131,129 @@ class RateLimitInterceptorTest {
 
             // then
             assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("should_rate_limit_적용_when_트레일링_슬래시_경로로_우회_시도")
+        void should_applyRateLimit_when_trailingSlashVariant() {
+            // given: 설정은 "/api/v1/auth/login", 요청은 트레일링 슬래시 변형
+            RateLimitProperties.EndpointRateLimit endpoint = new RateLimitProperties.EndpointRateLimit();
+            endpoint.setPath("/api/v1/auth/login");
+            endpoint.setRequestsPerMinute(5);
+            endpoint.setPerUser(false);
+
+            given(rateLimitProperties.isEnabled()).willReturn(true);
+            given(request.getRequestURI()).willReturn("/api/v1/auth/login/");
+            given(rateLimitProperties.getEndpoints()).willReturn(List.of(endpoint));
+            stubBucketAllow();
+
+            // when
+            boolean result = interceptor.preHandle(request, response, null);
+
+            // then: limiter가 경로를 해석하여 rate limit을 적용(버킷 소비)했는지 검증
+            assertThat(result).isTrue();
+            verify(proxyManager).builder();
+        }
+
+        @Test
+        @DisplayName("should_rate_limit_적용_when_매트릭스변수_경로로_우회_시도")
+        void should_applyRateLimit_when_matrixVariantPath() {
+            // given
+            RateLimitProperties.EndpointRateLimit endpoint = new RateLimitProperties.EndpointRateLimit();
+            endpoint.setPath("/api/v1/password/verify-code");
+            endpoint.setRequestsPerMinute(5);
+            endpoint.setPerUser(false);
+
+            given(rateLimitProperties.isEnabled()).willReturn(true);
+            given(request.getRequestURI()).willReturn("/api/v1/password/verify-code;jsessionid=abc");
+            given(rateLimitProperties.getEndpoints()).willReturn(List.of(endpoint));
+            stubBucketAllow();
+
+            // when
+            boolean result = interceptor.preHandle(request, response, null);
+
+            // then
+            assertThat(result).isTrue();
+            verify(proxyManager).builder();
+        }
+
+        @Test
+        @DisplayName("should_rate_limit_적용_when_BEST_MATCHING_PATTERN_속성_존재")
+        void should_applyRateLimit_when_bestMatchingPatternAttributePresent() {
+            // given: MVC가 해석한 best-matching 패턴을 사용
+            RateLimitProperties.EndpointRateLimit endpoint = new RateLimitProperties.EndpointRateLimit();
+            endpoint.setPath("/api/v1/auth/login");
+            endpoint.setRequestsPerMinute(5);
+            endpoint.setPerUser(false);
+
+            given(rateLimitProperties.isEnabled()).willReturn(true);
+            given(request.getAttribute(
+                    org.springframework.web.servlet.HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE))
+                    .willReturn("/api/v1/auth/login");
+            given(request.getRequestURI()).willReturn("/api/v1/auth/login");
+            given(rateLimitProperties.getEndpoints()).willReturn(List.of(endpoint));
+            stubBucketAllow();
+
+            // when
+            boolean result = interceptor.preHandle(request, response, null);
+
+            // then
+            assertThat(result).isTrue();
+            verify(proxyManager).builder();
+        }
+
+        @Test
+        @DisplayName("should_k6_우회헤더_무시_when_prod_프로파일")
+        void should_ignoreK6BypassHeader_when_prodProfile() {
+            // given: prod 프로파일 + 유효한 k6 토큰 설정 + 일치하는 헤더
+            environment.setActiveProfiles("prod");
+            RateLimitProperties.EndpointRateLimit endpoint = new RateLimitProperties.EndpointRateLimit();
+            endpoint.setPath("/api/v1/auth/login");
+            endpoint.setRequestsPerMinute(5);
+            endpoint.setPerUser(false);
+
+            given(rateLimitProperties.isEnabled()).willReturn(true);
+            given(request.getRequestURI()).willReturn("/api/v1/auth/login");
+            given(rateLimitProperties.getEndpoints()).willReturn(List.of(endpoint));
+            stubBucketAllow();
+
+            // when
+            boolean result = interceptor.preHandle(request, response, null);
+
+            // then: prod에서는 헤더를 읽지 않고 rate limit을 그대로 적용
+            assertThat(result).isTrue();
+            verify(proxyManager).builder();
+            verify(request, never()).getHeader("X-K6-Token");
+            verify(rateLimitProperties, never()).getK6BypassToken();
+        }
+
+        @Test
+        @DisplayName("should_k6_우회_허용_when_비prod_프로파일_토큰일치")
+        void should_allowK6Bypass_when_nonProdProfileTokenMatches() {
+            // given: 비-prod + 일치하는 k6 토큰 헤더
+            given(rateLimitProperties.isEnabled()).willReturn(true);
+            given(rateLimitProperties.getK6BypassToken()).willReturn("secret-k6");
+            given(request.getHeader("X-K6-Token")).willReturn("secret-k6");
+
+            // when
+            boolean result = interceptor.preHandle(request, response, null);
+
+            // then: rate limit 미적용으로 통과, 버킷 미조회
+            assertThat(result).isTrue();
+            verify(proxyManager, never()).builder();
+        }
+
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        private void stubBucketAllow() {
+            io.github.bucket4j.distributed.proxy.RemoteBucketBuilder builder =
+                    org.mockito.Mockito.mock(io.github.bucket4j.distributed.proxy.RemoteBucketBuilder.class);
+            io.github.bucket4j.Bucket bucket = org.mockito.Mockito.mock(io.github.bucket4j.Bucket.class);
+            given(proxyManager.builder()).willReturn(builder);
+            org.mockito.Mockito.doReturn(bucket).when(builder).build(
+                    org.mockito.ArgumentMatchers.any(byte[].class),
+                    org.mockito.ArgumentMatchers.<java.util.function.Supplier>any());
+            given(bucket.tryConsume(1)).willReturn(true);
+            given(bucket.getAvailableTokens()).willReturn(4L);
         }
     }
 }

--- a/src/test/java/com/cotalk/infrastructure/ratelimit/RateLimitInterceptorTest.java
+++ b/src/test/java/com/cotalk/infrastructure/ratelimit/RateLimitInterceptorTest.java
@@ -247,7 +247,10 @@ class RateLimitInterceptorTest {
         private void stubBucketAllow() {
             io.github.bucket4j.distributed.proxy.RemoteBucketBuilder builder =
                     org.mockito.Mockito.mock(io.github.bucket4j.distributed.proxy.RemoteBucketBuilder.class);
-            io.github.bucket4j.Bucket bucket = org.mockito.Mockito.mock(io.github.bucket4j.Bucket.class);
+            // build()의 선언 반환 타입은 BucketProxy이므로 Bucket이 아닌 BucketProxy를 모킹해야
+            // Mockito가 WrongTypeOfReturnValue를 던지지 않는다.
+            io.github.bucket4j.distributed.BucketProxy bucket =
+                    org.mockito.Mockito.mock(io.github.bucket4j.distributed.BucketProxy.class);
             given(proxyManager.builder()).willReturn(builder);
             org.mockito.Mockito.doReturn(bucket).when(builder).build(
                     org.mockito.ArgumentMatchers.any(byte[].class),

--- a/src/test/java/com/cotalk/infrastructure/security/SecurityConfigCorsValidationTest.java
+++ b/src/test/java/com/cotalk/infrastructure/security/SecurityConfigCorsValidationTest.java
@@ -1,0 +1,72 @@
+package com.cotalk.infrastructure.security;
+
+import com.cotalk.infrastructure.config.properties.AppProperties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+/**
+ * SecurityConfig의 CORS fail-open 방어(M-2) 단위 테스트.
+ *
+ * <p>{@code allowCredentials=true} 상태에서 와일드카드("*")/"null" 오리진이
+ * 설정되면 시작 시점에 예외로 기동을 실패시키는지 검증한다.</p>
+ *
+ * @author seunggu.lee
+ */
+@DisplayName("SecurityConfig CORS 검증")
+class SecurityConfigCorsValidationTest {
+
+    private SecurityConfig newConfig(String allowedOrigins) {
+        JwtAuthenticationFilter filter = mock(JwtAuthenticationFilter.class);
+        AppProperties appProperties = new AppProperties(
+                allowedOrigins,
+                new AppProperties.Cors(allowedOrigins),
+                new AppProperties.Redis("chat:room:", "user:event:"),
+                new AppProperties.PasswordReset(30),
+                new AppProperties.Terms("1.0", "1.0"),
+                new AppProperties.Encryption("dGhpc2lzYXRlc3RrZXlmb3JkZXZlbG9wbWVudG9ubHk=", false),
+                new AppProperties.Swagger("http://localhost:8080", "API 서버"),
+                AppProperties.Search.of("dGVzdC1ibGluZC1pbmRleC1zZWNyZXQtZm9yLXVuaXQtdGVzdHM="),
+                new AppProperties.Lock(false)
+        );
+        return new SecurityConfig(filter, appProperties);
+    }
+
+    @Test
+    @DisplayName("should_예외_발생_when_와일드카드_오리진_with_자격증명")
+    void should_throw_when_wildcardOriginWithCredentials() {
+        // given
+        SecurityConfig config = newConfig("*");
+
+        // when & then
+        assertThatThrownBy(config::validateCorsConfiguration)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("와일드카드");
+    }
+
+    @Test
+    @DisplayName("should_예외_발생_when_null_오리진_with_자격증명")
+    void should_throw_when_nullStringOriginWithCredentials() {
+        // given: "null" 문자열 오리진 포함
+        SecurityConfig config = newConfig("https://app.cotalk.com,null");
+
+        // when & then
+        assertThatThrownBy(config::validateCorsConfiguration)
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @DisplayName("should_정상_when_명시적_오리진만_설정")
+    void should_pass_when_onlyExplicitOrigins() {
+        // given
+        SecurityConfig config = newConfig("https://app.cotalk.com,https://admin.cotalk.com");
+
+        // when & then
+        assertThatCode(config::validateCorsConfiguration).doesNotThrowAnyException();
+        assertThat(config).isNotNull();
+    }
+}

--- a/src/test/java/com/cotalk/infrastructure/security/SecurityConfigTest.java
+++ b/src/test/java/com/cotalk/infrastructure/security/SecurityConfigTest.java
@@ -167,16 +167,20 @@ class SecurityConfigTest {
     @Test
     @DisplayName("should_인증게이트_통과_when_actuator_health_공개유지")
     void should_passSecurityGate_when_actuatorHealthPublic() throws Exception {
-        // when & then: health는 공개 유지 (인증 401이 아닌, 핸들러 부재로 404)
+        // when & then: health는 공개 유지 → 인증 게이트를 통과(401 아님).
+        // @WebMvcTest 슬라이스에는 actuator 핸들러가 없어 디스패치 시 NoResourceFoundException이
+        // 발생하고, GlobalExceptionHandler의 catch-all(Exception)이 이를 500으로 매핑한다.
+        // 핵심은 401(인증 차단)이 아니라는 점이며, 이는 health가 permitAll임을 검증한다.
         mockMvc.perform(get("/actuator/health"))
-                .andExpect(status().isNotFound());
+                .andExpect(status().isInternalServerError());
     }
 
     @Test
     @DisplayName("should_인증게이트_통과_when_actuator_info_공개유지")
     void should_passSecurityGate_when_actuatorInfoPublic() throws Exception {
-        // when & then: info는 공개 유지 (인증 401이 아닌, 핸들러 부재로 404)
+        // when & then: info는 공개 유지 → 인증 게이트를 통과(401 아님).
+        // health와 동일하게 슬라이스에 핸들러가 없어 catch-all에 의해 500으로 매핑된다.
         mockMvc.perform(get("/actuator/info"))
-                .andExpect(status().isNotFound());
+                .andExpect(status().isInternalServerError());
     }
 }

--- a/src/test/java/com/cotalk/infrastructure/security/SecurityConfigTest.java
+++ b/src/test/java/com/cotalk/infrastructure/security/SecurityConfigTest.java
@@ -155,4 +155,28 @@ class SecurityConfigTest {
                         .param("userId", "1"))
                 .andExpect(status().isUnauthorized());
     }
+
+    @Test
+    @DisplayName("should_401_반환_when_actuator_prometheus_인증없이_접근")
+    void should_returnUnauthorized_when_actuatorPrometheusWithoutAuth() throws Exception {
+        // when & then: M-4 - prometheus는 더 이상 permitAll이 아님 (ADMIN 전용)
+        mockMvc.perform(get("/actuator/prometheus"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("should_인증게이트_통과_when_actuator_health_공개유지")
+    void should_passSecurityGate_when_actuatorHealthPublic() throws Exception {
+        // when & then: health는 공개 유지 (인증 401이 아닌, 핸들러 부재로 404)
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("should_인증게이트_통과_when_actuator_info_공개유지")
+    void should_passSecurityGate_when_actuatorInfoPublic() throws Exception {
+        // when & then: info는 공개 유지 (인증 401이 아닌, 핸들러 부재로 404)
+        mockMvc.perform(get("/actuator/info"))
+                .andExpect(status().isNotFound());
+    }
 }

--- a/src/test/java/com/cotalk/infrastructure/websocket/WebSocketAuthInterceptorTest.java
+++ b/src/test/java/com/cotalk/infrastructure/websocket/WebSocketAuthInterceptorTest.java
@@ -56,6 +56,7 @@ class WebSocketAuthInterceptorTest {
             Message<?> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
 
             given(jwtTokenProvider.validateToken(token)).willReturn(true);
+            given(jwtTokenProvider.isAccessToken(token)).willReturn(true);
             given(jwtTokenProvider.getUserIdFromToken(token)).willReturn(userId);
 
             // when
@@ -63,6 +64,25 @@ class WebSocketAuthInterceptorTest {
 
             // then
             assertThat(result).isNotNull();
+        }
+
+        @Test
+        @DisplayName("should_예외_발생_when_ACCESS_토큰이_아닌_경우")
+        void should_throwException_when_notAccessToken() {
+            // given: 유효하지만 ACCESS가 아닌 토큰(예: REFRESH)
+            String token = "refresh-token";
+
+            StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.CONNECT);
+            accessor.setNativeHeader("Authorization", "Bearer " + token);
+            Message<?> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+            given(jwtTokenProvider.validateToken(token)).willReturn(true);
+            given(jwtTokenProvider.isAccessToken(token)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> interceptor.preSend(message, messageChannel))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("유효하지 않은 토큰입니다.");
         }
 
         @Test
@@ -110,6 +130,7 @@ class WebSocketAuthInterceptorTest {
             Message<?> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
 
             given(jwtTokenProvider.validateToken(token)).willReturn(true);
+            given(jwtTokenProvider.isAccessToken(token)).willReturn(true);
             given(jwtTokenProvider.getUserIdFromToken(token)).willReturn(userId);
 
             // when


### PR DESCRIPTION
## 백엔드 보안 하드닝 배치 (코드리뷰 후속 — 비차단 H/M/L)

출시 차단(C-1/H-1)에 이어, 보안 리뷰에서 식별된 비차단 항목들을 일괄 하드닝합니다.

- **H-2** rate-limit 매칭을 `startsWith` 접두 → `BEST_MATCHING_PATTERN_ATTRIBUTE` 기반 + URI 정규화로 교체. 트레일링 슬래시/경로 변형으로 로그인·비번재설정 brute-force 한도를 우회당하던 문제 차단.
- **M-1** WebSocket CONNECT에 `isAccessToken` 검사 추가 — HTTP 필터와 동일 불변식, 비-ACCESS 토큰 인증 우회 차단.
- **M-2** CORS fail-open 방지: `allowCredentials=true`인데 허용 오리진에 `*`/`null`이 있으면 기동 실패(배포 오타로 인한 조용한 약화 방지).
- **M-3** 시스템 메시지 로그에서 `content` 필드 제거 — 암호화 at-rest 설계와 일관.
- **M-4** `/actuator/prometheus`를 ADMIN 전용으로 이동(메트릭 노출 차단).
- **L-1** 비-test 프로파일에서 암호화 비활성 시 기동 WARN(fail-open 가시화).
- **L-3** prod 프로파일에서 k6 `X-K6-Token` 우회 무조건 무시(운영 우회 불가).

전체 테스트 그린(JaCoCo 60% 게이트 통과).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
