### PR TITLE
chore(security): OWASP dependency-check CVE 게이트 추가 (A06)

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,0 +1,68 @@
+name: Dependency CVE Scan (OWASP A06)
+
+# 의존성 취약점(CVE) 스캔.
+# - PR / main push 시 OWASP Dependency-Check 를 실행한다.
+# - CVSS 7.0 이상 취약점 발견 시 빌드를 실패시킨다(-PdependencyCheckCI=true).
+# - 주 1회 스케줄 실행으로 신규 공개 CVE를 조기에 탐지한다.
+#
+# [필수] 메인테이너는 리포지토리 Secret 에 NVD_API_KEY 를 추가해야 한다.
+#   - 발급: https://nvd.nist.gov/developers/request-an-api-key
+#   - 키가 없으면 NVD DB 갱신이 매우 느려지고 rate-limit 으로 실패할 수 있다.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    # 매주 월요일 03:00 UTC (KST 12:00) — 신규 CVE 탐지
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      # NVD 데이터 캐시(다운로드 시간 단축). 주 단위 키로 갱신.
+      - name: Cache NVD database
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/dependency-check-data
+          key: nvd-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            nvd-${{ runner.os }}-
+
+      - name: Run OWASP Dependency-Check (CVSS >= 7.0 fails build)
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        run: ./gradlew dependencyCheckAnalyze -PdependencyCheckCI=true --no-daemon
+
+      - name: Upload Dependency-Check report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-check-report
+          path: build/reports/dependency-check-report.*
+          if-no-files-found: ignore
+
+      - name: Upload SARIF to code scanning
+        if: always()
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: build/reports/dependency-check-report.sarif

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     jacoco
     id("org.springframework.boot") version "3.5.6"
     id("io.spring.dependency-management") version "1.1.7"
+    // OWASP Dependency-Check: 의존성 CVE 스캔 (OWASP A06). dependencyCheckAnalyze 태스크 제공.
+    id("org.owasp.dependencycheck") version "12.1.0"
 }
 
 group = "com.cotalk"
@@ -176,5 +178,43 @@ tasks.jacocoTestCoverageVerification {
                 "*.CoTalkApplication"
             )
         }
+    }
+}
+
+// ----------------------------------------------------------------------------
+// OWASP Dependency-Check (의존성 CVE 스캔, OWASP A06)
+//
+// - `./gradlew dependencyCheckAnalyze` 로 의존성 트리의 알려진 CVE를 스캔한다.
+// - 기본 `test` 태스크와 분리되어 있어 일반 개발 빌드 속도에 영향을 주지 않는다.
+// - 빌드 실패 게이트(failBuildOnCVSS)는 CI에서만 활성화한다:
+//     로컬:  게이트 비활성(11.0) → NVD DB가 없어도 개발 빌드가 깨지지 않음
+//     CI  :  `-PdependencyCheckCI=true` 전달 시 CVSS 7.0 이상에서 빌드 실패
+// - NVD API 키는 환경변수 NVD_API_KEY 로 주입한다(없으면 느리지만 동작).
+// ----------------------------------------------------------------------------
+val dependencyCheckCI = providers.gradleProperty("dependencyCheckCI").orNull == "true"
+
+dependencyCheck {
+    // CI에서만 빌드 실패 게이트 적용. 로컬은 11.0(=사실상 비활성)으로 개발 빌드 보호.
+    failBuildOnCVSS = if (dependencyCheckCI) 7.0f else 11.0f
+
+    // 문서화된 오탐(false positive) 억제 파일
+    suppressionFile = "owasp-suppressions.xml"
+
+    // NVD API 키(있으면 빠름, 없으면 느리지만 동작)
+    providers.environmentVariable("NVD_API_KEY").orNull?.let { nvd.apiKey = it }
+
+    // 테스트 전용 의존성은 런타임 위협이 아니므로 스캔 범위에서 제외
+    scanConfigurations = configurations
+        .filter { it.name.startsWith("runtimeClasspath") || it.name.startsWith("compileClasspath") }
+        .map { it.name }
+
+    // 리포트 포맷(HTML + SARIF: CI/보안 도구 연동 용이)
+    formats = listOf("HTML", "SARIF")
+
+    // 오래된 분석기로 인한 오탐/잡음 감소
+    analyzers.apply {
+        assemblyEnabled = false
+        nodeAuditEnabled = false
+        nodeEnabled = false
     }
 }

--- a/owasp-suppressions.xml
+++ b/owasp-suppressions.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  OWASP Dependency-Check 오탐(false positive) 억제 파일.
+
+  - 빌드(`dependencyCheckAnalyze`)가 오탐으로 실패할 때, 근거를 남기고 여기에 추가한다.
+  - 모든 억제 항목은 반드시 <notes>에 사유/판단 근거/검토일을 기록한다.
+  - 실제 취약점을 숨기는 용도로 쓰지 말 것. 우선순위는 "의존성 버전 업"이다.
+
+  문법 참고: https://jeremylong.github.io/DependencyCheck/general/suppression.html
+
+  예시(주석 처리됨):
+  <suppress>
+    <notes><![CDATA[
+      false positive: <라이브러리>는 취약한 <컴포넌트>를 포함하지 않음. 검토일 2026-06-28.
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/com\.example/.*$</packageUrl>
+    <cve>CVE-0000-00000</cve>
+  </suppress>
+-->
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+</suppressions>


### PR DESCRIPTION
## 목적 (closes A06 automated-scanning gap)

보안 등급 A→A+ 의 마지막 갭인 **자동 의존성 CVE 스캔 부재 (OWASP A06)** 를 해소한다.
감사 지적사항이었던 "빌드 실패 CVE 게이트 없음"을 OWASP dependency-check 의 build-failing gate 로 충족한다.

## 변경 사항

### 1. OWASP Dependency-Check 플러그인 (`build.gradle.kts`)
- `org.owasp.dependencycheck` 12.1.0 도입 (Gradle 9.3.1 / Java 25 호환)
- `./gradlew dependencyCheckAnalyze` 태스크로 의존성 트리 CVE 스캔
- **빌드 실패 게이트**: `failBuildOnCVSS`
  - CI (`-PdependencyCheckCI=true`): **CVSS 7.0 이상 → 빌드 실패**
  - 로컬: 11.0(사실상 비활성) → NVD DB 없이도 개발 빌드가 깨지지 않음
- 기본 `test` 태스크와 **완전 분리** → 일반 개발 빌드 속도 영향 없음 (`./gradlew test --rerun-tasks` 그래프에 depcheck 태스크 없음 확인)
- `NVD_API_KEY` 환경변수 지원, `owasp-suppressions.xml` 오탐 억제 스캐폴드 추가

### 2. CI 와이어링 (`.github/workflows/dependency-check.yml`)
- PR / main push / 주간 스케줄(월 03:00 UTC) / 수동 실행
- `-PdependencyCheckCI=true` 로 CVSS 7.0+ 발견 시 빌드 실패
- HTML/SARIF 리포트 아티팩트 업로드 + GitHub code scanning 연동

## ⚠️ 메인테이너 필수 작업
리포지토리 **Secret 에 `NVD_API_KEY` 추가** 필요.
- 발급: https://nvd.nist.gov/developers/request-an-api-key
- 키가 없으면 NVD DB 갱신이 매우 느려지고 rate-limit 으로 실패할 수 있음.

## 스캔 결과
로컬 환경에서 `./gradlew dependencyCheckAnalyze` 를 시도했으나, **NVD API 키 없이 전체 NVD 데이터베이스를 받는 경로가 매우 느려(rate-limit) 로컬에서 완주하지 못했다.** 거짓 "clean" 결과를 보고하지 않는다.
- 실제 스캔은 `NVD_API_KEY` 시크릿이 설정된 **CI 에서 완주**한다.
- 따라서 의존성 트리(Spring Boot 3.5.6, jjwt 0.12.5, jsoup, Bucket4j, MinIO/AWS SDK, redisson, firebase-admin)의 CVE-free 여부는 **CI 첫 실행에서 확정**된다.

## 검증
- `./gradlew test --rerun-tasks` → **BUILD SUCCESSFUL** (전체 스위트 GREEN, depcheck 태스크 미포함)
- `dependencyCheckAnalyze` 태스크 등록/설정 파싱 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)