### PR TITLE
refactor(backend): 정합성/구조 클린업 5건 (안읽음 ID일원화·분산락 워치독·링크프리뷰 record/catch·clientMessageId 에코)

### DIFF
--- a/src/main/java/com/cotalk/adapter/inbound/websocket/ChatWebSocketController.java
+++ b/src/main/java/com/cotalk/adapter/inbound/websocket/ChatWebSocketController.java
@@ -112,7 +112,8 @@ public class ChatWebSocketController {
         // 실패해도 메시지는 저장됨 - 다음 조회 시 표시
         try {
             broadcastChatMessageUseCase.broadcastMessage(
-                    result.message(), result.senderNickname(), result.senderAvatarUrl(), result.members());
+                    result.message(), result.senderNickname(), result.senderAvatarUrl(), result.members(),
+                    request.clientMessageId());
         } catch (Exception e) {
             log.error("[WS] Failed to broadcast message: messageId={}, roomId={}",
                     result.message().getId(), request.roomId(), e);

--- a/src/main/java/com/cotalk/adapter/inbound/websocket/dto/ChatMessageRequest.java
+++ b/src/main/java/com/cotalk/adapter/inbound/websocket/dto/ChatMessageRequest.java
@@ -9,8 +9,11 @@ import jakarta.validation.constraints.Size;
  * 텍스트 채팅 메시지 전송 요청 DTO.
  * WebSocket을 통해 클라이언트로부터 수신되는 텍스트 메시지 요청입니다.
  *
- * @param roomId   채팅방 ID
- * @param content  메시지 내용 (최대 5000자)
+ * @param roomId          채팅방 ID
+ * @param content         메시지 내용 (최대 5000자)
+ * @param clientMessageId 클라이언트 낙관적 전송(optimistic send) 상관관계 ID (선택).
+ *                        서버는 이를 영속화하지 않고 브로드캐스트 메시지에 그대로 에코하여
+ *                        클라이언트가 자신의 임시 메시지와 서버 에코를 정확히 매칭하도록 한다.
  * @author seunggu.lee
  */
 public record ChatMessageRequest(
@@ -19,5 +22,7 @@ public record ChatMessageRequest(
 
         @NotBlank(message = "메시지 내용은 필수입니다.")
         @Size(max = MessageConstants.MAX_MESSAGE_LENGTH, message = "메시지는 최대 " + MessageConstants.MAX_MESSAGE_LENGTH + "자까지 가능합니다.")
-        String content
+        String content,
+
+        String clientMessageId
 ) {}

--- a/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageJpaRepository.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageJpaRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -18,36 +17,6 @@ import java.util.Optional;
  * @author seunggu.lee
  */
 public interface MessageJpaRepository extends JpaRepository<MessageJpaEntity, Long> {
-
-    /**
-     * 채팅방 ID로 메시지 목록을 생성일 역순으로 조회한다.
-     *
-     * @param chatRoomId 채팅방 ID
-     * @param pageable 페이지 정보
-     * @return 메시지 목록
-     */
-    @Query("SELECT m FROM MessageJpaEntity m WHERE m.chatRoomId = :chatRoomId AND m.deleted = false ORDER BY m.createdAt DESC")
-    List<MessageJpaEntity> findByChatRoomIdOrderByCreatedAtDesc(@Param("chatRoomId") Long chatRoomId, Pageable pageable);
-
-    /**
-     * 채팅방에서 마지막 읽은 시각 이후의 읽지 않은 메시지 수를 조회한다.
-     *
-     * @param chatRoomId 채팅방 ID
-     * @param userId 사용자 ID (본인 메시지 제외)
-     * @param lastReadAt 마지막 읽은 시각
-     * @return 읽지 않은 메시지 수
-     */
-    @Query("""
-        SELECT COUNT(m)
-        FROM MessageJpaEntity m
-        WHERE m.chatRoomId = :chatRoomId
-          AND m.deleted = false
-          AND m.senderId <> :userId
-          AND (:lastReadAt IS NULL OR m.createdAt > :lastReadAt)
-        """)
-    long countUnreadMessages(@Param("chatRoomId") Long chatRoomId,
-                             @Param("userId") Long userId,
-                             @Param("lastReadAt") LocalDateTime lastReadAt);
 
     /**
      * 채팅방에서 마지막 읽은 메시지 ID 이후의 읽지 않은 메시지 수를 조회한다.

--- a/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageRepositoryAdapter.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/message/MessageRepositoryAdapter.java
@@ -10,7 +10,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -50,34 +49,6 @@ public class MessageRepositoryAdapter implements MessageRepository {
     @Override
     public Optional<Message> findById(Long id) {
         return messageJpaRepository.findById(id).map(mapper::toDomain);
-    }
-
-    /**
-     * 채팅방 ID로 메시지 목록을 생성일 역순으로 조회한다.
-     *
-     * @param chatRoomId 채팅방 ID
-     * @param page 페이지 번호
-     * @param size 페이지 크기
-     * @return 메시지 목록
-     */
-    @Override
-    public List<Message> findByChatRoomIdOrderByCreatedAtDesc(Long chatRoomId, int page, int size) {
-        return messageJpaRepository.findByChatRoomIdOrderByCreatedAtDesc(chatRoomId, PageRequest.of(page, size)).stream()
-                .map(mapper::toDomain)
-                .toList();
-    }
-
-    /**
-     * 채팅방에서 읽지 않은 메시지 수를 조회한다.
-     *
-     * @param chatRoomId 채팅방 ID
-     * @param userId 사용자 ID
-     * @param lastReadAt 마지막 읽은 시각
-     * @return 읽지 않은 메시지 수
-     */
-    @Override
-    public long countUnreadMessages(Long chatRoomId, Long userId, LocalDateTime lastReadAt) {
-        return messageJpaRepository.countUnreadMessages(chatRoomId, userId, lastReadAt);
     }
 
     @Override

--- a/src/main/java/com/cotalk/application/service/chat/BroadcastChatMessageService.java
+++ b/src/main/java/com/cotalk/application/service/chat/BroadcastChatMessageService.java
@@ -51,7 +51,7 @@ public class BroadcastChatMessageService implements BroadcastChatMessageUseCase 
      */
     @Override
     public void broadcastMessage(Message message, String senderNickname, String senderAvatarUrl,
-                                 List<ChatRoomMember> members) {
+                                 List<ChatRoomMember> members, String clientMessageId) {
         // 카톡/라인 방식: 발신자를 제외한 모든 멤버가 읽지 않은 상태로 시작
         int unreadCount = Math.max(0, members.size() - 1);
 
@@ -82,7 +82,8 @@ public class BroadcastChatMessageService implements BroadcastChatMessageUseCase 
                 unreadCount,
                 null,  // eventType (일반 메시지)
                 null,  // relatedUserId
-                null   // relatedUserNickname
+                null,  // relatedUserNickname
+                clientMessageId  // 클라이언트 낙관적 전송 상관관계 ID (에코, 영속화 안 함)
         );
 
         chatMessageBroker.publish(message.getChatRoomId(), broadcastMessage);

--- a/src/main/java/com/cotalk/application/service/chatroom/LeaveChatRoomService.java
+++ b/src/main/java/com/cotalk/application/service/chatroom/LeaveChatRoomService.java
@@ -32,8 +32,14 @@ import java.util.List;
  *
  * <p>동시성 제어:
  * <ul>
- *   <li>분산락: 동일 채팅방에 대한 동시 퇴장 방지</li>
+ *   <li>분산락: 동일 채팅방에 대한 동시 퇴장 방지(워치독으로 트랜잭션 도중 락 만료 방지)</li>
  * </ul>
+ *
+ * <p><b>이중 진입 멱등성(defense in depth)</b>: 분산락이 비활성(NoOp) 상태이거나
+ * 동일 요청이 중복 진입하더라도, 본 서비스는 멱등하다. 두 번째 진입은 상태를 변경하기 전에
+ * {@link #doLeaveChatRoom}의 {@code findByChatRoomIdAndUserId}에서 이미 멤버가 삭제되어
+ * {@link ChatRoomAccessDeniedException}으로 거부된다. 따라서 멤버 중복 삭제나 퇴장
+ * 시스템 메시지 중복 발송이 발생하지 않는다.</p>
  *
  * <p><b>방/메시지 이력 보존 정책</b>: 멤버가 나가도 채팅방과 메시지 이력은
  * 삭제하지 않고 보존한다. 이는 의도된 도메인 규칙으로, 잔존 멤버 수에 따라
@@ -181,7 +187,8 @@ public class LeaveChatRoomService implements LeaveChatRoomUseCase {
                 0,    // unreadCount (시스템 메시지는 읽음 처리 불필요)
                 "USER_LEFT",     // eventType
                 leavingUserId,   // relatedUserId
-                userNickname     // relatedUserNickname
+                userNickname,    // relatedUserNickname
+                null             // clientMessageId (시스템 메시지, 해당 경로 없음)
         );
 
         chatMessageBroker.publish(chatRoomId, broadcastMessage);

--- a/src/main/java/com/cotalk/application/service/chatroom/ReinviteDirectChatMemberService.java
+++ b/src/main/java/com/cotalk/application/service/chatroom/ReinviteDirectChatMemberService.java
@@ -144,7 +144,8 @@ public class ReinviteDirectChatMemberService implements ReinviteDirectChatMember
                 0,    // unreadCount (시스템 메시지는 읽음 처리 불필요)
                 "USER_JOINED",   // eventType
                 inviteeId,       // relatedUserId
-                inviteeNickname  // relatedUserNickname
+                inviteeNickname, // relatedUserNickname
+                null             // clientMessageId (시스템 메시지, 해당 경로 없음)
         );
 
         chatMessageBroker.publish(chatRoomId, broadcastMessage);

--- a/src/main/java/com/cotalk/application/service/message/MessageBroadcastService.java
+++ b/src/main/java/com/cotalk/application/service/message/MessageBroadcastService.java
@@ -89,7 +89,8 @@ public class MessageBroadcastService {
                 message.getFileContentType(),
                 thumbnailUrl,
                 unreadCount,
-                null, null, null
+                null, null, null,
+                null  // clientMessageId (해당 경로 없음)
         );
 
         chatMessageBroker.publish(message.getChatRoomId(), broadcastMessage);

--- a/src/main/java/com/cotalk/application/service/message/MessageLinkPreviewService.java
+++ b/src/main/java/com/cotalk/application/service/message/MessageLinkPreviewService.java
@@ -11,8 +11,6 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -64,13 +62,17 @@ public class MessageLinkPreviewService {
     @Async
     @Transactional
     public void fetchAndSaveLinkPreview(Long messageId, String url) {
+        Message message;
+        LinkPreviewQueryResult result;
+        // DB 커밋 관심사: 미리보기 수집/저장 실패는 그레이스풀 디그레이션(메시지 자체는 유지)이므로
+        // 여기서만 광범위하게 흡수한다. 이 블록을 통과하지 못하면 이벤트 발행도 하지 않는다.
         try {
-            LinkPreviewQueryResult result = linkPreviewQueryPort.queryLinkPreview(url);
+            result = linkPreviewQueryPort.queryLinkPreview(url);
             Optional<Message> opt = messageRepository.findById(messageId);
             if (opt.isEmpty()) {
                 return;
             }
-            Message message = opt.get();
+            message = opt.get();
             message.applyLinkPreview(
                     result.url(),
                     result.title(),
@@ -79,22 +81,69 @@ public class MessageLinkPreviewService {
             );
             messageRepository.save(message);
             log.debug("Link preview saved for messageId={}, url={}", messageId, url);
+        } catch (Exception e) {
+            log.warn("Failed to fetch/save link preview for messageId={}, url={}: {}", messageId, url, e.getMessage());
+            return;
+        }
 
-            // Publish LINK_PREVIEW_UPDATED event so WebSocket clients can update in real-time
-            Map<String, Object> event = new LinkedHashMap<>();
-            event.put("schemaVersion", 1);
-            event.put("eventId", "linkpreview:" + messageId + ":" + System.currentTimeMillis());
-            event.put("eventType", "LINK_PREVIEW_UPDATED");
-            event.put("chatRoomId", message.getChatRoomId());
-            event.put("messageId", messageId);
-            event.put("linkPreviewUrl", result.url());
-            event.put("linkPreviewTitle", result.title());
-            event.put("linkPreviewDescription", result.description());
-            event.put("linkPreviewImageUrl", result.imageUrl());
-            chatMessageBroker.publishRoomEvent(message.getChatRoomId(), event);
+        // 발행 관심사: DB 커밋과 분리한다. 발행 실패는 영속화된 미리보기와 별개의 문제이므로
+        // 별도 try로 좁혀 명확한 메시지/레벨로 가시화한다(그레이스풀 디그레이션은 유지).
+        publishLinkPreviewUpdated(messageId, message.getChatRoomId(), result);
+    }
+
+    /**
+     * LINK_PREVIEW_UPDATED 이벤트를 채팅방에 발행하여 WebSocket 클라이언트가 실시간 갱신하도록 한다.
+     *
+     * <p>발행 실패가 메시지 영속화(이미 커밋됨)를 되돌리지 않도록 DB 관심사와 분리해 호출한다.
+     * 지속적인 발행 실패도 최소한 가시적으로 로깅되도록 별도 try로 좁힌다.</p>
+     *
+     * @param messageId  메시지 ID
+     * @param chatRoomId 채팅방 ID
+     * @param result     수집된 링크 미리보기 결과
+     */
+    private void publishLinkPreviewUpdated(Long messageId, Long chatRoomId, LinkPreviewQueryResult result) {
+        try {
+            LinkPreviewUpdatedEvent event = new LinkPreviewUpdatedEvent(
+                    1,
+                    "linkpreview:" + messageId + ":" + System.currentTimeMillis(),
+                    "LINK_PREVIEW_UPDATED",
+                    chatRoomId,
+                    messageId,
+                    result.url(),
+                    result.title(),
+                    result.description(),
+                    result.imageUrl()
+            );
+            chatMessageBroker.publishRoomEvent(chatRoomId, event);
             log.debug("Published LINK_PREVIEW_UPDATED event for messageId={}", messageId);
         } catch (Exception e) {
-            log.warn("Failed to fetch link preview for messageId={}, url={}: {}", messageId, url, e.getMessage());
+            log.warn("Failed to publish LINK_PREVIEW_UPDATED event for messageId={}: {}", messageId, e.getMessage());
         }
     }
+
+    /**
+     * 링크 미리보기 갱신 이벤트 DTO.
+     * Redis Pub/Sub -> WebSocket 방 토픽(/topic/chat/room/{roomId})으로 전달되는 이벤트다.
+     *
+     * @param schemaVersion          스키마 버전
+     * @param eventId                이벤트 고유 ID (중복 체크용)
+     * @param eventType              이벤트 유형 (LINK_PREVIEW_UPDATED)
+     * @param chatRoomId             채팅방 ID
+     * @param messageId              미리보기가 갱신된 메시지 ID
+     * @param linkPreviewUrl         미리보기 대상 URL
+     * @param linkPreviewTitle       미리보기 제목
+     * @param linkPreviewDescription 미리보기 설명
+     * @param linkPreviewImageUrl    미리보기 이미지 URL
+     */
+    private record LinkPreviewUpdatedEvent(
+            Integer schemaVersion,
+            String eventId,
+            String eventType,
+            Long chatRoomId,
+            Long messageId,
+            String linkPreviewUrl,
+            String linkPreviewTitle,
+            String linkPreviewDescription,
+            String linkPreviewImageUrl
+    ) {}
 }

--- a/src/main/java/com/cotalk/application/service/message/MessageReplyForwardService.java
+++ b/src/main/java/com/cotalk/application/service/message/MessageReplyForwardService.java
@@ -183,7 +183,8 @@ public class MessageReplyForwardService implements MessageReplyForwardUseCase {
                 message.getCreatedAt().atZone(ZoneOffset.UTC).toInstant().toEpochMilli(),
                 fileUrl, message.getFileName(), message.getFileSize(),
                 message.getFileContentType(), thumbnailUrl,
-                unreadCount, null, null, null);
+                unreadCount, null, null, null,
+                null);  // clientMessageId (해당 경로 없음)
 
         chatMessageBroker.publish(chatRoomId, broadcastMsg);
 

--- a/src/main/java/com/cotalk/domain/port/inbound/chat/BroadcastChatMessageUseCase.java
+++ b/src/main/java/com/cotalk/domain/port/inbound/chat/BroadcastChatMessageUseCase.java
@@ -27,6 +27,24 @@ public interface BroadcastChatMessageUseCase {
      * @param senderAvatarUrl 발신자 프로필 이미지 URL (사전 조회됨)
      * @param members         채팅방 멤버 목록 (사전 조회됨)
      */
+    default void broadcastMessage(Message message, String senderNickname, String senderAvatarUrl,
+                                  List<ChatRoomMember> members) {
+        broadcastMessage(message, senderNickname, senderAvatarUrl, members, null);
+    }
+
+    /**
+     * 메시지를 채팅방 참여자들에게 브로드캐스트하며, 클라이언트 상관관계 ID를 에코한다.
+     *
+     * <p>{@code clientMessageId}는 클라이언트의 낙관적 전송(optimistic send) 매칭용 일시적
+     * 상관관계 ID다. 브로드캐스트 메시지에 그대로 담아 에코하여, 발신 클라이언트가 자신의 임시
+     * 메시지와 서버 에코를 정확히 매칭하도록 한다. 영속화하지 않으며 없으면 {@code null}이다.</p>
+     *
+     * @param message         브로드캐스트할 메시지
+     * @param senderNickname  발신자 닉네임 (사전 조회됨)
+     * @param senderAvatarUrl 발신자 프로필 이미지 URL (사전 조회됨)
+     * @param members         채팅방 멤버 목록 (사전 조회됨)
+     * @param clientMessageId 클라이언트 낙관적 전송 상관관계 ID (없으면 null)
+     */
     void broadcastMessage(Message message, String senderNickname, String senderAvatarUrl,
-                          List<ChatRoomMember> members);
+                          List<ChatRoomMember> members, String clientMessageId);
 }

--- a/src/main/java/com/cotalk/domain/port/outbound/ChatMessageBroker.java
+++ b/src/main/java/com/cotalk/domain/port/outbound/ChatMessageBroker.java
@@ -102,6 +102,9 @@ public interface ChatMessageBroker {
      * @param eventType         이벤트 유형 (USER_LEFT, USER_JOINED 등, 시스템 메시지인 경우)
      * @param relatedUserId     관련 사용자 ID (나간 사용자, 참여한 사용자 등)
      * @param relatedUserNickname 관련 사용자 닉네임
+     * @param clientMessageId   클라이언트 낙관적 전송(optimistic send) 상관관계 ID.
+     *                          클라이언트가 STOMP 전송 본문에 담아 보내면 그대로 에코한다.
+     *                          영속화하지 않는 일시적(transient) 값이며, 없으면 null이다.
      */
     record ChatBroadcastMessage(
             Long messageId,
@@ -120,6 +123,7 @@ public interface ChatMessageBroker {
             Integer unreadCount,
             String eventType,
             Long relatedUserId,
-            String relatedUserNickname
+            String relatedUserNickname,
+            String clientMessageId
     ) {}
 }

--- a/src/main/java/com/cotalk/domain/port/outbound/DistributedLockPort.java
+++ b/src/main/java/com/cotalk/domain/port/outbound/DistributedLockPort.java
@@ -39,7 +39,10 @@ public interface DistributedLockPort {
                          TimeUnit timeUnit, Runnable runnable);
 
     /**
-     * 기본 설정(대기 3초, 유지 10초)으로 분산락을 획득한 후 작업을 실행한다.
+     * 기본 설정(대기 3초, 유지 시간은 워치독 자동 연장)으로 분산락을 획득한 후 작업을 실행한다.
+     *
+     * <p>락 임계영역 안의 DB 트랜잭션이 길어져도 락이 트랜잭션 도중 만료되지 않도록
+     * 구현체가 락 유지 시간을 자동 연장(워치독)한다.</p>
      *
      * @param lockKey  락 키
      * @param supplier 실행할 작업
@@ -49,7 +52,7 @@ public interface DistributedLockPort {
     <T> T executeWithLock(String lockKey, Supplier<T> supplier);
 
     /**
-     * 기본 설정(대기 3초, 유지 10초)으로 분산락을 획득한 후 작업을 실행한다 (반환값 없음).
+     * 기본 설정(대기 3초, 유지 시간은 워치독 자동 연장)으로 분산락을 획득한 후 작업을 실행한다 (반환값 없음).
      *
      * @param lockKey  락 키
      * @param runnable 실행할 작업

--- a/src/main/java/com/cotalk/domain/port/outbound/MessageRepository.java
+++ b/src/main/java/com/cotalk/domain/port/outbound/MessageRepository.java
@@ -3,7 +3,6 @@ package com.cotalk.domain.port.outbound;
 import com.cotalk.domain.entity.Message;
 import com.cotalk.domain.model.PageQuery;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -11,6 +10,10 @@ import java.util.Optional;
 /**
  * 메시지 레포지토리 포트.
  * 채팅 메시지 데이터 저장 및 조회를 위한 인터페이스를 정의한다.
+ *
+ * <p><b>정렬 권위(ordering authority):</b> 안 읽음 수 집계와 히스토리 조회는 모두
+ * 메시지 ID(단조 증가 Snowflake)를 단일 정렬·비교 기준으로 사용한다. {@code createdAt}
+ * 기반 비교나 offset 페이지네이션은 사용하지 않는다(커서 기반 + ID 비교로 일원화).</p>
  *
  * @author seunggu.lee
  */
@@ -31,26 +34,6 @@ public interface MessageRepository {
      * @return 조회된 메시지 (Optional)
      */
     Optional<Message> findById(Long id);
-
-    /**
-     * 채팅방의 메시지를 생성일시 역순으로 페이징 조회한다.
-     *
-     * @param chatRoomId 채팅방 ID
-     * @param page       페이지 번호 (0부터 시작)
-     * @param size       페이지 크기
-     * @return 메시지 목록 (최신순)
-     */
-    List<Message> findByChatRoomIdOrderByCreatedAtDesc(Long chatRoomId, int page, int size);
-
-    /**
-     * 채팅방에서 특정 시점 이후의 읽지 않은 메시지 수를 조회한다.
-     *
-     * @param chatRoomId 채팅방 ID
-     * @param userId     사용자 ID
-     * @param lastReadAt 마지막 읽은 시간
-     * @return 읽지 않은 메시지 수
-     */
-    long countUnreadMessages(Long chatRoomId, Long userId, LocalDateTime lastReadAt);
 
     /**
      * 채팅방에서 마지막 읽은 메시지 ID 이후의 읽지 않은 메시지 수를 조회한다.

--- a/src/main/java/com/cotalk/infrastructure/lock/DistributedLockExecutor.java
+++ b/src/main/java/com/cotalk/infrastructure/lock/DistributedLockExecutor.java
@@ -49,6 +49,19 @@ public class DistributedLockExecutor implements DistributedLockPort {
     private static final String LOCK_PREFIX = "lock:";
 
     /**
+     * 기본 락 유지 시간 센티넬: Redisson 워치독(watchdog) 사용.
+     *
+     * <p>{@code leaseTime = -1}로 {@code tryLock}을 호출하면 Redisson 워치독이 활성화되어,
+     * 락을 보유한 스레드가 살아있는 동안 락 만료를 자동으로 연장한다(기본 {@code lockWatchdogTimeout}
+     * 30초를 10초 주기로 갱신). 이로써 락 임계영역 안에서 DB 트랜잭션(친구요청·친구수락·방나가기 등)이
+     * 길어져도 트랜잭션 도중 락이 만료되어 동시성 보호가 풀리는 문제를 방지한다.</p>
+     *
+     * <p>워치독은 {@code finally}의 {@code unlock()}으로 락이 해제되면 함께 중단되므로,
+     * 정상 경로/예외 경로 모두에서 락이 확실히 해제된다.</p>
+     */
+    private static final long WATCHDOG_LEASE_TIME = -1L;
+
+    /**
      * NoOp 모드에서 동일 경고가 호출마다 폭주하는 것을 막기 위한 최소 로깅 간격(ms).
      * Redis 다운 시 락 사용처(친구수락·방나가기 등)가 다발 호출돼도 이 간격당 한 번만 경고한다.
      */
@@ -203,7 +216,10 @@ public class DistributedLockExecutor implements DistributedLockPort {
 
     /**
      * 기본 설정으로 분산락을 획득한 후 작업을 실행한다.
-     * 대기 시간 3초, 유지 시간 10초.
+     * 대기 시간 3초, 유지 시간은 Redisson 워치독(자동 연장)에 위임한다({@link #WATCHDOG_LEASE_TIME}).
+     *
+     * <p>락 임계영역 안에서 DB 트랜잭션이 길어져도 락이 트랜잭션 도중 만료되지 않도록
+     * 워치독이 보유 중인 락을 자동 연장한다.</p>
      *
      * @param lockKey  락 키
      * @param supplier 실행할 작업
@@ -212,17 +228,18 @@ public class DistributedLockExecutor implements DistributedLockPort {
      */
     @Override
     public <T> T executeWithLock(String lockKey, Supplier<T> supplier) {
-        return executeWithLock(lockKey, 3, 10, TimeUnit.SECONDS, supplier);
+        return executeWithLock(lockKey, 3, WATCHDOG_LEASE_TIME, TimeUnit.SECONDS, supplier);
     }
 
     /**
      * 기본 설정으로 분산락을 획득한 후 작업을 실행한다 (반환값 없음).
+     * 대기 시간 3초, 유지 시간은 Redisson 워치독(자동 연장)에 위임한다({@link #WATCHDOG_LEASE_TIME}).
      *
      * @param lockKey  락 키
      * @param runnable 실행할 작업
      */
     @Override
     public void executeWithLock(String lockKey, Runnable runnable) {
-        executeWithLock(lockKey, 3, 10, TimeUnit.SECONDS, runnable);
+        executeWithLock(lockKey, 3, WATCHDOG_LEASE_TIME, TimeUnit.SECONDS, runnable);
     }
 }

--- a/src/main/java/com/cotalk/infrastructure/messaging/InMemoryChatMessageBroker.java
+++ b/src/main/java/com/cotalk/infrastructure/messaging/InMemoryChatMessageBroker.java
@@ -80,7 +80,8 @@ public class InMemoryChatMessageBroker implements ChatMessageBroker {
                 msg.unreadCount(),
                 msg.eventType(),
                 msg.relatedUserId(),
-                msg.relatedUserNickname()
+                msg.relatedUserNickname(),
+                msg.clientMessageId()
         );
     }
 
@@ -137,6 +138,7 @@ public class InMemoryChatMessageBroker implements ChatMessageBroker {
             Integer unreadCount,
             String eventType,
             Long relatedUserId,
-            String relatedUserNickname
+            String relatedUserNickname,
+            String clientMessageId
     ) {}
 }

--- a/src/main/java/com/cotalk/infrastructure/messaging/RedisChatMessageSubscriber.java
+++ b/src/main/java/com/cotalk/infrastructure/messaging/RedisChatMessageSubscriber.java
@@ -186,7 +186,8 @@ public class RedisChatMessageSubscriber implements MessageListener {
                 msg.unreadCount(),
                 msg.eventType(),
                 msg.relatedUserId(),
-                msg.relatedUserNickname()
+                msg.relatedUserNickname(),
+                msg.clientMessageId()
         );
     }
 
@@ -210,6 +211,7 @@ public class RedisChatMessageSubscriber implements MessageListener {
      * @param eventType        이벤트 유형 (USER_LEFT, USER_JOINED 등, 시스템 메시지인 경우)
      * @param relatedUserId    관련 사용자 ID (나간 사용자, 참여한 사용자 등)
      * @param relatedUserNickname 관련 사용자 닉네임
+     * @param clientMessageId  클라이언트 낙관적 전송 상관관계 ID (에코, 없으면 null)
      */
     public record WebSocketChatMessage(
             Integer schemaVersion,
@@ -230,7 +232,8 @@ public class RedisChatMessageSubscriber implements MessageListener {
             Integer unreadCount,
             String eventType,
             Long relatedUserId,
-            String relatedUserNickname
+            String relatedUserNickname,
+            String clientMessageId
     ) {}
 
     /**

--- a/src/test/java/com/cotalk/adapter/inbound/websocket/ChatWebSocketControllerTest.java
+++ b/src/test/java/com/cotalk/adapter/inbound/websocket/ChatWebSocketControllerTest.java
@@ -120,7 +120,7 @@ class ChatWebSocketControllerTest {
     @DisplayName("메시지 전송 시 저장 후 브로드캐스트 유스케이스 호출")
     void should_saveAndBroadcast_when_sendMessage() {
         // given
-        ChatMessageRequest request = new ChatMessageRequest(100L, "테스트 메시지");
+        ChatMessageRequest request = new ChatMessageRequest(100L, "테스트 메시지", "client-tmp-42");
 
         ChatRoomMember member1 = ChatRoomMember.builder()
                 .id(1L)
@@ -145,7 +145,8 @@ class ChatWebSocketControllerTest {
 
         // then
         verify(sendMessageUseCase).sendMessageWithContext(100L, 1L, "테스트 메시지");
-        verify(broadcastChatMessageUseCase).broadcastMessage(mockMessage, "발신자", null, members);
+        // clientMessageId가 인바운드 요청에서 브로드캐스트 호출로 그대로 전달되어야 한다
+        verify(broadcastChatMessageUseCase).broadcastMessage(mockMessage, "발신자", null, members, "client-tmp-42");
         verify(publishChatListUpdateUseCase).publishChatListUpdate(mockMessage, members, "발신자");
     }
 
@@ -388,7 +389,7 @@ class ChatWebSocketControllerTest {
     @DisplayName("채팅방 멤버가 아닌 사용자의 메시지 전송은 거부된다")
     void should_rejectMessage_when_userNotMember() {
         // given
-        ChatMessageRequest request = new ChatMessageRequest(100L, "테스트 메시지");
+        ChatMessageRequest request = new ChatMessageRequest(100L, "테스트 메시지", null);
         Long unauthorizedUserId = 999L;
 
         doThrow(new ChatRoomAccessDeniedException(100L, unauthorizedUserId))

--- a/src/test/java/com/cotalk/adapter/outbound/persistence/MessageRepositoryAdapterTest.java
+++ b/src/test/java/com/cotalk/adapter/outbound/persistence/MessageRepositoryAdapterTest.java
@@ -28,7 +28,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -160,28 +159,6 @@ class MessageRepositoryAdapterTest {
         }
 
         @Test
-        @DisplayName("채팅방 ID로 메시지 목록을 역순으로 조회한다")
-        void should_findMessages_when_chatRoomIdProvided() {
-            // given
-            for (int i = 1; i <= 5; i++) {
-                messageRepository.save(Message.builder()
-                        .id(10000L + i)
-                        .chatRoomId(chatRoom.getId())
-                        .senderId(user1.getId())
-                        .content("메시지 " + i)
-                        .type(MessageType.TEXT)
-                        .build());
-            }
-
-            // when
-            List<Message> messages = messageRepository.findByChatRoomIdOrderByCreatedAtDesc(
-                    chatRoom.getId(), 0, 3);
-
-            // then
-            assertThat(messages).hasSize(3);
-        }
-
-        @Test
         @DisplayName("가장 최근 메시지를 조회한다")
         void should_findLatestMessage_when_chatRoomIdProvided() {
             // given - 단일 메시지만 저장 (Optional 반환을 위해)
@@ -217,57 +194,6 @@ class MessageRepositoryAdapterTest {
     @Nested
     @DisplayName("읽지 않은 메시지 카운트 시")
     class CountUnread {
-
-        @Test
-        @DisplayName("마지막 읽은 시간 이후의 메시지 수를 반환한다")
-        void should_countUnreadMessages_when_lastReadAtProvided() {
-            // given
-            LocalDateTime baseTime = LocalDateTime.of(2024, 1, 1, 12, 0);
-
-            for (int i = 1; i <= 5; i++) {
-                messageRepository.save(Message.builder()
-                        .id(10000L + i)
-                        .chatRoomId(chatRoom.getId())
-                        .senderId(user1.getId())
-                        .content("메시지 " + i)
-                        .type(MessageType.TEXT)
-                        .build());
-            }
-
-            // when
-            long unreadCount = messageRepository.countUnreadMessages(
-                    chatRoom.getId(), user2.getId(), baseTime);
-
-            // then
-            assertThat(unreadCount).isGreaterThanOrEqualTo(0);
-        }
-
-        @Test
-        @DisplayName("마지막 읽은 시간이 null이면 모든 메시지를 카운트한다")
-        void should_countAllMessages_when_lastReadAtIsNull() {
-            // given
-            messageRepository.save(Message.builder()
-                    .id(10001L)
-                    .chatRoomId(chatRoom.getId())
-                    .senderId(user1.getId())
-                    .content("메시지 1")
-                    .type(MessageType.TEXT)
-                    .build());
-            messageRepository.save(Message.builder()
-                    .id(10002L)
-                    .chatRoomId(chatRoom.getId())
-                    .senderId(user1.getId())
-                    .content("메시지 2")
-                    .type(MessageType.TEXT)
-                    .build());
-
-            // when - user2의 관점에서 user1이 보낸 메시지 카운트
-            long unreadCount = messageRepository.countUnreadMessages(
-                    chatRoom.getId(), user2.getId(), null);
-
-            // then - null이면 모든 메시지가 카운트됨 (본인 메시지 제외)
-            assertThat(unreadCount).isEqualTo(2);
-        }
 
         @Test
         @DisplayName("마지막 읽은 메시지 ID 이후의 메시지 수를 반환한다")

--- a/src/test/java/com/cotalk/application/service/chat/BroadcastChatMessageServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/chat/BroadcastChatMessageServiceTest.java
@@ -128,6 +128,42 @@ class BroadcastChatMessageServiceTest {
     }
 
     @Test
+    void should_echoClientMessageId_when_provided() {
+        // given
+        Message message = MessageTestFixture.createTextMessage(1L, 100L, 1L);
+        String senderNickname = "발신자";
+        List<ChatRoomMember> members = List.of(
+                ChatRoomTestFixture.createChatRoomMember(1L, 100L, 1L),
+                ChatRoomTestFixture.createChatRoomMember(2L, 100L, 2L)
+        );
+
+        // when - 클라이언트 상관관계 ID를 전달
+        broadcastChatMessageService.broadcastMessage(message, senderNickname, null, members, "client-tmp-99");
+
+        // then - 브로드캐스트 메시지에 clientMessageId가 그대로 에코되어야 한다
+        ArgumentCaptor<ChatBroadcastMessage> captor = ArgumentCaptor.forClass(ChatBroadcastMessage.class);
+        verify(chatMessageBroker).publish(eq(100L), captor.capture());
+        assertThat(captor.getValue().clientMessageId()).isEqualTo("client-tmp-99");
+    }
+
+    @Test
+    void should_haveNullClientMessageId_when_absent() {
+        // given
+        Message message = MessageTestFixture.createTextMessage(1L, 100L, 1L);
+        List<ChatRoomMember> members = List.of(
+                ChatRoomTestFixture.createChatRoomMember(1L, 100L, 1L)
+        );
+
+        // when - clientMessageId 없는 4-arg 기본 경로
+        broadcastChatMessageService.broadcastMessage(message, "발신자", null, members);
+
+        // then - 부재를 허용하며 null로 전달된다
+        ArgumentCaptor<ChatBroadcastMessage> captor = ArgumentCaptor.forClass(ChatBroadcastMessage.class);
+        verify(chatMessageBroker).publish(eq(100L), captor.capture());
+        assertThat(captor.getValue().clientMessageId()).isNull();
+    }
+
+    @Test
     void should_broadcastMessageWithTimestamp_when_messageHasCreatedAt() {
         // given
         Message message = MessageTestFixture.createTextMessage(1L, 100L, 1L);

--- a/src/test/java/com/cotalk/application/service/message/MessageLinkPreviewServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/message/MessageLinkPreviewServiceTest.java
@@ -14,7 +14,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Map;
+import java.lang.reflect.Method;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,10 +42,24 @@ class MessageLinkPreviewServiceTest {
     private ChatMessageBroker chatMessageBroker;
 
     @Captor
-    private ArgumentCaptor<Map<String, Object>> eventCaptor;
+    private ArgumentCaptor<Object> eventCaptor;
 
     @InjectMocks
     private MessageLinkPreviewService messageLinkPreviewService;
+
+    /**
+     * 발행된 이벤트 record의 접근자(accessor)를 리플렉션으로 호출해 값을 읽는다.
+     * 이벤트 record는 서비스 내부 private 타입이라 테스트에서 타입으로 참조할 수 없으므로 사용한다.
+     */
+    private static Object accessor(Object event, String component) {
+        try {
+            Method m = event.getClass().getDeclaredMethod(component);
+            m.setAccessible(true);
+            return m.invoke(event);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("이벤트 접근자 호출 실패: " + component, e);
+        }
+    }
 
     @Test
     @DisplayName("링크 미리보기 저장 후 LINK_PREVIEW_UPDATED 이벤트를 발행해야 함")
@@ -83,17 +97,17 @@ class MessageLinkPreviewServiceTest {
         // Then: chatMessageBroker.publishRoomEvent가 호출되어야 함
         verify(chatMessageBroker, times(1)).publishRoomEvent(eq(chatRoomId), eventCaptor.capture());
 
-        Map<String, Object> event = eventCaptor.getValue();
+        Object event = eventCaptor.getValue();
         assertThat(event).isNotNull();
-        assertThat(event.get("schemaVersion")).isEqualTo(1);
-        assertThat(event.get("eventType")).isEqualTo("LINK_PREVIEW_UPDATED");
-        assertThat(event.get("chatRoomId")).isEqualTo(chatRoomId);
-        assertThat(event.get("messageId")).isEqualTo(messageId);
-        assertThat(event.get("linkPreviewUrl")).isEqualTo(url);
-        assertThat(event.get("linkPreviewTitle")).isEqualTo("Example Title");
-        assertThat(event.get("linkPreviewDescription")).isEqualTo("Example Description");
-        assertThat(event.get("linkPreviewImageUrl")).isEqualTo("https://example.com/image.jpg");
-        assertThat(event.get("eventId")).asString().startsWith("linkpreview:" + messageId + ":");
+        assertThat(accessor(event, "schemaVersion")).isEqualTo(1);
+        assertThat(accessor(event, "eventType")).isEqualTo("LINK_PREVIEW_UPDATED");
+        assertThat(accessor(event, "chatRoomId")).isEqualTo(chatRoomId);
+        assertThat(accessor(event, "messageId")).isEqualTo(messageId);
+        assertThat(accessor(event, "linkPreviewUrl")).isEqualTo(url);
+        assertThat(accessor(event, "linkPreviewTitle")).isEqualTo("Example Title");
+        assertThat(accessor(event, "linkPreviewDescription")).isEqualTo("Example Description");
+        assertThat(accessor(event, "linkPreviewImageUrl")).isEqualTo("https://example.com/image.jpg");
+        assertThat(accessor(event, "eventId")).asString().startsWith("linkpreview:" + messageId + ":");
     }
 
     @Test

--- a/src/test/java/com/cotalk/infrastructure/lock/DistributedLockExecutorTest.java
+++ b/src/test/java/com/cotalk/infrastructure/lock/DistributedLockExecutorTest.java
@@ -126,7 +126,7 @@ class DistributedLockExecutorTest {
         Integer expectedResult = 42;
 
         given(redissonClient.getLock(anyString())).willReturn(rLock);
-        given(rLock.tryLock(eq(3L), eq(10L), eq(TimeUnit.SECONDS))).willReturn(true);
+        given(rLock.tryLock(eq(3L), eq(-1L), eq(TimeUnit.SECONDS))).willReturn(true);
         given(rLock.isHeldByCurrentThread()).willReturn(true);
 
         // when
@@ -144,7 +144,7 @@ class DistributedLockExecutorTest {
         AtomicInteger counter = new AtomicInteger(0);
 
         given(redissonClient.getLock(anyString())).willReturn(rLock);
-        given(rLock.tryLock(eq(3L), eq(10L), eq(TimeUnit.SECONDS))).willReturn(true);
+        given(rLock.tryLock(eq(3L), eq(-1L), eq(TimeUnit.SECONDS))).willReturn(true);
         given(rLock.isHeldByCurrentThread()).willReturn(true);
 
         // when

--- a/src/test/java/com/cotalk/infrastructure/messaging/InMemoryChatMessageBrokerTest.java
+++ b/src/test/java/com/cotalk/infrastructure/messaging/InMemoryChatMessageBrokerTest.java
@@ -64,7 +64,8 @@ class InMemoryChatMessageBrokerTest {
                 1,              // unreadCount
                 null,           // eventType
                 null,           // relatedUserId
-                null            // relatedUserNickname
+                null,           // relatedUserNickname
+                "client-abc-123" // clientMessageId
         );
 
         // when
@@ -80,6 +81,8 @@ class InMemoryChatMessageBrokerTest {
         assertEquals(roomId, capturedMessage.roomId());
         assertEquals("안녕하세요", capturedMessage.content());
         assertEquals("TEXT", capturedMessage.type());
+        // clientMessageId가 브로드캐스트 메시지로 그대로 에코되어야 한다
+        assertEquals("client-abc-123", capturedMessage.clientMessageId());
     }
 
     @Test
@@ -104,7 +107,8 @@ class InMemoryChatMessageBrokerTest {
                 1,   // unreadCount
                 null, // eventType
                 null, // relatedUserId
-                null  // relatedUserNickname
+                null, // relatedUserNickname
+                null  // clientMessageId
         );
 
         // when
@@ -151,7 +155,7 @@ class InMemoryChatMessageBrokerTest {
         ChatBroadcastMessage message = new ChatBroadcastMessage(
                 1L, 1L, "테스트유저", null, roomId, "test", "TEXT",
                 System.currentTimeMillis(), null, null, null, null, null, 1,
-                null, null, null
+                null, null, null, null
         );
 
         // when

--- a/src/test/java/com/cotalk/infrastructure/messaging/RedisChatMessageBrokerTest.java
+++ b/src/test/java/com/cotalk/infrastructure/messaging/RedisChatMessageBrokerTest.java
@@ -85,7 +85,8 @@ class RedisChatMessageBrokerTest {
                     System.currentTimeMillis(),
                     null, null, null, null, null,  // file fields
                     1,            // unreadCount
-                    null, null, null  // eventType, relatedUserId, relatedUserNickname
+                    null, null, null,  // eventType, relatedUserId, relatedUserNickname
+                    null  // clientMessageId
             );
 
             // when
@@ -122,7 +123,8 @@ class RedisChatMessageBrokerTest {
                     "image/jpeg",
                     "https://storage.example.com/thumb.jpg",
                     1,  // unreadCount
-                    null, null, null  // eventType, relatedUserId, relatedUserNickname
+                    null, null, null,  // eventType, relatedUserId, relatedUserNickname
+                    null  // clientMessageId
             );
 
             // when
@@ -148,7 +150,7 @@ class RedisChatMessageBrokerTest {
             ChatBroadcastMessage message = new ChatBroadcastMessage(
                     100L, 1L, "테스트유저", null, roomId, "test", "TEXT",
                     System.currentTimeMillis(), null, null, null, null, null, 1,
-                    null, null, null
+                    null, null, null, null
             );
             when(mockMapper.writeValueAsString(message))
                     .thenThrow(new JsonProcessingException("Serialization failed") {});

--- a/src/test/java/com/cotalk/infrastructure/messaging/RedisChatMessageSubscriberTest.java
+++ b/src/test/java/com/cotalk/infrastructure/messaging/RedisChatMessageSubscriberTest.java
@@ -217,7 +217,8 @@ class RedisChatMessageSubscriberTest {
                     1L, 2L, "테스트유저", "https://example.com/avatar.jpg", 3L, "content", "TEXT",
                     java.time.LocalDateTime.now(),
                     "fileUrl", "fileName", 100L, "text/plain", "thumbUrl", 1,
-                    null, null, null  // eventType, relatedUserId, relatedUserNickname
+                    null, null, null,  // eventType, relatedUserId, relatedUserNickname
+                    "client-xyz"  // clientMessageId
             );
 
             // then
@@ -235,6 +236,7 @@ class RedisChatMessageSubscriberTest {
             assertThat(message.fileContentType()).isEqualTo("text/plain");
             assertThat(message.thumbnailUrl()).isEqualTo("thumbUrl");
             assertThat(message.unreadCount()).isEqualTo(1);
+            assertThat(message.clientMessageId()).isEqualTo("client-xyz");
         }
     }
 


### PR DESCRIPTION
## 백엔드 정합성/구조 클린업 (5건)

헥사고날 도메인 순수화(#182) 위에서 진행한 정합성·구조 정리. 의도된 변경 외 동작 보존.

### 1. 안 읽음 수 메시지 ID 기준 일원화 + 죽은 시간 기반 경로 제거 (MEDIUM+LOW)
- 라이브 호출 없는 시간 기반 `countUnreadMessages(LocalDateTime)`(`createdAt > :lastReadAt`)를 포트/어댑터/JPA에서 삭제. 라이브 경로(배치+단건)는 ID 기준 `countUnreadMessagesByLastReadMessageId`.
- 마찬가지로 호출 없는 오프셋 페이징 `findByChatRoomIdOrderByCreatedAtDesc(page,size)` 삭제(라이브 히스토리는 커서 기반).
- 메시지 ID가 안 읽음/히스토리의 단일 정렬 권위임을 포트 JavaDoc에 명시.

### 2. 분산락 leaseTime 하드닝 (MEDIUM)
- `DistributedLockExecutor` 기본 convenience 메서드를 leaseTime=10s → Redisson 워치독(leaseTime=-1, 자동 연장)으로 전환. 락 임계영역의 DB 트랜잭션(친구요청/친구수락/방나가기)이 길어져도 트랜잭션 도중 락 만료를 방지.
- finally의 `isHeldByCurrentThread()` unlock 유지(정상/예외 경로 모두 해제).
- `LeaveChatRoomService`는 이중 진입 시 두 번째가 멤버 조회에서 `ChatRoomAccessDeniedException`으로 거부되어 멱등함을 확인·명시(defense in depth).

### 3. 링크 프리뷰 이벤트 DTO record 전환 (LOW)
- 손수 만든 `LinkedHashMap<String,Object>` 대신 형제 이벤트(RoomReadEvent/MessageDeletedEvent) 스타일의 `LinkPreviewUpdatedEvent` record로 전환해 타입 안전성 확보.

### 4. 링크 프리뷰 catch 범위 축소 (LOW)
- 메서드 전체(커밋 후 WebSocket 발행 포함)를 감싸던 `catch(Exception)`을 DB 수집/저장 관심사와 발행 관심사로 분리. 발행 실패를 별도 try로 좁혀 올바른 레벨로 가시화하되 그레이스풀 디그레이션 의도는 유지.

### 5. 백엔드가 clientMessageId를 에코 (Flutter H1 완성)
- 송신 inbound(`ChatMessageRequest`, STOMP 송신 본문)에 optional `clientMessageId` 추가, 브로드캐스트/에코 DTO(`ChatBroadcastMessage` 및 Redis·InMemory WebSocket 전송 DTO)까지 그대로 에코. 일시적 상관관계 ID로 영속화하지 않으며 부재(null) 허용.
- 이로써 Flutter 클라이언트의 낙관적 전송(optimistic send) 정확 매칭(H1)이 완성된다.

## 검증
- `./gradlew test` 전체 GREEN (BUILD SUCCESSFUL, 1820 tests, JaCoCo 게이트 통과)
- `./gradlew test --tests "*HexagonalArchitecture*"` GREEN (도메인 순수성 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
