### PR TITLE
fix(security): rate-limit 버킷 키 URI 변형 우회 차단 + 데드코드 제거

### DIFF
--- a/src/main/java/com/cotalk/adapter/outbound/persistence/chatroom/ChatRoomMemberJpaRepository.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/chatroom/ChatRoomMemberJpaRepository.java
@@ -99,24 +99,6 @@ public interface ChatRoomMemberJpaRepository extends JpaRepository<ChatRoomMembe
                                        @Param("lastReadMessageId") Long lastReadMessageId);
 
     /**
-     * 특정 메시지를 읽지 않은 멤버 수를 조회한다.
-     * 메시지 생성 시간보다 lastReadAt이 이전이거나 null인 멤버의 수를 반환한다.
-     * 발신자는 제외한다.
-     *
-     * @param chatRoomId       채팅방 ID
-     * @param messageCreatedAt 메시지 생성 시간
-     * @param senderId         발신자 ID (제외할 사용자)
-     * @return 읽지 않은 멤버 수
-     */
-    @Query("SELECT COUNT(m) FROM ChatRoomMemberJpaEntity m " +
-           "WHERE m.chatRoomId = :chatRoomId " +
-           "AND m.userId != :senderId " +
-           "AND (m.lastReadAt IS NULL OR m.lastReadAt < :messageCreatedAt)")
-    int countUnreadMembers(@Param("chatRoomId") Long chatRoomId,
-                           @Param("messageCreatedAt") LocalDateTime messageCreatedAt,
-                           @Param("senderId") Long senderId);
-
-    /**
      * 특정 메시지를 읽지 않은 멤버 수를 조회한다. (messageId 기준)
      */
     @Query("SELECT COUNT(m) FROM ChatRoomMemberJpaEntity m " +

--- a/src/main/java/com/cotalk/adapter/outbound/persistence/chatroom/ChatRoomMemberRepositoryAdapter.java
+++ b/src/main/java/com/cotalk/adapter/outbound/persistence/chatroom/ChatRoomMemberRepositoryAdapter.java
@@ -142,19 +142,6 @@ public class ChatRoomMemberRepositoryAdapter implements ChatRoomMemberRepository
         return chatRoomMemberJpaRepository.updateLastReadMessageIdIfNewer(chatRoomId, userId, lastReadAt, lastReadMessageId);
     }
 
-    /**
-     * 특정 메시지를 읽지 않은 멤버 수를 조회한다.
-     *
-     * @param chatRoomId       채팅방 ID
-     * @param messageCreatedAt 메시지 생성 시간
-     * @param senderId         발신자 ID (제외할 사용자)
-     * @return 읽지 않은 멤버 수
-     */
-    @Override
-    public int countUnreadMembers(Long chatRoomId, LocalDateTime messageCreatedAt, Long senderId) {
-        return chatRoomMemberJpaRepository.countUnreadMembers(chatRoomId, messageCreatedAt, senderId);
-    }
-
     @Override
     public int countUnreadMembersByMessageId(Long chatRoomId, Long messageId, Long senderId) {
         return chatRoomMemberJpaRepository.countUnreadMembersByMessageId(chatRoomId, messageId, senderId);

--- a/src/main/java/com/cotalk/domain/port/outbound/ChatRoomMemberRepository.java
+++ b/src/main/java/com/cotalk/domain/port/outbound/ChatRoomMemberRepository.java
@@ -105,18 +105,6 @@ public interface ChatRoomMemberRepository {
     int updateLastReadMessageIdIfNewer(Long chatRoomId, Long userId, LocalDateTime lastReadAt, Long lastReadMessageId);
 
     /**
-     * 특정 메시지를 읽지 않은 멤버 수를 조회한다.
-     * 메시지 생성 시간보다 lastReadAt이 이전이거나 null인 멤버의 수를 반환한다.
-     * 발신자는 제외한다.
-     *
-     * @param chatRoomId       채팅방 ID
-     * @param messageCreatedAt 메시지 생성 시간
-     * @param senderId         발신자 ID (제외할 사용자)
-     * @return 읽지 않은 멤버 수
-     */
-    int countUnreadMembers(Long chatRoomId, LocalDateTime messageCreatedAt, Long senderId);
-
-    /**
      * 특정 메시지를 읽지 않은 멤버 수를 조회한다. (messageId 기준)
      * 발신자는 제외한다.
      *

--- a/src/main/java/com/cotalk/infrastructure/ratelimit/RateLimitInterceptor.java
+++ b/src/main/java/com/cotalk/infrastructure/ratelimit/RateLimitInterceptor.java
@@ -112,7 +112,7 @@ public class RateLimitInterceptor implements HandlerInterceptor {
             return true;
         }
 
-        String keyString = generateKey(request, limit);
+        String keyString = generateKey(request, limit, path);
         byte[] key = keyString.getBytes(StandardCharsets.UTF_8);
         Bucket bucket = resolveBucket(key, limit);
         boolean consumed = bucket.tryConsume(1);
@@ -251,11 +251,23 @@ public class RateLimitInterceptor implements HandlerInterceptor {
      * Rate Limit 키를 생성한다.
      * 사용자별 제한이면 사용자 ID, 아니면 클라이언트 IP를 기준으로 키를 생성한다.
      *
+     * <p>버킷 키의 엔드포인트 식별자는 raw 요청 URI가 아니라 매칭 단계에서 사용한
+     * 정규화/해석된 엔드포인트 식별자({@code endpointId})를 사용한다. 이로써
+     * {@code /api/v1/auth/login}, {@code /api/v1/auth/login/},
+     * {@code /api/v1/auth/login;jsessionid=...} 같은 URI 변형이 동일 클라이언트에 대해
+     * 서로 다른 버킷을 만들어 throttle을 우회(브루트포스 증폭)하는 것을 차단한다.
+     * 매칭된 엔드포인트 설정 경로({@link RateLimitProperties.EndpointRateLimit#getPath()})를
+     * 우선 사용하고, 없으면 해석된 매칭 경로로 대체한다.</p>
+     *
      * @param request HTTP 요청
      * @param limit Rate Limit 설정
+     * @param matchedPath 매칭 단계에서 해석된 경로(폴백용)
      * @return Rate Limit 키 문자열
      */
-    private String generateKey(HttpServletRequest request, RateLimitProperties.EndpointRateLimit limit) {
+    private String generateKey(HttpServletRequest request, RateLimitProperties.EndpointRateLimit limit, String matchedPath) {
+        String endpointId = (limit.getPath() != null && !limit.getPath().isBlank())
+                ? limit.getPath()
+                : matchedPath;
         if (limit.isPerUser()) {
             // 사용자별 제한
             Optional<Long> userId = extractToken(request)
@@ -263,12 +275,12 @@ public class RateLimitInterceptor implements HandlerInterceptor {
                     .map(jwtTokenProvider::getUserIdFromToken);
 
             if (userId.isPresent()) {
-                return "rate-limit:user:" + userId.get() + ":" + request.getRequestURI();
+                return "rate-limit:user:" + userId.get() + ":" + endpointId;
             }
         }
         // IP별 제한
         String ip = getClientIpAddress(request);
-        return "rate-limit:ip:" + ip + ":" + request.getRequestURI();
+        return "rate-limit:ip:" + ip + ":" + endpointId;
     }
 
     /**

--- a/src/test/java/com/cotalk/infrastructure/ratelimit/RateLimitInterceptorTest.java
+++ b/src/test/java/com/cotalk/infrastructure/ratelimit/RateLimitInterceptorTest.java
@@ -190,7 +190,6 @@ class RateLimitInterceptorTest {
             given(request.getAttribute(
                     org.springframework.web.servlet.HandlerMapping.BEST_MATCHING_PATTERN_ATTRIBUTE))
                     .willReturn("/api/v1/auth/login");
-            given(request.getRequestURI()).willReturn("/api/v1/auth/login");
             given(rateLimitProperties.getEndpoints()).willReturn(List.of(endpoint));
             stubBucketAllow();
 
@@ -228,6 +227,68 @@ class RateLimitInterceptorTest {
         }
 
         @Test
+        @DisplayName("should_동일버킷_사용_when_URI_변형으로_우회_시도")
+        void should_useSameBucket_when_uriVariantsOfSameEndpoint() {
+            // given: 동일 엔드포인트의 두 URI 변형(트레일링 슬래시 유무)을 같은 클라이언트(IP)가 호출
+            RateLimitProperties.EndpointRateLimit endpoint = new RateLimitProperties.EndpointRateLimit();
+            endpoint.setPath("/api/v1/auth/login");
+            endpoint.setRequestsPerMinute(5);
+            endpoint.setPerUser(false);
+
+            given(rateLimitProperties.isEnabled()).willReturn(true);
+            given(rateLimitProperties.getEndpoints()).willReturn(List.of(endpoint));
+            given(request.getRemoteAddr()).willReturn("203.0.113.7");
+
+            java.util.List<byte[]> capturedKeys = new ArrayList<>();
+            stubBucketCapturingKey(capturedKeys);
+
+            // when: 첫 요청은 raw URI, 두 번째 요청은 트레일링 슬래시 변형
+            given(request.getRequestURI()).willReturn("/api/v1/auth/login");
+            interceptor.preHandle(request, response, null);
+            given(request.getRequestURI()).willReturn("/api/v1/auth/login/");
+            interceptor.preHandle(request, response, null);
+
+            // then: 두 변형 모두 동일한 버킷 키(=동일 버킷)를 사용해야 우회가 차단됨
+            assertThat(capturedKeys).hasSize(2);
+            assertThat(capturedKeys.get(0)).isEqualTo(capturedKeys.get(1));
+        }
+
+        @Test
+        @DisplayName("should_6번째_시도_차단_when_URI_변형으로_시도수_누적")
+        void should_throttleSixthAttempt_when_uriVariantsShareBucket() {
+            // given: 분당 5회 제한. 동일 클라이언트가 URI 변형을 섞어 6회 시도
+            RateLimitProperties.EndpointRateLimit endpoint = new RateLimitProperties.EndpointRateLimit();
+            endpoint.setPath("/api/v1/auth/login");
+            endpoint.setRequestsPerMinute(5);
+            endpoint.setPerUser(false);
+
+            given(rateLimitProperties.isEnabled()).willReturn(true);
+            given(rateLimitProperties.getEndpoints()).willReturn(List.of(endpoint));
+            given(request.getRemoteAddr()).willReturn("203.0.113.8");
+
+            // 키별로 단일 버킷을 공유하여 실제 누적 소비를 모사
+            stubBucketSharedByKey(5);
+
+            String[] variants = {
+                    "/api/v1/auth/login",
+                    "/api/v1/auth/login/",
+                    "/api/v1/auth/login;jsessionid=a",
+                    "/api/v1/auth/login",
+                    "/api/v1/auth/login/"
+            };
+            for (String uri : variants) {
+                given(request.getRequestURI()).willReturn(uri);
+                boolean result = interceptor.preHandle(request, response, null);
+                assertThat(result).isTrue();
+            }
+
+            // when & then: 6번째(또 다른 변형) 시도는 동일 버킷이 소진되어 차단되어야 함
+            given(request.getRequestURI()).willReturn("/api/v1/auth/login;jsessionid=b");
+            org.assertj.core.api.Assertions.assertThatThrownBy(() -> interceptor.preHandle(request, response, null))
+                    .isInstanceOf(com.cotalk.domain.exception.RateLimitExceededException.class);
+        }
+
+        @Test
         @DisplayName("should_k6_우회_허용_when_비prod_프로파일_토큰일치")
         void should_allowK6Bypass_when_nonProdProfileTokenMatches() {
             // given: 비-prod + 일치하는 k6 토큰 헤더
@@ -257,6 +318,60 @@ class RateLimitInterceptorTest {
                     org.mockito.ArgumentMatchers.<java.util.function.Supplier>any());
             given(bucket.tryConsume(1)).willReturn(true);
             given(bucket.getAvailableTokens()).willReturn(4L);
+        }
+
+        /**
+         * 항상 통과하는 버킷을 stub하되, build()에 전달된 key(byte[])를 capture한다.
+         */
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        private void stubBucketCapturingKey(java.util.List<byte[]> capturedKeys) {
+            io.github.bucket4j.distributed.proxy.RemoteBucketBuilder builder =
+                    org.mockito.Mockito.mock(io.github.bucket4j.distributed.proxy.RemoteBucketBuilder.class);
+            io.github.bucket4j.distributed.BucketProxy bucket =
+                    org.mockito.Mockito.mock(io.github.bucket4j.distributed.BucketProxy.class);
+            given(proxyManager.builder()).willReturn(builder);
+            org.mockito.Mockito.doAnswer(invocation -> {
+                capturedKeys.add(invocation.getArgument(0, byte[].class));
+                return bucket;
+            }).when(builder).build(
+                    org.mockito.ArgumentMatchers.any(byte[].class),
+                    org.mockito.ArgumentMatchers.<java.util.function.Supplier>any());
+            given(bucket.tryConsume(1)).willReturn(true);
+            given(bucket.getAvailableTokens()).willReturn(4L);
+        }
+
+        /**
+         * key(String 표현) 별로 단일 버킷을 공유하여, capacity회까지만 tryConsume이 성공하도록 모사한다.
+         * 동일 버킷 키를 사용하는 URI 변형들이 시도수를 누적 소비하는지 검증하기 위함이다.
+         */
+        @SuppressWarnings({"unchecked", "rawtypes"})
+        private void stubBucketSharedByKey(int capacity) {
+            io.github.bucket4j.distributed.proxy.RemoteBucketBuilder builder =
+                    org.mockito.Mockito.mock(io.github.bucket4j.distributed.proxy.RemoteBucketBuilder.class);
+            java.util.Map<String, io.github.bucket4j.distributed.BucketProxy> bucketsByKey = new java.util.HashMap<>();
+            java.util.Map<String, int[]> remainingByKey = new java.util.HashMap<>();
+            given(proxyManager.builder()).willReturn(builder);
+            org.mockito.Mockito.doAnswer(invocation -> {
+                byte[] keyBytes = invocation.getArgument(0, byte[].class);
+                String keyStr = new String(keyBytes, java.nio.charset.StandardCharsets.UTF_8);
+                return bucketsByKey.computeIfAbsent(keyStr, k -> {
+                    int[] remaining = {capacity};
+                    remainingByKey.put(k, remaining);
+                    io.github.bucket4j.distributed.BucketProxy bucket =
+                            org.mockito.Mockito.mock(io.github.bucket4j.distributed.BucketProxy.class);
+                    given(bucket.tryConsume(1)).willAnswer(inv -> {
+                        if (remaining[0] > 0) {
+                            remaining[0]--;
+                            return true;
+                        }
+                        return false;
+                    });
+                    given(bucket.getAvailableTokens()).willAnswer(inv -> (long) remaining[0]);
+                    return bucket;
+                });
+            }).when(builder).build(
+                    org.mockito.ArgumentMatchers.any(byte[].class),
+                    org.mockito.ArgumentMatchers.<java.util.function.Supplier>any());
         }
     }
 }


### PR DESCRIPTION
보안/아키텍처 재감사(re-audit)에서 남은 2건의 finding을 마감합니다.

## 1. SECURITY — rate-limit 버킷 키 URI 변형 우회 차단
이전 수정은 rate-limit **엔드포인트 매칭**만 resolved-pattern(`BEST_MATCHING_PATTERN_ATTRIBUTE` + URI 정규화)으로 바꿨고, 정작 클라이언트별 **버킷 키**는 여전히 raw `request.getRequestURI()`로 만들고 있었습니다.

- 결과: `/api/v1/auth/login` 과 `/api/v1/auth/login/`(또는 매트릭스 변형 `;jsessionid=...`)이 **동일 limit에 매칭되지만 서로 다른 버킷**을 생성 → 공격자가 URI 변형을 돌려가며 미인증 자격증명 엔드포인트(login/signup/password verify-code/oauth login)의 브루트포스 throttle을 우회 가능.
- 수정: `generateKey`가 매칭 단계와 **동일한 해석된 엔드포인트 식별자**(매칭된 `EndpointRateLimit.getPath()`, 폴백은 정규화된 매칭 경로)를 사용. 모든 URI 변형이 클라이언트별 단일 버킷을 공유합니다. per-user / per-IP 동작은 그대로 유지.
- 테스트: 두 URI 변형이 동일 버킷 키를 사용하는지, 변형을 섞어 시도해도 6번째 시도가 (리셋되지 않고) 차단되는지 검증.

## 2. ARCHITECTURE — 죽은 시간기반 안읽음 카운트 메서드 제거
`countUnreadMembers(chatRoomId, LocalDateTime, senderId)` 는 프로덕션·테스트 통틀어 호출자가 0건인 데드코드였습니다(grep 확인). 포트 인터페이스 / 영속성 어댑터 / JpaRepository 쿼리 3계층에서 제거했고, 라이브 경로인 ID 기반 `countUnreadMembersByMessageId` 는 유지했습니다.

## 검증
- `./gradlew test` 전체 그린 (JaCoCo 게이트 통과)
- ArchUnit(`*HexagonalArchitecture*`) 통과 — 도메인에 Spring/JPA 재유입 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)