### PR TITLE
fix(monitoring): actuator/prometheus 무인증 스크랩 허용 및 nginx 엣지 차단

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -216,6 +216,15 @@ http {
             proxy_set_header X-Forwarded-For $real_client_ip;
         }
 
+        # Actuator 민감 엔드포인트 외부 노출 차단.
+        # health/info는 공개 유지(로드밸런서/CI 헬스 게이트). prometheus/metrics/caches는 외부 차단.
+        # Prometheus는 도커 내부망에서 app:8080으로 직접 스크랩하므로 이 차단에 영향받지 않는다.
+        # 존재 자체를 숨기기 위해 404로 응답한다.
+        location ~ ^/actuator/(prometheus|metrics|caches) {
+            access_log off;
+            return 404;
+        }
+
         # REST API endpoints (general rate limiting)
         location / {
             limit_req zone=api_general burst=50 nodelay;

--- a/src/main/java/com/cotalk/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/com/cotalk/infrastructure/security/SecurityConfig.java
@@ -153,9 +153,14 @@ public class SecurityConfig {
                         .requestMatchers("/ws/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
                         .requestMatchers("/actuator/health", "/actuator/health/**", "/actuator/info").permitAll()
+                        // Prometheus 스크랩 전용. 앱 레벨에서는 permitAll이지만 공개 노출은
+                        // nginx 엣지에서 /actuator/prometheus를 404로 차단한다(docker/nginx/nginx.conf).
+                        // Prometheus는 도커 내부망에서 app:8080으로 직접 스크랩하므로 nginx 차단에 영향받지 않는다.
+                        // (M-4: 이전엔 ADMIN 전용이었으나, 무인증 스크랩과의 충돌을 엣지 차단으로 대체)
+                        .requestMatchers("/actuator/prometheus").permitAll()
                         // 관리자 전용 엔드포인트
                         .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
-                        // /actuator/prometheus 포함 그 외 모든 actuator 엔드포인트는 ADMIN 전용 (메트릭 노출 차단)
+                        // 그 외 모든 actuator 엔드포인트(metrics, caches 등)는 ADMIN 전용 (민감 정보 노출 차단)
                         .requestMatchers("/actuator/**").hasRole("ADMIN")
                         // 그 외 모든 요청은 인증 필요
                         .anyRequest().authenticated())

--- a/src/test/java/com/cotalk/infrastructure/security/SecurityConfigTest.java
+++ b/src/test/java/com/cotalk/infrastructure/security/SecurityConfigTest.java
@@ -157,10 +157,20 @@ class SecurityConfigTest {
     }
 
     @Test
-    @DisplayName("should_401_반환_when_actuator_prometheus_인증없이_접근")
-    void should_returnUnauthorized_when_actuatorPrometheusWithoutAuth() throws Exception {
-        // when & then: M-4 - prometheus는 더 이상 permitAll이 아님 (ADMIN 전용)
+    @DisplayName("should_인증게이트_통과_when_actuator_prometheus_무인증_스크랩허용")
+    void should_passSecurityGate_when_actuatorPrometheusWithoutAuth() throws Exception {
+        // when & then: prometheus는 무인증 스크랩 허용(permitAll). 공개 노출은 nginx 엣지에서 차단한다.
+        // health/info와 동일하게 @WebMvcTest 슬라이스에 actuator 핸들러가 없어 catch-all에 의해
+        // 500으로 매핑된다. 핵심은 401(인증 차단)이 아니라는 점 → permitAll 검증.
         mockMvc.perform(get("/actuator/prometheus"))
+                .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    @DisplayName("should_401_반환_when_actuator_metrics_인증없이_접근")
+    void should_returnUnauthorized_when_actuatorMetricsWithoutAuth() throws Exception {
+        // when & then: metrics 등 그 외 actuator 엔드포인트는 여전히 ADMIN 전용 → 무인증 시 401.
+        mockMvc.perform(get("/actuator/metrics"))
                 .andExpect(status().isUnauthorized());
     }
 


### PR DESCRIPTION
## 문제
그라파나가 코톡 서버를 **down**으로 표시. 실제 원인은 서버 다운이 아니라 `/actuator/prometheus`가 ADMIN 전용(401)이라 Prometheus 스크랩이 실패한 것. (서버·공개 백엔드 `cotalk-api.tpsg.co.kr`는 정상 200 UP)

## 변경
- **SecurityConfig**: `/actuator/prometheus`를 `permitAll`로 전환(`/actuator/** hasRole(ADMIN)` 매처 앞). Prometheus는 도커 내부망에서 `app:8080` 직접 스크랩.
- **nginx**: 공개 노출 방지를 위해 `/actuator/(prometheus|metrics|caches)`를 엣지에서 **404 차단**. `health`/`info`는 공개 유지(LB·CI 헬스 게이트).
- `metrics`/`caches` 등 그 외 actuator는 **ADMIN 전용 유지**.
- M-4(원래 ADMIN 잠금)의 메트릭 비노출 의도는 엣지 차단으로 **보존**.

## 테스트
- `SecurityConfigTest`: prometheus는 게이트 통과(permitAll) 검증으로 변경, `metrics` 401 검증 추가 → 통과.
- nginx 문법 검증(docker network) 통과.
- 독립 security-reviewer 검토: **승인, 필수 블로커 0건**.

## 영향
- 헬스체크(`:8080/actuator/health/liveness`)·CI 카나리 게이트 변경 없음 → 배포 파이프라인 호환.
- 머지 시 `deploy.yml` 카나리 배포로 app 이미지 갱신 + nginx 재생성(엣지 차단 반영).

🤖 Generated with [Claude Code](https://claude.com/claude-code)