### PR TITLE
fix: 알림설정 입력 검증·푸시 경로 방어 + 차단목록 N+1 제거

### DIFF
--- a/src/main/java/com/cotalk/adapter/inbound/rest/NotificationSettingController.java
+++ b/src/main/java/com/cotalk/adapter/inbound/rest/NotificationSettingController.java
@@ -8,6 +8,7 @@ import com.cotalk.domain.port.inbound.notification.UpdateNotificationSettingUseC
 import com.cotalk.infrastructure.security.CustomUserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -58,7 +59,7 @@ public class NotificationSettingController {
     @PutMapping
     public ResponseEntity<NotificationSettingResponse> updateNotificationSetting(
             @AuthenticationPrincipal CustomUserPrincipal principal,
-            @RequestBody UpdateNotificationSettingRequest request) {
+            @Valid @RequestBody UpdateNotificationSettingRequest request) {
 
         NotificationSetting setting = updateNotificationSettingUseCase.updateNotificationSetting(
                 principal.getUserId(),

--- a/src/main/java/com/cotalk/adapter/inbound/rest/dto/notification/UpdateNotificationSettingRequest.java
+++ b/src/main/java/com/cotalk/adapter/inbound/rest/dto/notification/UpdateNotificationSettingRequest.java
@@ -1,5 +1,7 @@
 package com.cotalk.adapter.inbound.rest.dto.notification;
 
+import jakarta.validation.constraints.Pattern;
+
 /**
  * 알림 설정 업데이트 요청 DTO.
  *
@@ -18,10 +20,24 @@ public record UpdateNotificationSettingRequest(
         Boolean messageNotification,
         Boolean friendRequestNotification,
         Boolean groupInviteNotification,
+        @Pattern(
+                regexp = "NAME_AND_MESSAGE|NAME_ONLY|NOTHING",
+                message = "알림 미리보기 모드는 NAME_AND_MESSAGE, NAME_ONLY, NOTHING 중 하나여야 합니다"
+        )
         String notificationPreviewMode,
         Boolean soundEnabled,
         Boolean vibrationEnabled,
         Boolean doNotDisturbEnabled,
+        // 형식이 틀린 시간은 저장 후 푸시 발송 경로의 LocalTime.parse()에서
+        // 터지므로 반드시 저장 시점에 거부해야 한다.
+        @Pattern(
+                regexp = "^([01]\\d|2[0-3]):[0-5]\\d$",
+                message = "방해 금지 시작 시간은 HH:mm 형식이어야 합니다"
+        )
         String doNotDisturbStart,
+        @Pattern(
+                regexp = "^([01]\\d|2[0-3]):[0-5]\\d$",
+                message = "방해 금지 종료 시간은 HH:mm 형식이어야 합니다"
+        )
         String doNotDisturbEnd
 ) {}

--- a/src/main/java/com/cotalk/application/service/friend/GetBlockedUsersService.java
+++ b/src/main/java/com/cotalk/application/service/friend/GetBlockedUsersService.java
@@ -10,6 +10,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * 차단 사용자 목록 조회 유스케이스 구현체.
@@ -27,7 +31,8 @@ public class GetBlockedUsersService implements GetBlockedUsersUseCase {
 
     /**
      * 차단한 사용자 목록을 조회한다.
-     * 차단 관계를 조회하고 해당 사용자 정보를 반환한다.
+     * 차단 관계를 조회한 뒤 사용자 정보를 배치로 한 번에 조회하며(N+1 방지),
+     * 차단 관계 순서를 보존하고 삭제된 사용자는 결과에서 제외한다.
      *
      * @param blockerId 차단 목록을 조회할 사용자 ID
      * @return 차단한 사용자 목록
@@ -35,11 +40,19 @@ public class GetBlockedUsersService implements GetBlockedUsersUseCase {
     @Override
     public List<User> getBlockedUsers(Long blockerId) {
         List<Block> blocks = blockRepository.findByBlockerId(blockerId);
+        if (blocks.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> blockedIds = blocks.stream()
+                .map(Block::getBlockedId)
+                .toList();
+        Map<Long, User> usersById = userRepository.findAllById(blockedIds).stream()
+                .collect(Collectors.toMap(User::getId, Function.identity()));
 
         return blocks.stream()
-                .map(block -> userRepository.findById(block.getBlockedId()))
-                .filter(java.util.Optional::isPresent)
-                .map(java.util.Optional::get)
+                .map(block -> usersById.get(block.getBlockedId()))
+                .filter(Objects::nonNull)
                 .toList();
     }
 }

--- a/src/main/java/com/cotalk/application/service/message/AddMessageReactionService.java
+++ b/src/main/java/com/cotalk/application/service/message/AddMessageReactionService.java
@@ -109,7 +109,7 @@ public class AddMessageReactionService implements AddMessageReactionUseCase {
         try {
             MessageReaction reaction = MessageReaction.create(messageId, userId, emoji);
             MessageReaction saved = reactionRepository.save(reaction);
-            log.info("Message reaction added: messageId={}, userId={}, emoji={}", messageId, userId, emoji);
+            log.debug("Message reaction added: messageId={}, userId={}, emoji={}", messageId, userId, emoji);
             return saved;
         } catch (DataIntegrityViolationException e) {
             // 동시성으로 인한 중복 - 기존 반응 반환

--- a/src/main/java/com/cotalk/application/service/message/MarkAsReadService.java
+++ b/src/main/java/com/cotalk/application/service/message/MarkAsReadService.java
@@ -86,7 +86,7 @@ public class MarkAsReadService implements MarkAsReadUseCase {
         int updated = chatRoomMemberRepository.updateLastReadMessageIdIfNewer(chatRoomId, userId, now, lastReadMessageId);
 
         if (updated > 0) {
-            log.info("Marked as read: userId={}, chatRoomId={}, lastReadAt={}", userId, chatRoomId, now);
+            log.debug("Marked as read: userId={}, chatRoomId={}, lastReadAt={}", userId, chatRoomId, now);
         } else {
             log.debug("No DB update occurred: userId={}, chatRoomId={} (lastReadAt already newer or same)", userId, chatRoomId);
         }
@@ -118,7 +118,7 @@ public class MarkAsReadService implements MarkAsReadUseCase {
                     .map(ChatRoomMember::getLastReadMessageId)
                     .orElse(lastReadMessageId); // 조회 실패 시 계산한 값 사용
         }
-        log.info("Publishing chat list update after markAsRead: chatRoomId={}, userId={}, updated={}, lastReadMessageId={}", 
+        log.debug("Publishing chat list update after markAsRead: chatRoomId={}, userId={}, updated={}, lastReadMessageId={}", 
                 chatRoomId, userId, updated, currentLastReadMessageId);
         publishChatListUpdate(chatRoomId, userId, now, currentLastReadMessageId);
     }

--- a/src/main/java/com/cotalk/application/service/message/MessageBroadcastService.java
+++ b/src/main/java/com/cotalk/application/service/message/MessageBroadcastService.java
@@ -66,7 +66,7 @@ public class MessageBroadcastService {
                                   List<ChatRoomMember> members) {
         int unreadCount = Math.max(0, members.size() - 1);
 
-        log.info("[MessageBroadcastService] broadcastToRedis roomId={}, messageId={}, senderId={}, type={}",
+        log.debug("[MessageBroadcastService] broadcastToRedis roomId={}, messageId={}, senderId={}, type={}",
                 message.getChatRoomId(), message.getId(), message.getSenderId(), message.getType());
 
         // 첨부파일 URL은 단기 Pre-signed URL로 재발급해 브로드캐스트한다(H-1). 수신자는 채팅방 멤버로,

--- a/src/main/java/com/cotalk/application/service/message/RemoveMessageReactionService.java
+++ b/src/main/java/com/cotalk/application/service/message/RemoveMessageReactionService.java
@@ -48,7 +48,7 @@ public class RemoveMessageReactionService implements RemoveMessageReactionUseCas
                 .orElseThrow(() -> new MessageReactionNotFoundException(messageId, userId, emojiString));
 
         reactionRepository.delete(reaction);
-        log.info("Message reaction removed: messageId={}, userId={}, emoji={}", messageId, userId, emoji);
+        log.debug("Message reaction removed: messageId={}, userId={}, emoji={}", messageId, userId, emoji);
     }
 
     /**

--- a/src/main/java/com/cotalk/domain/entity/NotificationSetting.java
+++ b/src/main/java/com/cotalk/domain/entity/NotificationSetting.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 import java.time.LocalTime;
+import java.time.format.DateTimeParseException;
 
 /**
  * 알림 설정 도메인 엔티티.
@@ -131,8 +132,16 @@ public class NotificationSetting extends DomainBaseEntity {
             return false;
         }
 
-        LocalTime start = LocalTime.parse(doNotDisturbStart);
-        LocalTime end = LocalTime.parse(doNotDisturbEnd);
+        LocalTime start;
+        LocalTime end;
+        try {
+            start = LocalTime.parse(doNotDisturbStart);
+            end = LocalTime.parse(doNotDisturbEnd);
+        } catch (DateTimeParseException e) {
+            // 검증 도입 이전에 저장된 손상 형식이 푸시 발송(특히 벌크 필터)
+            // 경로를 중단시키지 않도록 "설정 미비 = 허용"과 동일하게 취급한다.
+            return false;
+        }
 
         if (start.isBefore(end)) {
             // 같은 날 범위 (예: 09:00 ~ 18:00)

--- a/src/main/java/com/cotalk/infrastructure/websocket/WebSocketEventListener.java
+++ b/src/main/java/com/cotalk/infrastructure/websocket/WebSocketEventListener.java
@@ -149,7 +149,7 @@ public class WebSocketEventListener {
         try {
             Long userId = Long.parseLong(userIdStr);
             chatRoomPresenceTracker.markActive(roomId, userId, sessionId);
-            log.info(
+            log.debug(
                     "[WS] SUBSCRIBE sessionId={}, subscriptionId={}, userId={}, destination={}, roomId={}",
                     sessionId, subscriptionId, userId, destination, roomId
             );
@@ -188,7 +188,7 @@ public class WebSocketEventListener {
         try {
             Long userId = Long.parseLong(userIdStr);
             chatRoomPresenceTracker.markInactive(roomId, userId, sessionId);
-            log.info(
+            log.debug(
                     "[WS] UNSUBSCRIBE sessionId={}, subscriptionId={}, userId={}, roomId={}",
                     sessionId, subscriptionId, userId, roomId
             );
@@ -209,7 +209,7 @@ public class WebSocketEventListener {
         }
         for (Long roomId : roomsBySubscription.values()) {
             chatRoomPresenceTracker.markInactive(roomId, userId, sessionId);
-            log.info("[WS] DISCONNECT cleanup sessionId={}, userId={}, roomId={}", sessionId, userId, roomId);
+            log.debug("[WS] DISCONNECT cleanup sessionId={}, userId={}, roomId={}", sessionId, userId, roomId);
         }
         chatRoomPresenceTracker.clearSession(userId, sessionId);
     }

--- a/src/test/java/com/cotalk/adapter/inbound/rest/NotificationSettingControllerTest.java
+++ b/src/test/java/com/cotalk/adapter/inbound/rest/NotificationSettingControllerTest.java
@@ -119,4 +119,87 @@ class NotificationSettingControllerTest {
                 .andExpect(jsonPath("$.doNotDisturbEnabled").value(true))
                 .andExpect(jsonPath("$.doNotDisturbStart").value("22:00"));
     }
+
+    @Test
+    @DisplayName("방해 금지 시간이 HH:mm 형식이 아니면 400을 반환한다")
+    @WithMockCustomUser(userId = 100L)
+    void should_return400_when_doNotDisturbTimeFormatInvalid() throws Exception {
+        // 저장은 통과하고 푸시 발송 경로의 LocalTime.parse()에서
+        // 지연 폭발(500)하던 입력을 저장 시점에 거부해야 한다.
+        String requestBody = """
+                {
+                    "doNotDisturbEnabled": true,
+                    "doNotDisturbStart": "25:99",
+                    "doNotDisturbEnd": "07:00"
+                }
+                """;
+
+        mockMvc.perform(put("/api/v1/notifications/settings")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("방해 금지 시간에 콜론 없는 값이 오면 400을 반환한다")
+    @WithMockCustomUser(userId = 100L)
+    void should_return400_when_doNotDisturbTimeMissingColon() throws Exception {
+        String requestBody = """
+                {
+                    "doNotDisturbEnabled": true,
+                    "doNotDisturbStart": "0900",
+                    "doNotDisturbEnd": "07:00"
+                }
+                """;
+
+        mockMvc.perform(put("/api/v1/notifications/settings")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("미리보기 모드에 허용되지 않은 값이 오면 400을 반환한다")
+    @WithMockCustomUser(userId = 100L)
+    void should_return400_when_previewModeInvalid() throws Exception {
+        String requestBody = """
+                {
+                    "notificationPreviewMode": "EVERYTHING"
+                }
+                """;
+
+        mockMvc.perform(put("/api/v1/notifications/settings")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("허용된 미리보기 모드는 정상 처리된다")
+    @WithMockCustomUser(userId = 100L)
+    void should_updateSetting_when_previewModeValid() throws Exception {
+        // given
+        Long userId = 100L;
+        NotificationSetting updatedSetting = NotificationSetting.builder()
+                .id(1L)
+                .userId(userId)
+                .notificationPreviewMode("NAME_ONLY")
+                .build();
+
+        given(updateNotificationSettingUseCase.updateNotificationSetting(
+                eq(userId), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .willReturn(updatedSetting);
+
+        String requestBody = """
+                {
+                    "notificationPreviewMode": "NAME_ONLY"
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(put("/api/v1/notifications/settings")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk());
+    }
 }

--- a/src/test/java/com/cotalk/application/service/friend/GetBlockedUsersServiceTest.java
+++ b/src/test/java/com/cotalk/application/service/friend/GetBlockedUsersServiceTest.java
@@ -13,11 +13,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
-import java.util.Optional;
 
 import static com.cotalk.common.fixture.UserTestFixture.createUser;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class GetBlockedUsersServiceTest {
@@ -32,7 +34,7 @@ class GetBlockedUsersServiceTest {
     private GetBlockedUsersService getBlockedUsersService;
 
     @Test
-    @DisplayName("차단한 사용자 목록 조회 성공")
+    @DisplayName("차단한 사용자 목록 조회 성공 - 배치 조회 1회로 처리(N+1 금지)")
     void should_returnBlockedUsers_when_validBlockerId() {
         // given
         Long blockerId = 1L;
@@ -46,8 +48,9 @@ class GetBlockedUsersServiceTest {
         User blockedUser2 = createUser(blockedId2, "blocked2@test.com", "차단유저2");
 
         given(blockRepository.findByBlockerId(blockerId)).willReturn(List.of(block1, block2));
-        given(userRepository.findById(blockedId1)).willReturn(Optional.of(blockedUser1));
-        given(userRepository.findById(blockedId2)).willReturn(Optional.of(blockedUser2));
+        // 배치 조회 결과가 요청 순서와 달라도 차단 목록 순서를 보존해야 한다
+        given(userRepository.findAllById(List.of(blockedId1, blockedId2)))
+                .willReturn(List.of(blockedUser2, blockedUser1));
 
         // when
         List<User> result = getBlockedUsersService.getBlockedUsers(blockerId);
@@ -56,6 +59,7 @@ class GetBlockedUsersServiceTest {
         assertThat(result).hasSize(2);
         assertThat(result.get(0).getNickname()).isEqualTo("차단유저1");
         assertThat(result.get(1).getNickname()).isEqualTo("차단유저2");
+        verify(userRepository, never()).findById(anyLong());
     }
 
     @Test
@@ -87,8 +91,9 @@ class GetBlockedUsersServiceTest {
         User blockedUser1 = createUser(blockedId1, "blocked1@test.com", "차단유저1");
 
         given(blockRepository.findByBlockerId(blockerId)).willReturn(List.of(block1, block2));
-        given(userRepository.findById(blockedId1)).willReturn(Optional.of(blockedUser1));
-        given(userRepository.findById(blockedId2)).willReturn(Optional.empty()); // 삭제된 사용자
+        // 삭제된 사용자는 배치 조회 결과에 포함되지 않는다
+        given(userRepository.findAllById(List.of(blockedId1, blockedId2)))
+                .willReturn(List.of(blockedUser1));
 
         // when
         List<User> result = getBlockedUsersService.getBlockedUsers(blockerId);

--- a/src/test/java/com/cotalk/domain/entity/NotificationSettingTest.java
+++ b/src/test/java/com/cotalk/domain/entity/NotificationSettingTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalTime;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -208,6 +210,40 @@ class NotificationSettingTest {
             assertThat(setting.isDoNotDisturbEnabled()).isTrue();
             assertThat(setting.getDoNotDisturbStart()).isEqualTo("23:00");
             assertThat(setting.getDoNotDisturbEnd()).isEqualTo("06:00");
+        }
+    }
+
+    @Nested
+    @DisplayName("방해 금지 시간대 판별 시")
+    class IsInDoNotDisturbTime {
+
+        @Test
+        @DisplayName("자정을 넘는 범위에서 시간대 내이면 true를 반환한다")
+        void should_returnTrue_when_nowWithinOvernightRange() {
+            // given
+            NotificationSetting setting = NotificationSettingTestFixture.createWithDoNotDisturb(1L, 100L, "23:00", "07:00");
+
+            // when & then
+            assertThat(setting.isInDoNotDisturbTime(LocalTime.of(0, 30))).isTrue();
+            assertThat(setting.isInDoNotDisturbTime(LocalTime.of(12, 0))).isFalse();
+        }
+
+        @Test
+        @DisplayName("저장된 시간 형식이 손상돼도 예외 대신 false를 반환한다")
+        void should_returnFalse_when_storedTimeFormatCorrupted() {
+            // 검증 도입 이전에 저장된 잘못된 형식이 푸시 발송(특히 벌크 필터)
+            // 경로 전체를 중단시키지 않아야 한다. 설정 미비 = 허용과 동일하게 취급.
+            NotificationSetting corrupted = NotificationSettingTestFixture.createWithDoNotDisturb(1L, 100L, "25:99", "07:00");
+
+            assertThat(corrupted.isInDoNotDisturbTime(LocalTime.of(0, 30))).isFalse();
+        }
+
+        @Test
+        @DisplayName("콜론 없는 손상 형식도 예외 대신 false를 반환한다")
+        void should_returnFalse_when_storedTimeMissingColon() {
+            NotificationSetting corrupted = NotificationSettingTestFixture.createWithDoNotDisturb(1L, 100L, "2300", "0700");
+
+            assertThat(corrupted.isInDoNotDisturbTime(LocalTime.of(23, 30))).isFalse();
         }
     }
 }


### PR DESCRIPTION
## 요약

탐색 → 구현 → 서브에이전트 리뷰 반영 순서로 진행한 API 일관성 하드닝 배치입니다.

### 알림 설정 (런타임 500 결함 수정)
- `UpdateNotificationSettingRequest`에 `@Pattern` 검증 추가: DnD 시간(HH:mm), 미리보기 모드 화이트리스트(`NAME_AND_MESSAGE|NAME_ONLY|NOTHING`) + 컨트롤러 `@Valid`
  - 기존에는 잘못된 시간이 그대로 저장되고 푸시 발송 경로의 `LocalTime.parse()`에서 지연 폭발(500)
- **기존 손상 데이터 방어** (리뷰 지적 반영): `isInDoNotDisturbTime`이 파싱 실패 시 예외 대신 `false` 반환 — 손상 행 하나가 벌크 푸시 배치 전체를 중단시키는 것을 차단

### 성능
- `GetBlockedUsersService` N+1 제거: 차단 N건마다 `findById` → `findAllById` 배치 조회 1회 (차단 순서 보존, 삭제 사용자 필터 유지)

### 운영성
- 메시지 브로드캐스트·읽음·리액션·채팅방 구독/해제 등 고빈도 정상 흐름 로그를 `debug`로 강등 (WS 연결/해제 세션 수명주기는 `info` 유지, `warn`은 모두 보존)

## 검증
- TDD(Red→Green)로 컨트롤러 테스트 4건 + 도메인 테스트 3건 추가, 서비스 테스트 배치 조회 기대로 갱신
- 전체 Gradle 테스트 스위트 통과 (JaCoCo 게이트 포함)
- 코드리뷰 서브에이전트 승인 (major 1건 → 푸시 경로 방어 커밋으로 반영)

## 후속 제안 (이번 PR 범위 외)
- 차단 목록 API 페이징 (응답 형태 변경 → 클라이언트 조율 필요)
- `AdminService` 무인자 목록 조회의 메모리 limit → DB 페이지네이션 통일
- `UpdateProfileRequest`의 statusMessage/avatarUrl 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)